### PR TITLE
Trim redundant content across reference files

### DIFF
--- a/references/differentiation.md
+++ b/references/differentiation.md
@@ -1,13 +1,6 @@
-# Differentiation: Escaping the AI-Polish Middle
+# Differentiation Protocol
 
-**This is not an optional add-on.** Differentiation is the 5th scoring dimension (scored 1-5 on every answer during analyze) and the single biggest factor separating Hire from Strong Hire in competitive processes.
-
-When everyone preps with AI, everyone sounds the same: safe, polished, slightly robotic. The baseline has inflated. What used to be impressive is now table stakes.
-
-Your edge isn't "using AI." Your edge is showing things AI can't fake:
-- **Earned secrets**: Insights only you can claim because you lived them
-- **Clarity under pressure**: Real-time thinking that can't be memorized
-- **Spiky POV**: Principled stances that sound like a person, not a PDF
+Reference for earned secret extraction, spiky POV development, and clarity-under-pressure drills. Differentiation is scored as the 5th dimension (see SKILL.md rubric).
 
 ### When Differentiation Coaching Fires
 
@@ -68,20 +61,6 @@ Review the candidate's storybank and transcripts. For each major experience, ask
 > **Proof**: After introducing mandatory design docs, our PR rejection rate dropped from 30% to 8%, and time-to-merge decreased by 40%.
 >
 > **When to Deploy**: Questions about collaboration, code quality, technical leadership
-
-**Designer Example**:
-> **Earned Secret**: Users are great at expressing pain but terrible at prescribing solutions. The features they ask for often solve problems only 5% of users have.
->
-> **Proof**: Users demanded Feature X. Research showed they actually needed Feature Y. We shipped Y, got 30% adoption. Later found X would've served only 5% of users.
->
-> **When to Deploy**: Questions about user research, prioritization, stakeholder management
-
-**Data Science Example**:
-> **Earned Secret**: The model that wins in A/B test is rarely the model with the best offline metrics. Production data has noise that test sets sanitize away.
->
-> **Proof**: Our best-performing model on test data underperformed a simpler model in production by 15% because the test set didn't include seasonal patterns.
->
-> **When to Deploy**: Questions about model evaluation, experiment design, bridging research and production
 
 ---
 
@@ -175,41 +154,3 @@ Then test: "You're at the 90-second mark, and I interrupt with: 'Can you give me
 - Gets defensive: "Well, actually..."
 - Restarts from the beginning instead of adapting
 - Fills silence with filler words instead of thinking
-
----
-
-## When to Use Differentiation
-
-**Deploy earned secrets when:**
-- Question asks about your unique perspective or philosophy
-- You sense the interviewer is hearing similar answers from everyone
-- You want to be memorable in debrief discussions
-
-**Deploy spiky POV when:**
-- Question feels like a softball ("What do you think about X?")
-- You're confident the company culture aligns with your take
-- You want to test cultural fit (do they appreciate contrarian thinkers?)
-
-**Deploy clarity skills when:**
-- Interview feels scripted and you want to show range
-- Interviewer throws unexpected question
-- You want to demonstrate senior-level presence
-
-**Avoid differentiation when:**
-- Early screening rounds (just clear the bar)
-- Interviewer seems to want safe, predictable answers
-- Your spiky take would clash with company values
-
----
-
-## Integration Points
-
-Differentiation is woven into the core workflows, not bolted on:
-
-- **`analyze`**: Every answer is scored on Differentiation (1-5). Scores < 3 trigger this protocol.
-- **`stories`**: Every storybank entry requires an Earned Secret field. Stories without one are flagged as incomplete.
-- **`practice`**: Drills include differentiation coaching — "That answer was correct but generic. What's the version only you could give?"
-- **`prep`**: Prep briefs include an "Earned secret to deploy" field in positioning.
-- **`mock`**: Post-mock debrief includes a differentiation analysis across the full interview arc.
-
-The goal: make it structurally impossible to ignore differentiation. It's not something you "add later" — it's baked into every answer from the start.

--- a/references/rubrics-detailed.md
+++ b/references/rubrics-detailed.md
@@ -154,18 +154,6 @@ See SKILL.md for seniority band definitions (Early Career, Mid-Career, Senior/Le
 
 ---
 
-## Delivering Scores: Coaching-Informed Approach
-
-Scoring is a tool for growth, not judgment. Follow this delivery sequence:
-
-1. **Invite self-assessment first**: Before sharing scores, ask: "How do you think that answer landed? What would you rate it?" This builds calibration skills.
-
-2. **Lead with strengths**: Identify what scored well and name WHY it worked. "Your structure was a 4 here — you front-loaded the headline and every sentence advanced the story. That's exactly what makes interviewers lean in."
-
-3. **Share growth areas as observations, not verdicts**: "I noticed the credibility score is lower on this one — the impact claim doesn't have numbers behind it yet. What data could you add?"
-
-4. **Co-create the improvement**: Rather than prescribing, ask: "Of the dimensions we scored, which one feels most important for you to work on?"
-
 ## Aggregate Scoring
 
 After scoring individual answers:

--- a/references/storybank-guide.md
+++ b/references/storybank-guide.md
@@ -1,22 +1,6 @@
 # Storybank Guide
 
-Your storybank is a searchable index of career experiences, organized for quick retrieval during interviews. It turns scattered memories into strategic assets.
-
----
-
-## Why a Storybank?
-
-Without one:
-- You grab the first story that comes to mind (often not the best fit)
-- You overuse favorites and neglect strong alternatives
-- You can't see coverage gaps until an interview exposes them
-- You forget details that made stories compelling
-
-With one:
-- Match the right story to each question instantly
-- Spot gaps before interviews
-- Retire weak stories before they hurt you
-- Track which stories land and which fall flat
+A searchable index of career experiences, organized for quick retrieval during interviews.
 
 ---
 
@@ -80,13 +64,6 @@ Rather than just listing accomplishments, use reflective prompts to surface stor
 - "What's a decision you'd make differently with hindsight? What did you learn?"
 - "When have things not gone according to plan? What did you do?"
 
-Also capture the standard categories:
-- Major projects led or contributed to
-- Problems solved
-- Conflicts navigated
-- Times you influenced without authority
-- Feedback received (positive or constructive)
-
 The reflective prompts tend to surface richer, more authentic stories than a pure brainstorm list.
 
 ### Step 2: STAR Format Each
@@ -125,22 +102,6 @@ Update the storybank:
 2. Add performance notes (did it land? feedback?)
 3. Adjust strength scores based on actual performance
 4. Note any new stories that emerged in conversation
-
-### Weekly Review
-
-Spend 15 minutes:
-- Flag overused stories (used 3+ times recently)
-- Identify underused stories that deserve airtime
-- Check if any stories should be retired
-- Add new experiences from current work
-
-### Monthly Audit
-
-Spend 30 minutes:
-- Review strength scores against actual interview performance
-- Retire stories scoring <3 consistently
-- Identify gaps that need new stories
-- Refresh details on aging stories (check if metrics still accurate)
 
 ---
 

--- a/references/transcript-processing.md
+++ b/references/transcript-processing.md
@@ -120,7 +120,7 @@ After scanning, include detected anti-patterns in the analysis output. Each dete
 
 ## Step 3: Multi-Lens Scoring
 
-Run the parsed transcript through evaluative lenses. **Important**: Which lenses you run depends on the post-scoring decision tree in `references/workflows.md` (under `analyze`). If a primary bottleneck is identified after initial scoring, scope the analysis accordingly rather than running all four lenses mechanically. Always follow the evidence sourcing standard from SKILL.md — source claims naturally in your language, and if you find yourself hedging or guessing more than 3 times in a single output, pause and request data before continuing.
+Run the parsed transcript through evaluative lenses. **Important**: Which lenses you run depends on the post-scoring decision tree in `references/workflows.md` (under `analyze`). If a primary bottleneck is identified after initial scoring, scope the analysis accordingly rather than running all four lenses mechanically. Always follow the evidence sourcing standard from SKILL.md. **For Quick Prep track**: Run only Lens 1 and skip to delta sheet.
 
 ### Lens 1: Hiring Manager Perspective
 
@@ -129,15 +129,7 @@ The person who'll champion you (or not) in the hiring committee.
 ```
 LENS 1: HIRING MANAGER PERSPECTIVE
 
-INPUTS:
-- Role: [title]
-- Company: [name]
-- Parsed Q&A from above
-- Company prep brief (values, priorities)
-- Hiring manager LinkedIn (if available)
-
-TASK:
-Act as the hiring manager for this role.
+Evaluate as the hiring manager for this role.
 
 For each answer, score 1-5 on:
 - Substance
@@ -180,12 +172,7 @@ The senior practitioner checking if you actually know what you're talking about.
 ```
 LENS 2: SKEPTICAL SPECIALIST
 
-INPUTS:
-- Candidate's role/discipline: [engineer / PM / designer / data scientist / etc.]
-- Parsed Q&A
-
-TASK:
-Role-play as a skeptical senior specialist in the candidate's field.
+Evaluate as a skeptical senior specialist in the candidate's field.
 
 For each technical or domain-specific answer, identify where they:
 - Hand-waved technical details
@@ -210,12 +197,6 @@ Checking if the candidate demonstrates the company's specific principles.
 ```
 LENS 3: VALUES ALIGNMENT
 
-INPUTS:
-- Company: [name]
-- Company values/principles: [list them]
-- Parsed Q&A
-
-TASK:
 Score each answer on alignment with company principles.
 
 FOR EACH PRINCIPLE:
@@ -241,10 +222,6 @@ Checking if answers are too long, too jargon-heavy, or meandering.
 ```
 LENS 4: CALIBRATION
 
-INPUTS:
-- Parsed Q&A
-
-TASK:
 For each answer >150 words, create:
 - 30-second version (≤80 words)
 - 90-second version (≤220 words)
@@ -366,18 +343,3 @@ What patterns are you noticing? ___
 What feels different now vs. earlier? ___
 ```
 
----
-
-## Timing Guidelines
-
-- Clean transcript: 5-10 minutes
-- Parse into Q&A: 10 minutes
-- Lens 1 (Hiring Manager): 15 minutes
-- Lens 2 (Specialist): 10 minutes
-- Lens 3 (Values): 10 minutes
-- Lens 4 (Calibration): 10 minutes
-- Synthesize delta: 10 minutes
-
-**Total: ~60-75 minutes for full analysis**
-
-For Quick Prep users: Run only Lens 1 and skip to delta sheet (~30 minutes).

--- a/references/workflows.md
+++ b/references/workflows.md
@@ -6,7 +6,7 @@ This file contains all detailed workflow specifications, schemas, and output for
 
 ## `kickoff` - Setup Workflow
 
-### Step 1: Coaching Configuration (ask one question at a time)
+### Step 1: Coaching Configuration
 
 Collect:
 
@@ -105,11 +105,7 @@ Based on interview history and profile:
 ### Before first interview (or ongoing)
 4. [specific action with command]
 
-## Next Commands
-- `prep [company]` (if target company is known)
-- `stories` (if storybank needs building)
-- `practice ladder` (if fundamentals need work)
-- `help` (to see all available commands)
+**Next commands**: `prep [company]`, `stories`, `practice ladder`, `help`
 ```
 
 ---
@@ -180,10 +176,7 @@ Cross-reference what you find with the candidate's profile:
 - Key things to research further before interviewing:
 - Networking angle: [who to talk to, what to ask]
 
-## Next Commands
-- `prep [company]` (when you have an interview scheduled)
-- `research [another company]` (to compare)
-- `stories` (to check if your storybank covers this company's priorities)
+**Next commands**: `prep [company]`, `research [another company]`, `stories`
 ```
 
 ### Coaching State Integration
@@ -411,11 +404,7 @@ When the candidate provides interviewer LinkedIn URLs or profile links, analyze 
 - **The concern to be ready for**: [the #1 most likely concern + your counter in one sentence]
 - **Your question to ask**: [the single best question for this interviewer/round]
 
-## Next Commands
-- `practice`
-- `mock [format]`
-- `concerns`
-- `hype`
+**Next commands**: `practice`, `mock [format]`, `concerns`, `hype`
 ```
 
 ---
@@ -433,13 +422,7 @@ Use `references/transcript-processing.md` as execution guide.
 5. Parse into Q&A pairs.
 6. Score each answer on 5 dimensions (including Differentiation).
 7. **Compare your scores to their self-assessment.** This is where the self-assessment becomes valuable — not as input to your scoring, but as a calibration signal. If you agree with their picks, explain why with evidence. If you disagree, say so plainly: "You flagged Q3 as your weakest, but I'd actually point to Q5 — here's why." The delta between their perception and your analysis is itself useful coaching data.
-8. **Signal-reading analysis.** Scan the transcript for interviewer behavior patterns — these are some of the highest-value insights you can give:
-   - Follow-up questions after an answer → interviewer was interested, the answer was landing
-   - Quick pivot to next question with no follow-up → answer didn't generate interest
-   - Interviewer rephrasing or redirecting mid-answer → the answer wasn't addressing what they asked
-   - "Tell me more about..." → they want depth, the candidate should have expanded
-   - Interviewer cutting the answer short → answer was running long or off-track
-   Include these observations in the per-answer analysis and in the overall debrief.
+8. **Signal-reading analysis.** Scan the transcript for interviewer behavior patterns using the Signal-Reading Module below. Include observations in the per-answer analysis and in the overall debrief.
 9. **Question decode for low-Relevance answers.** For any answer scoring < 3 on Relevance, don't just say "you missed the point." Explain what the question was actually probing for: "This question about 'a time you failed' isn't testing whether you've failed — it's testing self-awareness, learning orientation, and honesty. A targeted answer would have focused on what you learned and how it changed your approach, not on the failure itself."
 10. **Proactive rewrite of the weakest answer.** Don't just offer a rewrite — do one automatically for the lowest-scoring answer. Show the original excerpt and the improved version side by side with annotations. Say: "Here's what your weakest answer could look like at a 4-5. I'll show the delta so the improvement is concrete — not to give you a script, but to make it tangible." Still offer rewrites of other answers on request.
 11. **Triage — identify primary bottleneck and branch:**
@@ -494,7 +477,6 @@ When rewriting:
 - Preserve the candidate's voice — improve the content and structure, don't replace their personality.
 - Flag where the rewrite added information the candidate would need to supply: "I added a metric here — you'll need to fill in the actual number."
 
-This is the single highest-leverage coaching tool. Describing "add quantified impact" is 10x less effective than showing what the same answer looks like with quantified impact added.
 
 ### Delta Output Schema
 
@@ -546,10 +528,7 @@ This is the single highest-leverage coaching tool. Describing "add quantified im
 - Score confidence:
 - Data quality notes:
 
-## Next Commands
-- `practice`
-- `stories`
-- `progress`
+**Next commands**: `practice`, `stories`, `progress`
 ```
 
 ---
@@ -638,20 +617,12 @@ Based on the emotional check in step 1, adapt:
 - [ ] Transcript available → run `analyze` when ready
 - [ ] No transcript → directional analysis above is what we have
 
-## Next Commands
-- `analyze` (if transcript available)
-- `thankyou` (draft follow-up while it's fresh)
-- `hype` (if another interview is coming)
-- `progress` (to see how this fits the trend)
+**Next commands**: `analyze` (if transcript available), `thankyou`, `hype`, `progress`
 ```
 
 ### Coaching State Integration
 
-After debrief, update `coaching_state.md`:
-- Add to Interview Loops: round completed, date, stories used, signals noted
-- Update storybank: Last Used dates and performance notes for stories deployed
-- Add to Outcome Log with Result: pending (update when outcome is known)
-- Add to Session Log
+Update `coaching_state.md` per the State Update Triggers in SKILL.md.
 
 ---
 
@@ -839,7 +810,7 @@ When adding or improving stories, force specificity on:
 
 ### Rapid-Retrieval Drill (`stories drill`)
 
-The storybank's value is realized under pressure, not in a filing cabinet. This drill trains instant story selection:
+This drill trains instant story selection:
 
 1. Throw 10 interview questions in rapid succession (one at a time).
 2. For each question, candidate must respond within 10 seconds with: story ID + opening line.
@@ -918,9 +889,7 @@ After generating, save the ranked concerns to `coaching_state.md` (in the Interv
 - `progress` to track whether concerns are being addressed over time
 - `mock` to include questions targeting known concerns
 
-## Next Commands
-- `practice pushback` (drill all concerns)
-- `prep [company]`
+**Next commands**: `practice pushback`, `prep [company]`
 ```
 
 ---
@@ -1035,15 +1004,10 @@ If no prep exists, say so and suggest running `prep` first if time allows.
 5. Reframe: "This is a conversation to see if there's mutual fit. I'm also interviewing them."
 
 ## If You Bomb an Answer Mid-Interview
-- Notice the spiral. Name it internally: "That one's done."
-- Script: "That answer wasn't my strongest. Let me give this next one my full attention."
-- The interviewer has already moved on. You should too.
-- Do NOT try to circle back and fix the previous answer unless asked.
+See Psychological Readiness Module — Mid-Interview Recovery.
 
 ## If You Get a Question You Have No Story For
-- Buy 5 seconds: "That's a great question — let me think about the best example."
-- Use gap-handling Pattern 1 (Adjacent Bridge): connect to the closest experience you have.
-- Honesty + bridge > fumbled fabrication.
+See Gap-Handling Framework — Pattern 1: Adjacent Bridge.
 
 ## If You Have Back-to-Back Interviews
 - Between interviews: 5-minute reset. Don't review notes — your brain needs a break, not more input.
@@ -1053,9 +1017,7 @@ If no prep exists, say so and suggest running `prep` first if time allows.
 - If you bombed the last one: "That conversation is over. This interviewer doesn't know about it and doesn't care."
 - Quick re-read: glance at the Day-Of Cheat Sheet for the next interviewer (if different from the last).
 
-## Next Commands
-- `practice ladder`
-- `questions`
+**Next commands**: `practice ladder`, `questions`
 ```
 
 ---
@@ -1200,17 +1162,14 @@ Replay 3-4 key moments from the interviewer's point of view. This teaches candid
 2.
 3.
 
-## Next Commands
-- `mock [same format]` (retry)
-- `practice [specific drill]` (target a weakness)
-- `analyze` (if they have a real transcript to compare)
+**Next commands**: `mock [same format]`, `practice [specific drill]`, `analyze`
 ```
 
 ---
 
 ## `negotiate` - Post-Offer Negotiation Coaching
 
-### Sequence (one question at a time)
+### Sequence
 
 1. **Check coaching state.** If `coaching_state.md` exists with an Interview Loops entry for this company, pull context: what round they're at, what concerns were flagged, what stories landed. This shapes the negotiation — "You advanced through 4 rounds, which means they're invested. That's leverage."
 2. Collect offer details: base, equity, bonus, title, level, location, other terms.
@@ -1308,9 +1267,7 @@ When the candidate has more than one offer:
 - When to respond:
 - How to buy time if needed: "[exact language]"
 
-## Next Commands
-- `hype` (if more interviews coming)
-- `progress` (to close out the coaching arc)
+**Next commands**: `hype`, `progress`
 ```
 
 ---
@@ -1408,7 +1365,6 @@ When 3+ real interview outcomes exist, run a direct correlation analysis:
 
 ### Graduation Criteria
 
-Most coaching never defines "done." The candidate keeps practicing forever, or stops arbitrarily. Define what ready looks like so the candidate knows what they're working toward.
 
 **Ready for Interview (minimum bar):**
 - [ ] 3+ scores of 4+ across different dimensions in recent practice
@@ -1512,18 +1468,14 @@ This is hard but important. If after sustained effort, scores remain at 2-3 acro
 - Are we focused on the right bottleneck?
 - Anything to change about our approach?
 
-## Next Commands
-- `practice`
-- `stories`
-- `prep [company]`
-- `mock [format]`
+**Next commands**: `practice`, `stories`, `prep [company]`, `mock [format]`
 ```
 
 ---
 
 ## `reflect` - Post-Search Retrospective Workflow
 
-Closes the loop on a coaching engagement. Run when the candidate has accepted an offer, decided to pause their search, or wants to take stock after a sustained effort. This is the workflow that makes coaching feel complete rather than just fading out.
+Closes the loop on a coaching engagement. Run when the candidate has accepted an offer, decided to pause their search, or wants to take stock after a sustained effort.
 
 ### When to Trigger
 


### PR DESCRIPTION
## Summary
- Removed ~196 lines (~2K tokens, ~5% reduction) of provably redundant content across 5 reference files
- Collapsed verbose `## Next Commands` sections to single-line format (10 occurrences)
- Replaced duplicated coaching instructions with references to SKILL.md (the authoritative source)
- Removed human-facing motivational preambles that don't affect model behavior

## Files changed
- `references/workflows.md` — 48 lines saved
- `references/differentiation.md` — 58 lines saved
- `references/storybank-guide.md` — 39 lines saved
- `references/transcript-processing.md` — 38 lines saved
- `references/rubrics-detailed.md` — 12 lines saved

## Test plan
- [x] All cross-references verified (Signal-Reading Module, Psychological Readiness Module, Gap-Handling Framework, State Update Triggers)
- [x] No orphaned pointers (grep for removed section headers)
- [x] Line counts match expected reductions
- [ ] Run a sample `analyze` and `practice` workflow to confirm no behavioral regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)