### PR TITLE
Quality review: fill gaps, add examples, strengthen cross-references

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -36,6 +36,10 @@ At the end of every session (or when the user says they're done, or after any ma
 1. Write the updated coaching state to `coaching_state.md`.
 2. Confirm: "Session state saved. I'll pick up where we left off next time."
 
+### Mid-Session Save Protocol
+
+Don't wait until the end to save. Write to `coaching_state.md` after any major workflow completes (analyze, mock debrief, practice rounds, storybank changes) — not just at session close. If a long session is interrupted, the candidate shouldn't lose everything. When saving mid-session, don't announce it — just write the file silently and continue. Only confirm saves at session end.
+
 ### COACHING_STATE Format
 
 ```markdown
@@ -49,6 +53,7 @@ Last updated: [date]
 - Feedback directness: [1-5]
 - Interview timeline: [date or "ongoing"]
 - Biggest concern:
+- Known interview formats: [e.g., "behavioral screen, system design (verbal walkthrough)" — updated by Format Discovery Protocol during prep/mock]
 
 ## Storybank
 | ID | Title | Primary Skill | Earned Secret | Strength | Last Used |
@@ -115,7 +120,7 @@ Write to `coaching_state.md` whenever:
 6. **Deterministic outputs** using the schemas in `references/workflows.md`.
 7. **End every workflow with next command suggestions**.
 8. **Triage, don't just report**. After scoring, branch coaching based on what the data reveals. Follow the decision trees defined in each workflow — every candidate gets a different path based on their actual patterns.
-9. **Coaching meta-checks**. Every 3rd session (or when the candidate seems disengaged, defensive, or stuck), run a meta-check: "Is this feedback landing? Are we working on the right things? What's not clicking?" Build this into progress automatically, and trigger it ad-hoc when patterns suggest the coaching relationship needs recalibration.
+9. **Coaching meta-checks**. Every 3rd session (or when the candidate seems disengaged, defensive, or stuck), run a meta-check: "Is this feedback landing? Are we working on the right things? What's not clicking?" Build this into progress automatically, and trigger it ad-hoc when patterns suggest the coaching relationship needs recalibration. **To count sessions**: check the Session Log rows in `coaching_state.md` at session start. If the row count is a multiple of 3, include a meta-check in that session regardless of which command is run.
 10. **Surface the help command at key moments**. Users won't remember every command. Proactively remind them that `help` exists at these moments:
     - After kickoff completes: "By the way — type `help` anytime to see the full list of commands available to you."
     - After the first `analyze` or `practice` session: include a brief reminder in the Next Commands section.
@@ -232,11 +237,12 @@ Use first match:
 3. "Just had an interview" / "just finished" / post-interview context -> `debrief`
 4. Company + JD context -> `prep`
 5. Company name only (no JD, no interview scheduled) -> `research`
-6. Practice intent -> `practice`
-7. Progress/pattern intent -> `progress`
-8. "I got an offer" / offer details present -> `negotiate`
-9. "I'm done" / "accepted" / "wrapping up" -> `reflect`
-10. Otherwise -> ask whether to run `kickoff` or `help`
+6. System design / case study / technical interview practice intent -> `practice technical`
+7. Practice intent -> `practice`
+8. Progress/pattern intent -> `progress`
+9. "I got an offer" / offer details present -> `negotiate`
+10. "I'm done" / "accepted" / "wrapping up" -> `reflect`
+11. Otherwise -> ask whether to run `kickoff` or `help`
 
 ---
 

--- a/references/examples.md
+++ b/references/examples.md
@@ -158,3 +158,181 @@ These examples show what good skill output looks like. Use them as calibration a
 - Preserved the 30% fee reduction but made it specific (32%, $1.3M annualized) → approximations with context > round numbers
 
 **Note**: The candidate would need to supply the actual numbers (the $4M, $130K, 32%, $1.3M, and CFO detail). The rewrite shows *where* specificity belongs and *what kind* of detail transforms a 3 into a 5. If they don't have exact numbers, approximations with caveats ("roughly $4M/month") are far better than no numbers at all.
+
+---
+
+## Example 5: Kickoff Summary Showing Interview History Shaping Coaching Plan
+
+**Context**: Mid-career PM, currently interviewing at 2 companies. Has done 3 interviews in the past month — advanced past one phone screen, rejected from two first rounds. Provided resume and target companies.
+
+```markdown
+## Kickoff Summary
+- Track: Full System
+- Target Role(s): Senior PM
+- Seniority band: Mid-career (6 years experience)
+- Timeline: Active — interviews this week and next
+- Interview history: Active but not advancing (1/3 advance rate, both rejections at first round)
+- Feedback Directness: 4
+- Time-aware coaching mode: Focused
+
+## Profile Snapshot (from resume analysis)
+- Positioning strengths: Strong B2B SaaS trajectory, two promotions in 3 years at current company, owned a product line generating $8M ARR
+- Likely interviewer concerns: No consumer product experience (both target companies have consumer-facing products); current title is "PM" not "Senior PM" — may need to demonstrate seniority through scope, not title
+- Career narrative gaps: Transition from engineering (first 2 years) to product isn't explained — interviewers will ask, and you need a crisp 30-second version ready
+- Story seeds: "Launched enterprise billing platform" bullet likely has a rich prioritization story; "Reduced churn by 18%" probably has a customer-insight story behind it
+
+## Interview Readiness Assessment
+Based on interview history and profile:
+- Current readiness: Has foundation but gaps — advancing past some screens but not consistently
+- Biggest risk going in: First-round rejections suggest either Relevance (answering the wrong question) or Structure (losing the thread). We need data to diagnose which.
+- Biggest asset going in: Real quantified outcomes on resume — the raw material for strong stories exists
+
+## First Plan
+Your rejection pattern suggests a specific bottleneck — let's find it fast.
+
+### Immediate (this session)
+1. Build initial storybank with `stories` — capture 6-8 stories from your resume bullets, focusing on the enterprise billing and churn reduction experiences
+
+### This week
+2. Run `prep` for your nearest interview to sharpen question prediction and story mapping
+3. Run `practice ladder` — if Structure is the bottleneck (my hypothesis from first-round rejections), this will surface it in one session
+
+### Before next interview
+4. If you have a transcript from any rejected interview, run `analyze` — that's the fastest way to diagnose exactly what's not landing
+
+**Next commands**: `stories`, `prep [company]`, `practice ladder`, `help`
+```
+
+**Why this example matters**: Notice how interview history (active but not advancing, first-round rejections) shapes the entire plan. A first-time interviewer would get storybank building and fundamentals. This candidate gets a diagnostic approach — find the bottleneck fast because they're already in active loops.
+
+---
+
+## Example 6: Prep Brief Excerpt Showing Format-Specific Coaching
+
+**Context**: Senior Engineer preparing for a system design interview at a growth-stage startup. Format discovered through recruiter: 50-minute live verbal walkthrough, collaborative (interviewer participates), one problem.
+
+```markdown
+## Prep Brief: TechCo — Senior Software Engineer
+
+## Interview Format
+- Identified format: System design / case study (verbal walkthrough, collaborative)
+- Format source: Candidate confirmed with recruiter — 50 min, one problem, collaborative with senior engineer
+- Format-specific guidance: Collaborative formats reward thinking out loud and engaging with the interviewer's suggestions. Treat them as a partner, not an audience. Ask clarifying questions early, propose your approach, and invite feedback: "Does this direction make sense, or should I consider a different angle?"
+- Scoring weight adjustments for this format: Structure + Substance weighted highest. Credibility scored on process rigor, not answer correctness.
+- Coaching scope: I'll help you practice structuring your thinking visibly, scoping problems before diving in, narrating tradeoffs, and engaging with probing questions. I won't evaluate the technical correctness of your designs — for that, practice with a senior engineer peer.
+
+## Company Culture Read
+- Known culture signals: Careers page emphasizes "pragmatic engineering" and "shipping over perfection" (Tier 1 — from their careers page)
+- What this company rewards in interviews: Based on the JD's emphasis on "end-to-end ownership" and "working in ambiguity," they likely value candidates who can make decisions with incomplete information and explain their reasoning (Tier 1 — from JD)
+- What to avoid: Over-engineering in the system design. Their careers page mentions "right-sized solutions" twice — don't propose Google-scale architecture for a growth-stage problem.
+- What I don't know: Specific evaluation rubric, whether they use a scoring sheet, how much weight they put on system design vs. other rounds
+- Confidence in culture read: Medium
+- Sources used: Company careers page, JD, candidate input from recruiter conversation
+```
+
+**Why this example matters**: Shows how coaching scope boundaries appear naturally inside a prep brief — not as a disclaimer, but as a clear statement of what this coaching session can and can't deliver. Also demonstrates tiered sourcing (Tier 1 labels on every claim).
+
+---
+
+## Example 7: Mock Debrief Excerpt Showing Holistic Arc Analysis
+
+**Context**: Mid-career PM, mock behavioral screen (5 questions), targeting Series B startup.
+
+```markdown
+## Mock Interview Debrief: Behavioral Screen — GrowthCo PM
+
+## Overall Impression
+- Hiring signal: Mixed
+- One-sentence summary: Strong individual answers but the full interview felt like five separate stories rather than a cohesive narrative about who you are as a PM.
+
+## Arc Analysis
+- Energy trajectory: Started high → Ended medium. Your first two answers had genuine enthusiasm; by Q4 you sounded like you were reciting. The energy dip was visible.
+- Story diversity: 4 unique stories across 5 questions (S003 used twice — for prioritization and for conflict)
+- Pacing: Front-loaded. First two answers were 90 seconds each (ideal). Last two crept to 3+ minutes. The interviewer would notice.
+- Answer length distribution: Erratic — 85 words, 110 words, 280 words, 320 words, 190 words. The middle answers ballooned.
+
+## Holistic Patterns (things only visible across the full interview)
+- Repeated crutch phrases: "At the end of the day" appeared in 4 of 5 answers. "So basically" appeared in 3. These become invisible to you but very visible to the interviewer.
+- Topics avoided: No answer mentioned failure, disagreement with a manager, or something that went wrong. Five stories, all successes. An interviewer would wonder: "Does this person only tell me what went right?"
+- Questions that caused visible hesitation: Q4 ("Tell me about a time you failed") — you hesitated, then told a success story with a minor setback. This is a red flag for self-awareness.
+- Best moment of the interview: Q2, where you described killing a feature despite sales pressure. The earned secret about small-scale success being a political trap was memorable.
+- Worst moment and recovery quality: Q4. You didn't recover — the answer wandered and never landed a clear takeaway. Recovery: poor.
+
+## Signal Reading Notes
+- Q1: Follow-up indicated interest ("Tell me more about the data you used") — positive signal
+- Q3: Interviewer moved on quickly after your answer — likely negative, your impact statement was vague
+- Q4: Interviewer rephrased the question ("I mean a real failure, not just a challenge") — your first answer didn't land
+
+## Interviewer Perspective
+- "When you used S003 for both the prioritization and conflict questions, I noticed. It made me wonder if you have a limited range of experiences to draw from. In a real interview, I'd probe: 'Can you give me a different example?'"
+- "On Q4, I rephrased because your answer was about overcoming a challenge, not about failing. When a candidate can't name a real failure, I worry about self-awareness and honesty."
+- "Your Q2 answer was the one I'd bring to the hiring committee. The earned secret about features becoming politically unkillable at small scale — that stuck with me."
+
+## Top 3 Changes for Next Mock
+1. Prepare a genuine failure story. Not a "challenge I overcame" — a real mistake with real consequences and a real lesson. Run `stories add` and specifically mine for failure experiences.
+2. Practice ending answers. Your last sentence should be a clear takeaway, not a trail-off. Use the constraint ladder to practice the last 15 seconds of each story.
+3. Vary your stories. You have 8 stories in your storybank — use them. If you catch yourself reaching for S003 again, force yourself to pick a different one.
+
+**Next commands**: `stories add`, `practice ladder`, `mock behavioral`
+```
+
+**Why this example matters**: Demonstrates the holistic patterns only visible across a full mock — story recycling, energy trajectory, crutch phrases, topic avoidance. Individual answer scoring misses these. Also shows the Interviewer Perspective section that teaches signal-reading.
+
+---
+
+## Example 8: Progress Review Showing Trend Narration
+
+**Context**: Senior Designer, 5 sessions completed, 2 real interviews (1 advanced, 1 rejected). Running `progress` after 5th session.
+
+```markdown
+## Progress Snapshot
+- Sessions analyzed: 5
+- Real interviews completed: 2
+- Real interview outcomes: 1 advanced / 1 rejected / 0 pending
+- Current trend: Improving (with one plateau)
+
+## Your Trajectory
+
+- Substance: 2.5 → 3.0 → 3.5 → 3.5 → 4.0 — Steady climb. The jump from 2.5 to 3.0 happened in session 2 when you started adding user research numbers to your stories instead of just saying "we did research." The plateau at 3.5 broke in session 5 when you added alternatives-considered framing ("We tested three approaches..."). Keep doing that — it's working.
+
+- Structure: 3.0 → 3.0 → 3.5 → 4.0 → 4.0 — This was your first plateau and your first breakthrough. Structure didn't move until you practiced the constraint ladder in session 3. Once you learned to front-load the headline, everything tightened. You're now consistent at 4 — this is no longer a priority.
+
+- Relevance: 3.5 → 3.5 → 4.0 → 4.0 → 4.0 — Started strong, now solid. Your question-decoding improved naturally as Structure improved — once you knew where the answer was going, you stopped adding irrelevant context. No further action needed here.
+
+- Credibility: 2.0 → 2.5 → 3.0 → 3.0 → 3.5 — The slowest climber. Your root cause: modesty. You consistently undersell your individual contribution. The I/we audit in session 3 helped (2.5 → 3.0), but you've slipped back into "we" framing in the last two sessions. This needs active monitoring.
+
+- Differentiation: 2.0 → 2.0 → 2.5 → 3.0 → 3.5 — This didn't move at all until session 4, when we extracted your first earned secret ("The best design systems are built from constraints, not inspiration"). That was the unlock. You now have 3 earned secrets across your storybank. The next level (4+) requires weaving them into your answers naturally — right now they feel bolted on.
+
+## Self-Assessment Calibration
+- Your average self-ratings vs. my scores:
+  - Substance: You 3.8 / Me 3.5
+  - Structure: You 3.5 / Me 3.7
+  - Relevance: You 3.8 / Me 3.9
+  - Credibility: You 3.5 / Me 2.8
+  - Differentiation: You 2.5 / Me 2.6
+- Pattern: Over-rater on Credibility (by 0.7 — significant gap)
+- What this means: You think your individual contribution is coming through more clearly than it actually is. This is consistent with the modesty pattern — you believe you're claiming credit, but the interviewer isn't hearing it. The gap between your perception and reality on this dimension is the single most important thing to close.
+
+## Graduation Check
+- Interview-ready criteria: 4 of 6 met
+  - [x] 3+ scores of 4+ across dimensions (Substance, Structure, Relevance all hit 4)
+  - [x] No dimension consistently below 3 (all at 3+)
+  - [ ] 8+ stories, 5+ rated 4+ strength (you have 7 stories, only 3 at 4+)
+  - [x] Critical competency gaps covered
+  - [ ] Gap questions handled in practice (not yet tested)
+  - [x] Self-assessment calibrated within 0.5 (except Credibility — flagged above)
+- Assessment: Almost ready — two gaps to close before your next round
+
+## Top 2 Priorities (Next 2 Weeks)
+1. Priority: Close the Credibility gap — I/we audit on your top 5 stories
+   Why: Your self-assessment is 0.7 points off on this dimension, and the real interview rejection feedback ("hard to tell what she specifically did") confirms it
+   Drill: I/we audit + constraint practice on your 3 weakest-Credibility stories
+   Success metric: Credibility ≥ 3.5 in next practice with self-assessment within 0.3 of coach score
+
+2. Priority: Add 2 more stories to storybank and extract earned secrets
+   Why: 7 stories with only 3 at 4+ isn't enough for a competitive process. You need at least 5 at 4+ to have options.
+   Drill: `stories add` focusing on failure/learning experiences (your storybank has zero)
+   Success metric: 9+ stories, 5+ at 4+ strength, at least 1 failure story
+```
+
+**Why this example matters**: Shows trend narration as a story, not a spreadsheet. Each dimension gets a narrative arc with inflection points, causes, and next unlocks. The self-assessment calibration section reveals the most actionable insight (Credibility over-rating by 0.7 = the candidate thinks they're claiming credit but they're not). The graduation check makes readiness concrete.

--- a/references/role-drills.md
+++ b/references/role-drills.md
@@ -512,6 +512,79 @@ When running a panel drill:
 
 ---
 
+## High-Pressure Stress Drill (`practice stress`)
+
+This drill simulates the worst-case version of an interview — multiple stressors layered simultaneously. It's the final stress test before the real thing. Only run after the candidate has passed Stages 1-5 in the progression ladder.
+
+**Purpose**: Build resilience when everything goes wrong at once. Real interviews don't stress-test one dimension at a time — they combine time pressure, skepticism, unexpected questions, and format curveballs simultaneously.
+
+### Setup
+
+1. **Pull the candidate's weakest patterns** from `coaching_state.md` — Active Patterns, Score History, and Revisit Queue. The stress drill should target known vulnerabilities, not random pressure.
+2. **Select the role-specific drill** that matches their target (PM Six-Lens, Engineer Technical Depth, etc.). The stress drill layers pressure *on top of* the role-specific content.
+3. **Set the frame**: "This is the hardest drill I'll throw at you. It's designed to break your composure so we can see what happens when things go sideways. Don't try to be perfect — try to recover."
+
+### Stress Layers (apply 3-4 simultaneously)
+
+| Stressor | How to Apply | What It Tests |
+|---|---|---|
+| **Time compression** | "You have 60 seconds for this answer." Apply to questions that normally take 2-3 minutes. | Prioritization under pressure — can they find the headline fast? |
+| **Hostile interviewer** | Combine the Skeptic and Time-Pressured Exec archetypes. Interrupt early, challenge every claim, show impatience. | Composure and defensiveness management |
+| **Curveball sequencing** | Ask a question from a completely different domain mid-flow. Go from behavioral to "What's your biggest weakness?" to technical without transition. | Cognitive flexibility and recovery speed |
+| **Information denial** | When they ask clarifying questions, say "I can't tell you that — just go with your best judgment." Repeatedly. | Comfort with ambiguity and assumption transparency |
+| **Previous-answer callback** | Reference something they said 3 questions ago and challenge it: "Earlier you said X, but now you're saying Y — which is it?" | Consistency and composure when caught in a contradiction (real or perceived) |
+| **Silence after answer** | After their response, wait 5+ seconds. Say nothing. Then: "Is that your final answer, or do you want to add anything?" | Resistance to panic-filling silence |
+
+### Protocol
+
+1. Run 4-5 questions with 3-4 stressors active per question. Vary which stressors are applied.
+2. Do NOT debrief between questions — maintain pressure throughout, like a real interview.
+3. After the full sequence, give the candidate 30 seconds of silence before debriefing. They need to decompress.
+4. **Debrief the recovery, not the content.** The point isn't whether their answers were perfect — it's how they handled the pressure:
+   - Where did composure hold? Where did it break?
+   - What was their recovery time after a bad moment? (Instant? One question? Never recovered?)
+   - Did stress make them verbose or clipped? (Both are failure modes)
+   - Did they maintain their Structure scores under pressure, or did narrative architecture collapse first?
+
+### Scoring Per Round
+
+- Composure maintenance (stays grounded vs. spirals): 1-5
+- Recovery speed (bounces back vs. carries bad energy forward): 1-5
+- Content quality under pressure (substance holds vs. goes hollow): 1-5
+
+### Role-Specific Stress Variants
+
+- **PM**: Layer Business Lens + Skeptic Lens challenges simultaneously. Add a "the CEO just asked about this in the hallway" urgency framing.
+- **Engineer**: Ask them to explain a technical decision to a non-technical exec, then immediately pivot to a deep technical probe from a senior engineer persona. Test register-switching under time pressure.
+- **Designer**: Present harsh design critique mid-answer: "Our users wouldn't use this." Test whether they get defensive or curious.
+- **Data Scientist**: Challenge statistical methodology with a pointed "But couldn't you have just..." question that proposes a simpler approach. Test whether they defend rigor without being dismissive.
+- **Operations**: Introduce a new constraint mid-answer that invalidates their approach: "Actually, the timeline just got cut in half." Test real-time re-planning.
+- **Marketing**: Challenge attribution claims aggressively: "How do you know it wasn't just seasonal?" Layer with "And the budget for this was how much?"
+
+---
+
+## Difficulty Scaling Guide
+
+Within each role drill, questions range from entry-level to advanced. Use this guide to calibrate which questions to deploy at each stage of the candidate's progression.
+
+### How to Scale
+
+- **Warm-up (rounds 1-2)**: Start with open-ended questions that let the candidate choose their best material. Lower dimensions: "Walk me through...", "Tell me about..."
+- **Moderate (rounds 3-4)**: Add specificity and constraints. "Walk me through the unit economics" is harder than "How'd this impact revenue?" Force them to show depth, not just breadth.
+- **Advanced (rounds 5+)**: Deploy the hardest questions in each lens — the ones that expose gaps. Skeptic Lens questions, compound challenges ("Your metrics look cherry-picked AND your timeline seems aggressive"), and questions that require admitting uncertainty.
+
+### Role-Specific Difficulty Markers
+
+**PM Six-Lens**: Engineering and Data lenses are typically hardest for PMs — deploy those later. Business Lens questions escalate from "How'd this impact revenue?" (moderate) to "Walk me through the unit economics" (advanced) to "What was the opportunity cost vs. the next best project?" (expert).
+
+**Engineer Technical Depth**: Architecture and Edge Cases escalate most steeply. "What happens at 10x scale?" (moderate) → "What happens at 100x with half the infrastructure budget?" (advanced) → "Walk me through the failure mode when [component] and [component] both fail simultaneously" (expert).
+
+**Designer Critique**: Research Foundation questions are the warmup. Constraints and Accessibility escalate from "How did you work within brand guidelines?" (moderate) to "The engineering team says this is impossible to build. What do you do?" (advanced).
+
+**Data Scientist Methodology**: Problem Framing is the warmup. Evaluation and Methodology escalate from "What metrics did you optimize for?" (moderate) to "How did you prevent overfitting given your sample size?" (advanced) to "Your approach assumes stationarity — what breaks if that doesn't hold?" (expert).
+
+---
+
 ## General Drill Guidelines
 
 1. **Start easier, escalate**: Begin with straightforward questions, increase difficulty based on how well they handle early ones.

--- a/references/rubrics-detailed.md
+++ b/references/rubrics-detailed.md
@@ -150,7 +150,12 @@ When scoring reveals a pattern, name the root cause explicitly: "This looks like
 
 ## Seniority Calibration
 
-See SKILL.md for seniority band definitions (Early Career, Mid-Career, Senior/Lead, Executive). The bands there define what a "4" means at each level. Use those as your calibration reference when scoring.
+Scoring is not absolute — calibrate expectations to career stage. When scoring, always state which calibration band you're using.
+
+- **Early career (0-3 years)**: A "4 on Substance" means specific examples with at least one metric. Differentiation can come from learning velocity and intellectual curiosity. Expect less systems-level thinking; look for self-awareness about what they don't yet know.
+- **Mid-career (4-8 years)**: A "4 on Substance" means quantified impact with alternatives considered. Differentiation requires genuine earned secrets from hands-on work. Should demonstrate ownership of outcomes, not just tasks.
+- **Senior/Lead (8-15 years)**: A "4 on Substance" means systems-level thinking — second-order effects, organizational impact. Differentiation requires insights that reshape how the interviewer thinks about the problem. Should show judgment across ambiguous tradeoffs.
+- **Executive (15+ years)**: A "4 on Substance" means business-level impact with P&L awareness. Differentiation requires a coherent leadership philosophy backed by pattern recognition across multiple contexts. Should demonstrate how they build and scale through others.
 
 ---
 

--- a/references/workflows.md
+++ b/references/workflows.md
@@ -278,6 +278,15 @@ Don't guess. Help them find out:
 
 If they can't find out, default to a verbal walkthrough format (the most common and most coachable variant) and flag: "I'm defaulting to a verbal walkthrough format since we don't know the specifics. If you learn more about the format, tell me — it'll change how we prep."
 
+#### Saving Discovered Format
+
+After running Format Discovery, save the format details to `coaching_state.md` so subsequent commands don't re-ask:
+
+- **In Profile** (general): Update the `Known interview formats` field with any new format types discovered.
+- **In Interview Loops** (company-specific): Under the relevant company entry, add: `- Format: [discovered format details — e.g., "System design: 50 min verbal walkthrough, collaborative, one problem, with senior engineer"]`
+
+This prevents re-running discovery when the candidate later runs `mock`, `practice technical`, or `hype` for the same company.
+
 #### Format Variability Acknowledgment
 
 When coaching for these formats, be explicit that your guidance is adapted to what the candidate has described, not to insider knowledge of the company's process: "I'm working from what you've told me about the format. If anything is different on the day, the communication skills we're building — thinking out loud, asking clarifying questions, articulating tradeoffs — transfer regardless of the exact setup."
@@ -478,6 +487,15 @@ When the candidate provides interviewer LinkedIn URLs or profile links, analyze 
 ## `analyze` - Transcript Analysis Workflow
 
 Use `references/transcript-processing.md` as execution guide.
+
+### Cold Start (No Coaching State)
+
+If a candidate drops a transcript without having run `kickoff` first, don't refuse or force kickoff — but collect the minimum needed for a useful analysis:
+
+1. **Infer what you can from the transcript.** The questions asked often reveal role type, seniority level, and company culture. Note these inferences explicitly: "Based on the questions, this looks like a mid-career PM behavioral screen."
+2. **Ask for two things before scoring**: (a) "What seniority level are you targeting? This affects how I calibrate scores." (b) "What role/company is this for? Even brief context helps me assess Relevance."
+3. **Proceed with analysis.** Use inferred or stated seniority band for calibration. Skip story-mapping sections (no storybank exists). Skip cross-referencing with prep data.
+4. **After the analysis, suggest kickoff**: "I've scored this transcript, but I'm working without your full context — no storybank, no coaching history, no target company profile. If you want to get the most from this system, run `kickoff` to set up your coaching profile. Your analysis scores will carry forward."
 
 ### Step Sequence
 
@@ -794,6 +812,34 @@ The first round of every practice session is explicitly **unscored**. Its purpos
 - Try this single change:
 ```
 
+### `practice technical` — Session Protocol
+
+When the candidate runs `practice technical`, don't just throw all four drills at them. Run a structured session:
+
+1. **Check coaching state.** Does the candidate have a system design or technical+behavioral mix interview coming up? If so, tailor drill scenarios to their target company and role. If not, use generic scenarios.
+2. **Check Format Discovery data.** If the candidate has previously described their specific interview format (stored in coaching state Interview Loops or Profile), reference it: "You told me your system design round is a collaborative verbal walkthrough. I'll tailor the drills to that format."
+3. **Select 1-2 drills per session.** Don't run all four — a 30-minute session covering Thinking Out Loud + Clarification-Seeking is better than a shallow pass through all four. Selection logic:
+   - **First session**: Start with Clarification-Seeking (most common failure mode — jumping to solutions without scoping). Follow with Thinking Out Loud.
+   - **If preparing for technical+behavioral mix**: Prioritize Mode-Switching drill.
+   - **If the candidate's recent practice/analyze scores show weak tradeoff articulation**: Prioritize Tradeoff Articulation drill.
+   - **Subsequent sessions**: Rotate through whichever drills the candidate hasn't practiced, or revisit weak areas.
+4. **Run each drill following the protocol in `references/role-drills.md`** (Technical Communication Drills section). Use the role-specific scenario adaptations for the candidate's target role.
+5. **Debrief after each drill** using the standard Round Output Schema above.
+6. **End with integration note**: "These communication skills — scoping, narrating, articulating tradeoffs — transfer to every format variation. Even if the specific interview setup is different from what we practiced, the underlying skills are the same."
+
+### `practice stress` — Session Protocol
+
+The stress drill is the final test before a real high-stakes interview. See `references/role-drills.md` (High-Pressure Stress Drill section) for the full drill protocol, stress layers, and role-specific variants.
+
+**Session setup:**
+
+1. **Gate check.** Confirm the candidate has completed Stages 1-5 in the progression ladder. If not, flag it: "The stress drill is designed for candidates who've built a solid foundation. Your current stage is [X]. Want to work on [prerequisite drill] first, or push ahead anyway?" Respect their choice.
+2. **Pull weaknesses from coaching state.** The stress drill should target known patterns (from Active Patterns and Revisit Queue), not random pressure. Tell the candidate: "I'm designing this drill around your specific patterns — the places where you've been most vulnerable in practice."
+3. **Run 4-5 questions** with 3-4 stress layers active per question (see role-drills.md for the full layer menu).
+4. **Do NOT debrief between questions.** Maintain continuous pressure through the full sequence.
+5. **Post-drill debrief** focuses on recovery and composure, not content quality. Use the stress-specific scoring from role-drills.md.
+6. **Update coaching state**: Log the stress drill in Score History with type: practice/stress. Note composure and recovery scores alongside the standard 5-dimension scores.
+
 ---
 
 ## `stories` - Storybank Workflow
@@ -878,14 +924,7 @@ When adding or improving stories, force specificity on:
 
 ### Rapid-Retrieval Drill (`stories drill`)
 
-This drill trains instant story selection:
-
-1. Throw 10 interview questions in rapid succession (one at a time).
-2. For each question, candidate must respond within 10 seconds with: story ID + opening line.
-3. No perfect answers needed — this trains the retrieval reflex, not the delivery.
-4. After 10 rounds, debrief: which questions caused hesitation? Where did the candidate reach for the wrong story? Any gaps where no story fit?
-
-**Scoring**: Speed of retrieval (instant / hesitant / stuck), match quality (strong / partial / wrong story), opening line quality (hooks attention / generic / fumbled).
+See `references/storybank-guide.md` (Rapid-Retrieval Drill section) for the full protocol, scoring criteria, and progression rounds. In brief: 10 rapid-fire questions, 10 seconds each, candidate responds with story ID + opening line. Debrief focuses on retrieval gaps and hesitation patterns.
 
 ---
 
@@ -1091,6 +1130,15 @@ See Gap-Handling Framework — Pattern 1: Adjacent Bridge.
 ---
 
 ## `thankyou` - Follow-Up Workflow
+
+### Coaching State Integration
+
+Before drafting, check `coaching_state.md` for data that strengthens the thank-you:
+- **Interview Loops**: Pull interviewer names, round context, stories used, and signals observed from the most recent `debrief` entry.
+- **Interviewer Intelligence**: If interviewer profiles were researched during `prep`, reference shared interests or background to personalize the note.
+- **Storybank**: If `debrief` logged which stories were used and how they landed, use positive-signal stories as callback material ("I especially enjoyed discussing [topic from the story that landed well]").
+
+If no coaching state exists, ask the candidate for the callback material directly.
 
 ### Timing Guidance
 
@@ -1762,8 +1810,23 @@ Every prep system assumes you'll have a story for every question. You won't. Thi
 - Don't over-explain why you lack the experience (sounds defensive)
 - Don't use "we did X" to cover for personal gaps — interviewers catch this
 
+**Pattern Selection by Storybank Score:**
+
+When the storybank has been built, map gap response patterns to story strength scores:
+
+| Storybank Situation | Recommended Pattern | Why |
+|---|---|---|
+| **Story exists, strength 3+** | No gap-handling needed — use the story | The story is strong enough to deliver directly |
+| **Story exists, strength 2** | Pattern 1: Adjacent Bridge | The story has real content but isn't compelling enough to carry the answer. Bridge from the experience to the underlying principle — use the story as a springboard, not the centerpiece |
+| **Story exists, strength 1** | Pattern 3: Reframe to Strength or Pattern 4: Growth Narrative | The story is too thin to deliver. Better to honestly reframe than to deliver a weak story that hurts credibility |
+| **No story exists, adjacent experience available** | Pattern 1: Adjacent Bridge | You have real experience that's close — lead with that and draw the connection |
+| **No story exists, no adjacent experience** | Pattern 2: Hypothetical with Self-Awareness | Be honest, show your thinking process, and demonstrate learning orientation |
+| **Competency is a known development area** | Pattern 4: Growth Narrative | Turn the gap into a demonstration of self-awareness and proactive development |
+
+During `stories find gaps`, prescribe the specific pattern for each gap based on this mapping. During `practice gap`, drill the prescribed pattern under pressure.
+
 **Integration:**
-- During `stories find gaps`, flag questions where no story exists and prescribe which gap response pattern to prepare.
+- During `stories find gaps`, flag questions where no story exists and prescribe which gap response pattern to prepare (using the mapping above).
 - During `practice gap`, drill rapid gap-handling under pressure.
 - During `mock`, include at least one question designed to hit a known gap.
 
@@ -1831,3 +1894,84 @@ Non-native English speakers and candidates from different cultural backgrounds f
 
 **When Detected:**
 If scoring reveals patterns consistent with cultural communication differences (low Credibility despite strong content, low Structure despite clear thinking, consistent modesty in self-description), name it: "I think this might be a communication style difference rather than a skill gap. Let's work on adapting your natural style for this interview context, not replacing it."
+
+---
+
+## `help` - Command Reference Workflow
+
+### Logic
+
+When the user types `help`, generate a context-aware command guide — not just a static list.
+
+1. **Read `coaching_state.md`** to understand where the candidate is in their coaching journey.
+2. **Show the full command table** (from SKILL.md Command Registry).
+3. **Highlight the 2-3 most relevant commands right now** based on coaching state:
+   - If no coaching state exists: highlight `kickoff`
+   - If storybank is empty: highlight `stories`
+   - If an interview is scheduled within 48 hours: highlight `hype` and `prep`
+   - If transcripts exist but haven't been analyzed: highlight `analyze`
+   - If 3+ scored sessions exist: highlight `progress`
+   - If an offer was received: highlight `negotiate`
+   - If drill progression shows the candidate hasn't completed Stage 1: highlight `practice ladder`
+4. **Show current coaching state summary** (if it exists): track, seniority band, drill stage, number of stories, number of real interviews, and active company loops.
+5. **End with a prompt**: "What would you like to work on?"
+
+### Output Schema
+
+```markdown
+## Available Commands
+
+| Command | Purpose |
+|---|---|
+| `kickoff` | Initialize coaching profile |
+| `research [company]` | Lightweight company research + fit assessment |
+| `prep [company]` | Company + role prep brief |
+| `analyze` | Transcript analysis and scoring |
+| `debrief` | Post-interview rapid capture (same day) |
+| `practice` | Practice drill menu and rounds |
+| `mock [format]` | Full simulated interview (4-6 Qs) |
+| `stories` | Build/manage storybank |
+| `concerns` | Generate likely concerns + counters |
+| `questions` | Generate tailored interviewer questions |
+| `hype` | Pre-interview confidence and 3x3 plan |
+| `thankyou` | Thank-you note / follow-up drafts |
+| `progress` | Trend review, self-calibration, outcomes |
+| `negotiate` | Post-offer negotiation coaching |
+| `reflect` | Post-search retrospective + archive |
+
+## Where You Are Now
+[Brief coaching state summary — or "No coaching state found. Run `kickoff` to get started."]
+
+## Recommended Next
+Based on where you are:
+1. **[command]** — [why this is the highest-leverage move right now]
+2. **[command]** — [secondary recommendation]
+
+What would you like to work on?
+```
+
+---
+
+## Cross-Command Dependency Guide
+
+Commands produce better output when they have data from other commands. This table shows what each command can do with and without various pieces of coaching state. Use this to suggest prerequisites when a command would benefit from missing data.
+
+| Command | Works best with | Works without (with reduced quality) | Hard dependency (cannot run without) |
+|---|---|---|---|
+| `kickoff` | — | Everything — this is the entry point | — |
+| `research` | Profile from `kickoff` | Profile (gives generic fit assessment) | Company name |
+| `prep` | Storybank, coaching state profile, interviewer links | Storybank (can't do story mapping, flags the gap), profile (infers from JD) | Company + JD |
+| `analyze` | Coaching state (seniority band, storybank for story matching) | Seniority band (asks for it), storybank (skips story mapping) | Transcript |
+| `debrief` | Storybank (for Last Used updates), Interview Loops (for context) | Both (captures data without cross-referencing) | — |
+| `practice` | Score history (to set drill stage), storybank (for tailored questions), prep data (for company-specific drills) | All (uses generic questions, starts at Stage 1) | — |
+| `mock` | Prep data, storybank, score history, interviewer intel | All (uses generic questions and personas) | Format |
+| `stories` | Resume analysis from kickoff (for story seeds) | Resume (uses reflective prompts instead) | — |
+| `concerns` | Resume analysis, storybank, previous `analyze` results, JD | All (generates from candidate input only) | — |
+| `questions` | Prep data, interviewer intel, interview stage | All (generates generic questions) | — |
+| `hype` | Score history, storybank, prep brief, concerns | All (falls back to resume-based hype — explicitly flagged) | — |
+| `thankyou` | Debrief data, Interview Loops, interviewer intel | All (asks candidate for callbacks) | — |
+| `progress` | 3+ scored sessions, outcome data | Works with 1-2 sessions (reduced — see minimum data thresholds) | At least 1 scored session |
+| `negotiate` | Interview Loops, outcome log | Both (collects offer details fresh) | Offer details |
+| `reflect` | Full coaching state with score history and outcomes | Score history (narrates from limited data) | — |
+
+**How to use this**: When running a command that would benefit from missing data, mention the gap briefly and offer to fill it — don't refuse to run. Example: "I can run `prep` without a storybank, but I won't be able to map your stories to predicted questions. Want to build your storybank first with `stories`, or proceed and we'll do the mapping later?"


### PR DESCRIPTION
## Summary
- Fills all gaps identified in comprehensive code review across 5 files
- Adds `help` command workflow, `practice stress` drill, `practice technical` session protocol, cold start `analyze` path
- Adds 4 new worked examples (kickoff, prep brief, mock debrief, progress review)
- Adds cross-command dependency guide, gap-handling pattern-to-score mapping, difficulty scaling guide
- Makes `rubrics-detailed.md` self-contained with inline seniority calibration bands
- Adds mid-session save protocol, interview format persistence, session-counted meta-checks

## Test plan
- [ ] Verify all cross-references between files resolve correctly
- [ ] Confirm new examples follow existing quality patterns
- [ ] Check that practice stress drill follows the same structure as other drills in role-drills.md
- [ ] Verify help workflow output schema is consistent with other command schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)