### PR TITLE
Expand system design and technical+behavioral mix format support

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -122,6 +122,7 @@ Write to `coaching_state.md` whenever:
     - When the user seems unsure what to do next or asks a vague question: "Not sure where to go from here? Type `help` to see everything we can work on."
     - Every ~3 sessions if they haven't used it: weave a light reminder into the session close.
     - Keep it natural — one sentence, not a sales pitch. Vary the wording so it doesn't feel robotic.
+11. **Name what you can and can't coach.** For formats where the coach's value is communication coaching rather than domain expertise (system design, case study, technical+behavioral mix), say so upfront. A coach who pretends to evaluate system design correctness is worse than one who clearly says "I'm coaching how you communicate your thinking, not whether your design is right." See Technical Format Coaching Boundaries in `references/workflows.md` for specifics.
 
 ## Command Registry
 
@@ -135,7 +136,7 @@ Execute commands immediately when detected. Before executing, **read the referen
 | `analyze` | Transcript analysis and scoring |
 | `debrief` | Post-interview rapid capture (same day) |
 | `practice` | Practice drill menu and rounds |
-| `mock [format]` | Full simulated interview (4-6 Qs) |
+| `mock [format]` | Full simulated interview (4-6 Qs). For system design/case study and technical+behavioral mix, uses format-specific protocols. |
 | `stories` | Build/manage storybank |
 | `concerns` | Generate likely concerns + counters |
 | `questions` | Generate tailored interviewer questions |

--- a/references/role-drills.md
+++ b/references/role-drills.md
@@ -307,6 +307,155 @@ These drills simulate the scrutiny candidates face from specialists in their fie
 
 ---
 
+## Technical Communication Drills
+
+These drills target the communication skills needed for system design, case study, and mixed-format interviews. They are **not domain-specific technical practice** — they coach how you communicate technical thinking, not what you know. Use alongside the Format Discovery Protocol and Technical Format Coaching Boundaries defined in `references/workflows.md`.
+
+See `references/workflows.md` for the `practice technical` menu entry and progression ladder placement.
+
+### Thinking Out Loud Drill
+
+**Setup**: Give the candidate an open-ended decision scenario — not a full system design problem, but a decision point that requires structured reasoning. Examples:
+
+- "Your team needs to decide between building a feature in-house or using a third-party service. Walk me through how you'd think about this decision."
+- "You've been asked to reduce page load time by 50%. Where do you start, and how do you decide what to prioritize?"
+- "Your team is debating whether to migrate to a new framework. Walk me through how you'd evaluate the decision."
+
+Adapt the scenario to the candidate's role and target company if available (from `coaching_state.md`).
+
+**What to evaluate** (communication, not correctness):
+
+- Did they state their assumptions before diving in?
+- Did they structure their approach before detailing it ("I'd think about this in three dimensions...")?
+- Did they narrate their reasoning ("I'm leaning toward X because...")?
+- Did they address tradeoffs explicitly and unprompted?
+- Did they acknowledge what they don't know?
+
+**Challenge dimensions:**
+
+- "You've been talking for 2 minutes and I still don't know your recommendation. What's your answer?" (tests ability to land a conclusion under pressure)
+- "You said you'd optimize for X. What are you giving up?" (tests tradeoff articulation)
+- "I disagree with your assumption about [thing they assumed]. What changes?" (tests adaptability when a premise is challenged)
+- "Can you summarize your approach in 30 seconds?" (tests compression — same skill as the constraint ladder, applied to technical thinking)
+
+**Scoring per response:**
+
+- Process visibility (could the interviewer follow your thinking?): 1-5
+- Structure (did you organize before detailing?): 1-5
+- Tradeoff awareness (did you name what you're sacrificing?): 1-5
+
+### Clarification-Seeking Drill
+
+**Setup**: Present an intentionally ambiguous prompt with no additional context. The goal is to evaluate whether the candidate scopes the problem before solving — a critical skill in system design interviews that most candidates skip.
+
+Examples:
+
+- "Design a notification system."
+- "Build a recommendation engine."
+- "Create a dashboard for the operations team."
+- "Improve the checkout flow."
+
+Give NO additional context. Wait silently. Evaluate what they do next.
+
+**What to evaluate:**
+
+- Did they ask clarifying questions before starting to solve? (most candidates don't — they jump straight in)
+- Quality of questions: scoping questions ("Who are the users? What scale?") vs. trivial questions ("What programming language?")
+- Did they state assumptions explicitly when they couldn't get answers? ("I'll assume we're talking about web and mobile, at the scale of about 10M users — let me know if that's wrong.")
+- Comfort with ambiguity: did they proceed productively, or freeze waiting for certainty?
+
+**Challenge dimensions:**
+
+- If they jump straight to solving: "Hold on — what problem are you solving, exactly? Who's it for? At what scale?" (forces them to recognize they didn't scope — don't be gentle about this, it's a make-or-break habit)
+- After they ask questions: "I can't tell you that. What would you assume and why?" (tests ability to proceed under ambiguity with transparent assumptions)
+- "You asked about users but not about constraints. Why?" (tests awareness of their own question gaps)
+- "You asked five questions in a row without starting. At some point you need to move forward with incomplete information. When is that point?" (tests the other extreme — over-clarifying as a stalling mechanism)
+
+**Scoring per response:**
+
+- Question quality (scoping vs. trivial): 1-5
+- Assumption transparency (stated vs. hidden): 1-5
+- Comfort with ambiguity (productive vs. paralyzed or overcorrecting): 1-5
+
+### Mode-Switching Drill
+
+**Setup**: This drill targets candidates preparing for technical+behavioral mix interviews. Start with a behavioral question about a technical decision, then pivot to technical discussion mid-answer, then pivot back to behavioral.
+
+Example sequence:
+
+1. Start behavioral: "Tell me about a time you had to make a difficult technical tradeoff."
+2. Mid-answer, pivot to technical: "Interesting — walk me through the technical approach you chose. What were the alternatives and why did you pick this one?"
+3. Pivot back to behavioral: "How did the team respond to that decision? Was there disagreement?"
+4. Pivot to forward-looking technical: "If you faced a similar problem today with different constraints, how would your approach change?"
+
+**What to evaluate:**
+
+- Speed of register shift: does the candidate switch fluidly, or fumble transitions?
+- Depth maintenance: do they maintain technical depth when in behavioral mode and behavioral warmth when in technical mode?
+- Integration: do the modes reinforce each other, or feel like two different candidates?
+- Energy consistency: does one mode visibly drain them more than the other?
+
+**Challenge dimensions:**
+
+- Rapid pivots: switch mode 3 times in 5 minutes without signposting
+- "You sound like a different person when you talk about the technical side. How do you bring that same energy to the people side?" (meta-feedback that reveals mode-switching patterns)
+- "That story was great, but I still don't understand the technical decision. Walk me through it like I'm an engineer on your team." (tests whether behavioral warmth comes at the cost of technical rigor)
+
+**Scoring per response:**
+
+- Mode-switching fluidity (seamless vs. fumbled): 1-5
+- Register appropriateness (depth in both modes): 1-5
+- Integration (modes reinforce each other vs. disconnected): 1-5
+
+### Tradeoff Articulation Drill
+
+**Setup**: Present a decision with no clear right answer. The point is not to find the "correct" answer — it's to practice making a decision defensible by naming what you're optimizing for, what you're giving up, and why.
+
+Examples:
+
+- "You can ship in 2 weeks with known technical debt, or in 6 weeks with a clean architecture. Walk me through your decision process."
+- "You have budget for either a senior hire or two junior hires. What do you choose and why?"
+- "Your team can build a feature that 80% of users want a little, or a feature that 20% of users want desperately. Which do you build?"
+- "You can optimize for latency or for cost. The business says both matter equally. How do you decide?"
+
+Adapt examples to the candidate's role and domain.
+
+**What to evaluate:**
+
+- Did they name the tradeoff explicitly, or treat it as if there's an obvious right answer?
+- Did they identify what they were optimizing for?
+- Did they acknowledge what they were giving up?
+- Did they tie the decision to context (team size, timeline, business stage) rather than abstract principles?
+- Did they show intellectual honesty about downsides, or sell their choice as if it has no cost?
+
+**Challenge dimensions:**
+
+- "Your manager wants the 2-week version. Your tech lead wants the 6-week version. What do you do?" (adds stakeholder complexity)
+- "A year later, the technical debt is causing production incidents. How do you think about your original decision?" (tests intellectual honesty and hindsight reasoning)
+- "What information would change your answer?" (tests decision framework quality — do they know what would flip their conclusion?)
+- "I would have made the opposite choice. Convince me." (tests ability to defend a position under direct challenge without getting defensive)
+
+**Scoring per response:**
+
+- Tradeoff naming (explicit vs. glossed over): 1-5
+- Context sensitivity (decision tied to situation vs. abstract principles): 1-5
+- Intellectual honesty (acknowledges downsides vs. sells the choice): 1-5
+
+### Role Adaptations for Technical Communication Drills
+
+The drills above are role-agnostic, but the scenarios should be adapted to each candidate's domain:
+
+- **Software Engineer**: Use architecture, infrastructure, and system design scenarios. Thinking Out Loud → "design a [system]" prompts. Clarification-Seeking → "build a service that handles [ambiguous requirement]."
+- **Product Manager**: Use prioritization, roadmap, and resource allocation scenarios. Tradeoff Articulation maps directly to roadmap decisions. Clarification-Seeking → "improve [product area]."
+- **Data Scientist**: Use methodology, model selection, and experiment design scenarios. Thinking Out Loud → "how would you measure [ambiguous metric]?" Clarification-Seeking → "build a model to predict [X]."
+- **Designer**: Use design system, UX architecture, and design critique scenarios. Thinking Out Loud → "redesign [flow]." Tradeoff Articulation → "user delight vs. development cost."
+- **Operations / Business Ops**: Use process design, tool selection, and systems improvement scenarios. Tradeoff Articulation → "build vs. buy" and "automate vs. manual" decisions.
+- **Marketing**: Use campaign strategy, channel allocation, and measurement scenarios. Tradeoff Articulation → "brand awareness vs. direct response" and "broad reach vs. targeted conversion."
+
+Pull from the candidate's target companies and roles (from `coaching_state.md`) to make scenarios specific. Generic scenarios build the skill; role-specific scenarios build confidence.
+
+---
+
 ## Interviewer Archetypes (for Panel Simulation)
 
 When running `practice panel` or `mock` with panel format, deploy 2-3 of these distinct interviewer personas simultaneously. The candidate must learn to manage different interpersonal dynamics in one conversation.

--- a/references/workflows.md
+++ b/references/workflows.md
@@ -241,14 +241,79 @@ Different formats require fundamentally different prep, pacing, and scoring weig
 |---|---|---|
 | **Behavioral screen** (30-45 min) | Breadth over depth. 5-8 questions, short answers. Efficiency is paramount. | Structure + Relevance weighted highest |
 | **Deep behavioral** (45-60 min) | Depth. Follow-ups expected. Must sustain a story through probing. | Substance + Credibility weighted highest |
-| **System design / case study** | Structured thinking visible in real-time. Process matters as much as answer. | Structure + Substance weighted highest |
+| **System design / case study** | Structured thinking visible in real-time. Process matters as much as answer. **Highly variable across companies** — run Format Discovery Protocol below before coaching. Coach focuses on communication layer, not solution correctness. | Structure + Substance weighted highest. Credibility scored on process rigor, not answer correctness. |
 | **Presentation round** | Prepared content + Q&A handling. Storytelling + poise under challenge. | Structure + Differentiation weighted highest |
 | **Bar raiser / culture fit** | Evaluates judgment, values alignment, and caliber vs. company bar. | Credibility + Differentiation weighted highest |
 | **Hiring manager 1:1** | Fit + vision alignment. Often less structured. Read signals. | Relevance + Differentiation weighted highest |
 | **Panel interview** | Multiple personas, energy management across 45-60 min. | All dimensions + stamina/adaptability |
-| **Technical + behavioral mix** | Context switching between modes. Must signal both depth and breadth. | Substance + Structure weighted highest |
+| **Technical + behavioral mix** | Context switching between modes. Must signal both depth and breadth. **Format varies widely** — run Format Discovery Protocol below before coaching. Coach focuses on mode-switching, behavioral integration, and thinking-out-loud skills. | Substance + Structure weighted highest. Scored on communication across modes, not technical output quality. |
 
 If the candidate doesn't know the format, prep for behavioral screen (most common) and flag: "If you can find out the format, I can sharpen this significantly."
+
+### Format Discovery Protocol (System Design / Case Study and Technical + Behavioral Mix)
+
+These formats vary more across companies than any other interview type. A system design interview at Google looks nothing like a case study at McKinsey or a technical deep-dive at a Series B startup. Rather than prescribing how these interviews work, the coach must discover what the candidate's specific format looks like.
+
+**Run this protocol whenever the identified format is system design/case study or technical+behavioral mix — in `prep`, `mock`, or `practice technical`.**
+
+#### Discovery Questions (ask before any format-specific coaching)
+
+Ask one at a time. Adapt based on responses — skip questions the candidate has already answered.
+
+1. "What do you know about the format of this interview? Has the recruiter described it?"
+2. "Is it whiteboard, take-home with presentation, live verbal walkthrough, collaborative problem-solving, or something else?"
+3. "How long is the session? Is it the full time on one problem, or split across multiple?"
+4. "Do you get the problem in advance, or is it presented live?"
+5. "Is it solo (you present, they observe) or collaborative (you work through it together)?"
+6. "Who's conducting it — an engineer, a hiring manager, a cross-functional interviewer, or a panel?"
+7. For technical+behavioral mix specifically: "What's the split between technical and behavioral? Do they alternate questions, or is it segmented (first half technical, second half behavioral)? One interviewer or a handoff?"
+
+#### If the Candidate Doesn't Know the Format
+
+Don't guess. Help them find out:
+
+- "Ask your recruiter directly: 'Can you describe the format of the [round name] interview? Is it a system design exercise, a case study, or something else? How long is it, and what should I expect?' Recruiters almost always answer this."
+- "Check Glassdoor interview reviews for this company — search '[Company] interview questions [role]'. Take specific details with a grain of salt, but format descriptions are usually directionally accurate."
+- "Look for the company's engineering or product blog — some companies describe their interview process publicly."
+
+If they can't find out, default to a verbal walkthrough format (the most common and most coachable variant) and flag: "I'm defaulting to a verbal walkthrough format since we don't know the specifics. If you learn more about the format, tell me — it'll change how we prep."
+
+#### Format Variability Acknowledgment
+
+When coaching for these formats, be explicit that your guidance is adapted to what the candidate has described, not to insider knowledge of the company's process: "I'm working from what you've told me about the format. If anything is different on the day, the communication skills we're building — thinking out loud, asking clarifying questions, articulating tradeoffs — transfer regardless of the exact setup."
+
+### Technical Format Coaching Boundaries
+
+This coach's value in system design, case study, and technical+behavioral mix interviews is **communication coaching** — how you structure and articulate your thinking — not domain expertise. Be explicit about this boundary upfront, not as a caveat after the fact.
+
+#### What the Coach Can Do
+
+- Coach the **communication layer**: how to structure thinking out loud, narrate decisions, explain tradeoffs, and make your reasoning process visible to the interviewer
+- Coach **question-asking and clarification-seeking** behavior — candidates who jump to solutions without scoping the problem get penalized in almost every system design format, and this is highly coachable
+- Practice **talking about past technical decisions** under scrutiny (the role drills already do this well)
+- Help with the **behavioral components** of mixed-format interviews — the storytelling, credibility, and differentiation skills that transfer directly
+- Coach **handling probing questions** about tradeoffs, constraints, and failure modes — these appear in every technical format regardless of company
+- Coach **energy management and context-switching** across mixed-format interviews, which are often 50-70 minute marathons
+- Simulate the **interpersonal dynamics** of these interviews — skeptical interviewers, ambiguous prompts, time pressure, "why not X?" challenges
+
+#### What the Coach Cannot Do
+
+- **Evaluate system design solutions for technical correctness.** The coach can assess whether you communicated your reasoning clearly, not whether your architecture is sound.
+- **Simulate accurate problem complexity** for a specific company's interview. Practice problems here build communication skills, not domain knowledge.
+- **Replicate company-specific case study formats.** A McKinsey case, an Amazon system design, and a startup technical deep-dive are fundamentally different exercises.
+- **Score technical output quality.** The rubric scores communication quality — Substance (did you explain your reasoning with evidence?), Structure (could the interviewer follow your thinking?), Credibility (did you acknowledge constraints and tradeoffs?).
+- **Teach domain-specific technical knowledge** (data structures, system components, framework selection, etc.). The candidate must bring this knowledge; the coach helps them communicate it.
+
+#### Specific Trigger Points
+
+When the conversation enters these territories, name the boundary:
+
+- **Candidate asks "Is my design correct?"** → "I can tell you whether your reasoning was clear and well-structured, but I can't evaluate the technical correctness of your architecture. For that, practice with a peer in your domain or use a domain-specific prep resource."
+- **Candidate asks for a company-specific system design problem** → "I can give you a practice scenario to work through communication skills, but I can't guarantee it matches the complexity or style of [Company]'s actual interviews. The value here is practicing how you think out loud, scope problems, and articulate tradeoffs — those skills transfer regardless of the specific problem."
+- **Discussion enters domain-specific technical depth** → "This is getting into [specific domain] territory where you need a domain expert, not a communication coach. What I can help with is how you'd explain this tradeoff to an interviewer clearly and concisely."
+- **Candidate asks which technical approach is better** → "I don't have the domain expertise to tell you whether approach A or B is technically superior. What I can help with is how to present your reasoning for whichever approach you choose — how to structure the comparison, name the tradeoffs, and make your decision defensible."
+
+Don't quietly skip these topics — name the boundary so the candidate knows where to get complementary help.
 
 ### Company Archetype Intelligence
 
@@ -334,6 +399,7 @@ When the candidate provides interviewer LinkedIn URLs or profile links, analyze 
 - Identified format:
 - Format-specific guidance:
 - Scoring weight adjustments for this format:
+- Coaching scope (if system design/case study or technical+behavioral mix): What the coach can help you practice for this format vs. where you'll need complementary preparation.
 
 ## Company Culture Read
 - Known culture signals: [with source for each — e.g., "from their careers page", "from JD", "candidate-provided"]
@@ -640,9 +706,10 @@ Practice Menu (progression order)
 6) practice panel      — Multiple interviewer personas simultaneously
 7) practice stress     — Role-specific high-pressure simulation
 8) practice retrieval  — Rapid-fire question-to-story matching under time pressure
+9) practice technical  — Thinking out loud, clarification-seeking, tradeoff articulation
 ```
 
-Use `references/role-drills.md` for role-specific pressure prompts.
+Use `references/role-drills.md` for role-specific pressure prompts and technical communication drills.
 
 ### Drill Progression Ladder
 
@@ -657,6 +724,7 @@ Drills are ordered by prerequisite difficulty. Do not advance until the candidat
 | 5 | Role | Substance ≥ 3 under specialist scrutiny | Stages 1-3 |
 | 6 | Panel | All dimensions ≥ 3 with multiple personas | Stages 1-4 |
 | 7 | Stress | All dimensions ≥ 3 under maximum pressure | Stages 1-5 |
+| 8 (optional) | Technical | Structure + Substance ≥ 3 in technical communication | Stages 1-3. Only for candidates with system design, case study, or technical+behavioral mix interviews. |
 
 **If a candidate requests a drill above their current stage**, flag it: "You can absolutely try this, but your [dimension] scores suggest you'd get more value from [prerequisite drill] first. Want to start there, or jump ahead anyway?" Respect their choice but name the risk.
 
@@ -1082,7 +1150,7 @@ A complete simulated interview (4-6 questions in sequence) with holistic feedbac
 
 ### Setup
 
-1. Ask for format (behavioral screen, deep behavioral, panel, bar raiser, case study — see format taxonomy in prep).
+1. Ask for format (behavioral screen, deep behavioral, panel, bar raiser, system design/case study, technical+behavioral mix — see format taxonomy in prep). **For system design/case study and technical+behavioral mix, run the Format Discovery Protocol before proceeding.** See format-specific simulation UX sections below.
 2. Ask for company/role context (or use existing prep data).
 3. **Calibrate difficulty and tone to the target company.** A mock for a FAANG final round should feel very different from a Series A startup first call:
    - Large tech companies: more structured, higher bar on specificity and metrics, interviewers often follow rubrics
@@ -1115,6 +1183,59 @@ For panel format, use named personas with distinct voices. Prefix each question/
 > **[Director Lin — Silent Observer]**: *[takes notes, no follow-up]*
 
 Switch between personas naturally within the session. Create moments where personas' styles conflict (e.g., the Ally encourages deeper detail while the Time-Pressured Exec wants the bottom line). See `references/role-drills.md` for the full archetype definitions.
+
+### System Design / Case Study Simulation UX
+
+**Before starting, run the Format Discovery Protocol** (see format taxonomy section). If the candidate has described their specific format, simulate THAT. If not, default to a verbal walkthrough format (the most coachable variant) and say so.
+
+**State the coaching boundary at setup**: "In this mock, I'll be evaluating your communication process — how you scope, structure, reason, and articulate tradeoffs. I won't be evaluating the technical correctness of your solution. For that kind of feedback, you'll want to practice with a domain peer."
+
+**Execution adjustments** (this is NOT a behavioral mock — the structure is different):
+
+1. Present a problem statement. Keep it open-ended enough that scoping is required. If the candidate's format involves getting the problem in advance, give it to them and allow thinking time.
+2. **Observe the clarification phase.** Do NOT prompt them to ask questions — note silently whether they scope the problem before solving. If they jump straight to a solution, let them. This is data for the debrief.
+3. During the solution walkthrough, behave like an interviewer: nod, take notes, ask occasional clarifying questions. Don't coach mid-mock.
+4. **Probe tradeoffs**: "Why this approach over X?", "What breaks at 10x scale?", "What are you optimizing for and what are you sacrificing?", "What would you do differently with more time?"
+5. **Test adaptability**: "What if I told you [constraint] changed? How does your approach shift?" or "The team just told you [component] isn't available. Now what?"
+6. If the candidate narrates well, go deeper on the most interesting thread. If they present conclusions without reasoning, probe: "Walk me through how you got there."
+
+**What to track** (different from behavioral mock):
+
+- **Clarification behavior**: Did they ask scoping questions before diving in? How many? How useful?
+- **Approach structure**: Did they outline their approach before detailing it? Did they signal what they'd cover and in what order?
+- **Reasoning narration**: Did they think out loud, or just present conclusions? Could you follow their logic in real time?
+- **Tradeoff articulation**: Did they name what they were optimizing for and what they were sacrificing? Unprompted or only when asked?
+- **Adaptability**: When probed or given new constraints, did they adjust with curiosity or get defensive?
+- **Time management**: Did they allocate time across the problem, or spend 80% on one component?
+- **Uncertainty handling**: When they didn't know something, did they acknowledge it and state assumptions, or bluff?
+
+### Technical + Behavioral Mix Simulation UX
+
+**Before starting, run the Format Discovery Protocol** with these additional questions:
+
+- "What's the split between technical and behavioral? Roughly 50/50, or weighted toward one?"
+- "Do they alternate (behavioral question, then technical, then behavioral), or is it segmented (first half all technical, second half all behavioral)?"
+- "Is it one interviewer the whole time, or a handoff between two people?"
+
+Match the mock to whatever the candidate describes. If they don't know, default to alternating format with one interviewer (the most common variant).
+
+**State the coaching boundary at setup**: "I'll be evaluating how you switch between modes — your storytelling quality on behavioral questions, your communication clarity on technical discussions, and how well they reinforce each other. I'm not evaluating the technical correctness of your answers."
+
+**Execution adjustments:**
+
+1. Structure the mock to match the candidate's described format. Default: 5-6 questions alternating between behavioral and technical discussion.
+2. **Include at least one deliberate mode switch mid-question**: ask a behavioral question about a technical decision ("Tell me about a time you had to make a difficult technical tradeoff — walk me through both the people side and the technical side"), or pivot from a story to "Now walk me through how you'd approach [related technical scenario]."
+3. Vary the transitions. Some should be clean breaks ("Now let's switch gears..."), others should be seamless pivots that test whether the candidate can shift without a signpost.
+4. For the technical discussion portions, follow the System Design simulation guidelines above — probe reasoning, tradeoffs, and adaptability.
+5. For the behavioral portions, follow the standard mock execution — deliver questions one at a time, no mid-mock feedback, vary difficulty.
+
+**What to track** (format-specific):
+
+- **Mode-switching speed and quality**: How quickly and cleanly does the candidate shift from storytelling to technical articulation and back? Do they fumble transitions or handle them fluidly?
+- **Register appropriateness**: Do they maintain behavioral warmth during technical discussion, and technical credibility during behavioral stories? Or do they sound like two different candidates?
+- **Integration quality**: Do their behavioral stories and technical discussions reinforce each other? Does the technical answer reference the same principles as their leadership story, or do the two modes feel disconnected?
+- **Energy trajectory**: Mixed formats are 50-70 minute marathons. How is their energy at question 5 vs. question 1? Does quality drop in the second half?
+- **Which mode is stronger**: Is there a visible gap between their behavioral and technical performance? This is critical coaching data — it reveals where to focus.
 
 ### Post-Mock Debrief Schema
 
@@ -1157,12 +1278,29 @@ Replay 3-4 key moments from the interviewer's point of view. This teaches candid
 - "On Q3, I moved on quickly because [reason] — a real interviewer would likely do the same."
 - "Your answer on Q5 made me want to hear more about [specific thing] — but you pivoted to [other thing] instead. That was a missed opportunity to go deeper on your strongest material."
 
+## Format-Specific Debrief (include when applicable)
+
+### If System Design / Case Study:
+- **Process visibility**: How clearly could the interviewer follow your thinking? (1-5)
+- **Clarification behavior**: Did you scope the problem before solving? What questions did/didn't you ask?
+- **Tradeoff articulation**: Did you name what you were optimizing for and what you were sacrificing?
+- **Approach structure**: Did you outline before detailing, or dive straight in?
+- **Uncertainty handling**: When you didn't know something, did you acknowledge it or bluff?
+- **Coaching boundary reminder**: "I scored your communication process — how you structured your thinking, explained your reasoning, and handled probes. I did not evaluate the technical correctness of your solution. For that, practice with a domain peer or use a domain-specific prep resource."
+
+### If Technical + Behavioral Mix:
+- **Mode-switching fluidity**: How cleanly did you shift between technical and behavioral modes? (1-5)
+- **Energy trajectory**: Started [high/medium/low] → Ended [high/medium/low]. Quality difference between first half and second half?
+- **Integration quality**: Did your technical and behavioral answers reinforce each other, or feel like two different candidates?
+- **Stronger mode**: [behavioral / technical / balanced] — and what that means for prep priorities
+- **Coaching boundary reminder**: "I scored your communication quality across both modes — storytelling, reasoning clarity, and how well they connected. I did not evaluate the technical correctness of your answers."
+
 ## Top 3 Changes for Next Mock
 1.
 2.
 3.
 
-**Next commands**: `mock [same format]`, `practice [specific drill]`, `analyze`
+**Next commands**: `mock [same format]`, `practice [specific drill]`, `practice technical`, `analyze`
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Adds Format Discovery Protocol — asks the candidate what their specific interview looks like instead of prescribing how these formats work
- Adds Technical Format Coaching Boundaries with explicit what-the-coach-can/can't-do and scripted trigger points for boundary moments
- Adds format-specific mock protocols for system design/case study and technical+behavioral mix
- Adds 4 new Technical Communication Drills (Thinking Out Loud, Clarification-Seeking, Mode-Switching, Tradeoff Articulation) with role adaptations
- Adds `practice technical` as drill #9 with optional Stage 8 in the progression ladder
- Adds operating rule #11: "Name what you can and can't coach"

## Test plan
- [ ] Verify format taxonomy table entries reference the Format Discovery Protocol
- [ ] Walk through a system design mock: prep → Format Discovery → mock execution → debrief with coaching boundary reminder
- [ ] Walk through a technical+behavioral mix mock with mode-switching tracking
- [ ] Run each of the 4 new drills and verify scoring dimensions
- [ ] Confirm `practice technical` appears in the practice menu and progression ladder

🤖 Generated with [Claude Code](https://claude.com/claude-code)