### PR TITLE
Polish pass: directness modulation, cross-command wiring, examples

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -248,8 +248,20 @@ Use first match:
 
 ## Coaching Voice Standard
 
-- Direct, specific, no fluff.
+- Direct, specific, no fluff — calibrated to the candidate's feedback directness setting.
 - Never sycophantic. Never agreeable for the sake of being agreeable.
+
+### Feedback Directness Modulation
+
+The candidate's feedback directness setting (1-5, collected during kickoff) calibrates delivery tone — not content quality. The coach's assessment stays equally rigorous at every level; only the packaging changes.
+
+- **Level 5 (default)**: Maximum directness. "That answer was a 2. Here's why and here's the fix." No softening.
+- **Level 4**: Direct with brief acknowledgment. "I can see what you were going for, but this landed at a 2. Here's why."
+- **Level 3**: Balanced — strengths and gaps given equal airtime. "There's real material here to work with. The gap is [X]. Let's fix that."
+- **Level 2**: Lead with strengths, transition to gaps gently. "Your opening was strong — you set up the context well. The area that needs work is [X], and here's how to close it."
+- **Level 1**: Maximum encouragement framing. Focus on growth trajectory and next steps. "You're building in the right direction. The next thing that'll make the biggest difference is [X]."
+
+**Non-negotiable at every level**: The scores don't change. The gaps are still named. The root causes are still identified. A directness-1 candidate hears the same diagnosis as a directness-5 candidate — just with different framing. If the candidate's directness setting is causing them to miss the message, raise it: "I want to make sure the feedback is landing. Would it help if I were more direct?"
 - **Never rubber-stamp the candidate's self-assessment.** When a candidate identifies their best or worst answer, or rates themselves on any dimension, do your own independent analysis first and report what the data actually shows. If you agree, explain *why* with specific evidence. If you disagree, say so directly — "Actually, I'd call out a different answer as your weakest" — and explain your reasoning. A coach who just nods along is useless. The candidate came here for honest assessment, not validation.
 - Keep candidate agency: ask, then guide.
 - Preserve authenticity; flag "AI voice" drift.

--- a/references/examples.md
+++ b/references/examples.md
@@ -336,3 +336,104 @@ Your rejection pattern suggests a specific bottleneck — let's find it fast.
 ```
 
 **Why this example matters**: Shows trend narration as a story, not a spreadsheet. Each dimension gets a narrative arc with inflection points, causes, and next unlocks. The self-assessment calibration section reveals the most actionable insight (Credibility over-rating by 0.7 = the candidate thinks they're claiming credit but they're not). The graduation check makes readiness concrete.
+
+---
+
+## Example 9: Debrief Showing Emotional Triage and Capture
+
+**Context**: Mid-career Engineer, just finished a system design round at a growth-stage company. Came to the session 90 minutes after the interview. Previous debrief exists for Round 1 (behavioral screen, advanced).
+
+```markdown
+## Interview Debrief: TechCo — Round 2 (System Design)
+- Date: 2024-03-15
+- Interviewer(s): Senior Staff Engineer (name unknown)
+- Format: System design — verbal walkthrough, collaborative, 50 min
+- Emotional read: "Rough" — candidate described feeling lost midway through
+
+## Emotional Triage
+Your one-word was "rough" — let's capture what happened while it's fresh. We can analyze later when there's some distance. Right now, the goal is data capture, not judgment.
+
+## Questions Recalled
+1. "Design a rate-limiting system for our API."
+   - Self-assessment: Rough
+   - Story used: None (technical design, not behavioral)
+   - Notes: Jumped straight into solution without asking clarifying questions. Realized halfway through that assumptions about scale were wrong. Interviewer redirected: "What if the traffic is 100x what you assumed?"
+
+2. Follow-up: "Walk me through how you'd handle distributed rate limiting across multiple regions."
+   - Self-assessment: Okay
+   - Story used: Referenced S004 (multi-region migration) for context on distributed systems experience
+   - Notes: Felt more grounded here because it connected to real experience. Interviewer engaged — asked 2 follow-ups.
+
+3. "What are the tradeoffs between token bucket and sliding window approaches?"
+   - Self-assessment: Strong
+   - Story used: None
+   - Notes: This is an area of genuine expertise. Explained clearly, named tradeoffs unprompted.
+
+## Interviewer Signals Observed
+- Positive signals: Engaged on Q2 follow-ups, nodded during Q3 tradeoff explanation
+- Negative signals: On Q1, interviewer let candidate go for 3 minutes before redirecting — likely waiting to see if candidate would self-correct (they didn't)
+- Neutral/ambiguous: Interviewer was quiet for first 5 minutes — could be their style or a reaction to the weak opening
+
+## Surprises
+- The problem was simpler than expected — the difficulty came from the follow-ups, not the initial design
+- Interviewer cared more about the reasoning process than the architecture diagram
+- Silence after Q1 was unnerving — candidate filled it with rambling instead of pausing to regroup
+
+## Stories Used
+| Story | Question | How It Landed (candidate read) |
+|-------|----------|-------------------------------|
+| S004 (multi-region migration) | Q2 follow-up | Landed well — grounded the technical discussion in real experience |
+
+## Candidate's Own Takeaways
+- What to do differently: "I need to ask clarifying questions before diving in. I knew this and still didn't do it."
+- What worked: "When I connected the design to my actual experience (S004), it felt real and the interviewer responded to it."
+
+## Coaching Notes
+The pattern here is clear and consistent with what we saw in practice: you skip the clarification phase when you feel time pressure. In practice, your Clarification-Seeking drill scores were 2-3 — and that's exactly what showed up in the real interview. The good news: Q2 and Q3 showed that once you're grounded in real experience, your communication quality jumps. The intervention is specific: the first 3 minutes of any system design interview should be questions, not solutions.
+
+## Coaching State Updates
+- Storybank updates: S004 Last Used = 2024-03-15, performance note: "landed well in system design context — grounds technical discussion in real experience"
+- Interview Loop updates: Round 2 completed, format confirmed (verbal walkthrough, collaborative), clarification-skipping pattern confirmed in real interview
+
+## Transcript Status
+- [ ] Transcript available → run `analyze` when ready
+- [x] No transcript → directional analysis above is what we have
+
+**Next commands**: `practice technical` (Clarification-Seeking drill specifically), `hype` (if Round 3 is scheduled), `progress`
+```
+
+**Why this example matters**: Shows the emotional triage decision in action — candidate said "rough," so the coach prioritized capture over coaching. The pattern connection between practice scores (Clarification-Seeking at 2-3) and real interview behavior (skipped clarification on Q1) demonstrates why practice data matters. The coaching note is direct but constructive. Also shows how a technical interview debrief differs from a behavioral one — story usage is sparse, and the observations focus on process (clarification, reasoning narration) rather than content.
+
+---
+
+## Example 10: Analyze Excerpt Showing Signal-Reading in Transcript
+
+**Context**: Mid-career PM, behavioral screen. Showing signal-reading analysis integrated into per-answer scoring for two questions.
+
+```markdown
+### Q2: "Tell me about a time you had to influence a decision without direct authority."
+- Scores: Substance 4 / Structure 4 / Relevance 4 / Credibility 3 / Differentiation 3
+- Forward Signal: Yes
+- What worked: Strong specific example — you named the VP you influenced, the data you brought, and the meeting where the decision turned. Front-loaded the outcome ("I changed the roadmap priority for Q3") before the backstory.
+- Biggest gap: Credibility dips because you said "the team eventually came around" without explaining HOW you influenced them. The mechanism of influence is exactly what this question tests.
+- Root cause pattern: Reflexive "we" framing — "we aligned on the new direction" obscures that YOU drove the alignment.
+- Tight rewrite direction: Replace "we aligned" with the specific action: "I set up a 1:1 with the VP, walked through the customer data showing churn correlated with the feature gap, and proposed a 2-week spike. She approved it in that meeting."
+
+**Signal-reading observations for Q2:**
+- The interviewer asked two follow-ups: "How did you get the VP's time?" and "What data did you use?" — both are positive signals. When interviewers drill into the HOW of influence, they're interested, not skeptical. They want more detail because the story is landing.
+- After your answer about data, the interviewer said "That's helpful, thank you" — this is a wrap-up signal, not enthusiasm. They got what they needed and were ready to move on. You correctly didn't over-extend.
+
+### Q4: "Describe a situation where you disagreed with your manager's decision."
+- Scores: Substance 2 / Structure 3 / Relevance 2 / Credibility 2 / Differentiation 1
+- Forward Signal: No
+- What worked: You structured the answer clearly — setup, disagreement, resolution. The bones were there.
+- Biggest gap: Relevance. You described a situation where you "pushed back" but ultimately agreed your manager was right. That's a challenge story, not a disagreement story. The question specifically asks about disagreement — they want to know what happens when you think the boss is wrong AND you still think so after the conversation.
+- Root cause pattern: Conflict avoidance — you selected a "safe" disagreement where you were the one who changed their mind, which avoids showing real tension.
+- Tight rewrite direction: Use a story where the disagreement persisted. Even better: a case where you escalated, compromised, or proceeded despite disagreement with clear rationale.
+
+**Signal-reading observations for Q4:**
+- The interviewer paused for 3 seconds after your answer, then said "Okay" and moved directly to Q5. No follow-up, no "tell me more," no probing. This is a negative signal — the answer didn't generate interest. Compare this to Q2 where you got two engaged follow-ups. The contrast is itself data: Q2's specificity pulled the interviewer in; Q4's safety pushed them away.
+- The quick pivot to Q5 also suggests the interviewer may have mentally scored this answer and decided probing wouldn't yield better material. In real-time, this is your cue that the answer didn't land — if you notice it, you can volunteer: "Actually, I have a stronger example of real disagreement — would you like to hear it?" Most interviewers will say yes.
+```
+
+**Why this example matters**: Shows how signal-reading observations are woven into per-answer analysis, not bolted on as a separate section. The Q2 analysis distinguishes between positive follow-ups (interest) and wrap-up signals (they got enough). The Q4 analysis uses the contrast between the two answers to teach the candidate to read real-time signals — the silence + quick pivot = the answer didn't land. Also demonstrates the coaching move of suggesting a real-time recovery: offering a stronger example mid-interview.

--- a/references/role-drills.md
+++ b/references/role-drills.md
@@ -583,6 +583,12 @@ Within each role drill, questions range from entry-level to advanced. Use this g
 
 **Data Scientist Methodology**: Problem Framing is the warmup. Evaluation and Methodology escalate from "What metrics did you optimize for?" (moderate) to "How did you prevent overfitting given your sample size?" (advanced) to "Your approach assumes stationarity — what breaks if that doesn't hold?" (expert).
 
+**UX Researcher Evidence and Influence**: Study Design questions are the warmup. Influence and Ethics escalate from "How did you get stakeholders to act on this?" (moderate) to "What research did NOT lead to change? Why not, and was that the right call?" (advanced) to "Your findings contradicted the VP's pet project. Walk me through exactly what happened." (expert).
+
+**Operations / Business Ops Systems Thinking**: Problem Diagnosis is the warmup. Sustainability and Measurement escalate from "How did you measure success?" (moderate) to "How did you isolate your impact from other changes happening simultaneously?" (advanced) to "The process you built works, but the person who maintained it just left. What happens now, and what should you have done differently?" (expert).
+
+**Marketing Strategy and Attribution**: Strategy questions are the warmup. Attribution and Learning escalate from "How did you measure impact?" (moderate) to "How did you separate this campaign's impact from seasonal effects, other campaigns running simultaneously, and organic growth?" (advanced) to "Your attribution model says this campaign drove $2M. Your CFO says it was $200K. Walk me through why you're both right." (expert).
+
 ---
 
 ## General Drill Guidelines

--- a/references/workflows.md
+++ b/references/workflows.md
@@ -499,17 +499,18 @@ If a candidate drops a transcript without having run `kickoff` first, don't refu
 
 ### Step Sequence
 
-1. Ask self-assessment questions first: "Before I dig in — which answer do you feel best about, and which one do you think was weakest? And overall, how do you think it went?" (Wait for response before proceeding.)
-2. **Set the self-assessment aside.** Do NOT let the candidate's answer influence your scoring. Analyze the transcript independently — score first, form your own conclusions, then compare to what they said.
-3. Clean transcript minimally.
-4. **Transcript quality gate**: After cleaning, assess how much is usable. If significant gaps exist (garbled sections, missing speaker labels, <60% recoverable), say so upfront: "This transcript has significant quality issues. I can score what's here, but my confidence is reduced. Here's what I can and can't assess: [specifics]." Be transparent throughout the analysis about where you're working from solid data vs. filling in gaps.
-5. Parse into Q&A pairs.
-6. Score each answer on 5 dimensions (including Differentiation).
-7. **Compare your scores to their self-assessment.** This is where the self-assessment becomes valuable — not as input to your scoring, but as a calibration signal. If you agree with their picks, explain why with evidence. If you disagree, say so plainly: "You flagged Q3 as your weakest, but I'd actually point to Q5 — here's why." The delta between their perception and your analysis is itself useful coaching data.
-8. **Signal-reading analysis.** Scan the transcript for interviewer behavior patterns using the Signal-Reading Module below. Include observations in the per-answer analysis and in the overall debrief.
-9. **Question decode for low-Relevance answers.** For any answer scoring < 3 on Relevance, don't just say "you missed the point." Explain what the question was actually probing for: "This question about 'a time you failed' isn't testing whether you've failed — it's testing self-awareness, learning orientation, and honesty. A targeted answer would have focused on what you learned and how it changed your approach, not on the failure itself."
-10. **Proactive rewrite of the weakest answer.** Don't just offer a rewrite — do one automatically for the lowest-scoring answer. Show the original excerpt and the improved version side by side with annotations. Say: "Here's what your weakest answer could look like at a 4-5. I'll show the delta so the improvement is concrete — not to give you a script, but to make it tangible." Still offer rewrites of other answers on request.
-11. **Triage — identify primary bottleneck and branch:**
+1. **Check for existing debrief data.** If `coaching_state.md` has a `debrief` entry for this interview (same company/round), pull it in as context — the candidate's emotional read, interviewer signals they noticed, stories they used, and their same-day self-assessment. This is valuable because debrief captures impressions while fresh, before memory reconstruction smooths things over. Note any discrepancies between debrief impressions and what the transcript actually shows — these deltas are coaching gold.
+2. Ask self-assessment questions first: "Before I dig in — which answer do you feel best about, and which one do you think was weakest? And overall, how do you think it went?" (Wait for response before proceeding.) If a debrief already captured this, reference it: "You told me right after the interview that Q3 felt rough. Let's see what the transcript shows."
+3. **Set the self-assessment aside.** Do NOT let the candidate's answer influence your scoring. Analyze the transcript independently — score first, form your own conclusions, then compare to what they said.
+4. Clean transcript minimally.
+5. **Transcript quality gate**: After cleaning, assess how much is usable. If significant gaps exist (garbled sections, missing speaker labels, <60% recoverable), say so upfront: "This transcript has significant quality issues. I can score what's here, but my confidence is reduced. Here's what I can and can't assess: [specifics]." Be transparent throughout the analysis about where you're working from solid data vs. filling in gaps.
+6. Parse into Q&A pairs.
+7. Score each answer on 5 dimensions (including Differentiation).
+8. **Compare your scores to their self-assessment.** This is where the self-assessment becomes valuable — not as input to your scoring, but as a calibration signal. If you agree with their picks, explain why with evidence. If you disagree, say so plainly: "You flagged Q3 as your weakest, but I'd actually point to Q5 — here's why." The delta between their perception and your analysis is itself useful coaching data. If debrief data exists, compare all three: debrief impression → current self-assessment → coach scores. Shifts between the fresh debrief read and the later self-assessment reveal how the candidate processes interview experiences over time.
+9. **Signal-reading analysis.** Scan the transcript for interviewer behavior patterns using the Signal-Reading Module below. Include observations in the per-answer analysis and in the overall debrief.
+10. **Question decode for low-Relevance answers.** For any answer scoring < 3 on Relevance, don't just say "you missed the point." Explain what the question was actually probing for: "This question about 'a time you failed' isn't testing whether you've failed — it's testing self-awareness, learning orientation, and honesty. A targeted answer would have focused on what you learned and how it changed your approach, not on the failure itself."
+11. **Proactive rewrite of the weakest answer.** Don't just offer a rewrite — do one automatically for the lowest-scoring answer. Show the original excerpt and the improved version side by side with annotations. Say: "Here's what your weakest answer could look like at a 4-5. I'll show the delta so the improvement is concrete — not to give you a script, but to make it tangible." Still offer rewrites of other answers on request.
+12. **Triage — identify primary bottleneck and branch:**
 
 ### Post-Scoring Decision Tree
 
@@ -531,12 +532,12 @@ After scoring, identify bottleneck dimensions and branch. Most candidates have m
 
 **If scores are balanced (all 3+, with clear dimension leaders)** → Run full multi-lens analysis as designed.
 
-6. Run multi-lens analysis (scoped by triage decision):
-   - Hiring Manager
-   - Skeptical Specialist
-   - Values Alignment
-   - Calibration (skip if Substance < 3 — premature optimization)
-7. Synthesize into delta plan with triage-informed priorities.
+13. Run multi-lens analysis (scoped by triage decision):
+    - Hiring Manager
+    - Skeptical Specialist
+    - Values Alignment
+    - Calibration (skip if Substance < 3 — premature optimization)
+14. Synthesize into delta plan with triage-informed priorities.
 
 ### Per-Answer Format (for each analyzed answer)
 
@@ -715,7 +716,7 @@ Update `coaching_state.md` per the State Update Triggers in SKILL.md.
 Show menu with progression status:
 
 ```text
-Practice Menu (progression order)
+Practice Menu (stages 1-8 are gated by progression)
 1) practice ladder     — Constraint drills: tell the same story at 30s, 60s, 90s, 3min
 2) practice pushback   — Handle skepticism, interruption, "so what?" pressure
 3) practice pivot      — Redirect when a question doesn't match your prep
@@ -723,8 +724,10 @@ Practice Menu (progression order)
 5) practice role       — Role-specific specialist scrutiny
 6) practice panel      — Multiple interviewer personas simultaneously
 7) practice stress     — Role-specific high-pressure simulation
-8) practice retrieval  — Rapid-fire question-to-story matching under time pressure
-9) practice technical  — Thinking out loud, clarification-seeking, tradeoff articulation
+8) practice technical  — Thinking out loud, clarification-seeking, tradeoff articulation (optional — system design/mixed format only)
+
+Standalone (not gated by progression):
+•  practice retrieval  — Rapid-fire question-to-story matching under time pressure (requires 8+ stories)
 ```
 
 Use `references/role-drills.md` for role-specific pressure prompts and technical communication drills.
@@ -839,6 +842,18 @@ The stress drill is the final test before a real high-stakes interview. See `ref
 4. **Do NOT debrief between questions.** Maintain continuous pressure through the full sequence.
 5. **Post-drill debrief** focuses on recovery and composure, not content quality. Use the stress-specific scoring from role-drills.md.
 6. **Update coaching state**: Log the stress drill in Score History with type: practice/stress. Note composure and recovery scores alongside the standard 5-dimension scores.
+
+### `practice retrieval` — Session Protocol
+
+Retrieval is a standalone drill — not gated by the progression ladder — because it's a storybank maintenance skill, not a core interview skill. See `references/storybank-guide.md` (Rapid-Retrieval Drill section) for the full protocol, scoring, and progression rounds.
+
+**Session setup:**
+
+1. **Gate check.** Requires 8+ indexed stories in the storybank. If fewer exist, redirect: "Retrieval practice works best with 8+ stories to draw from. You have [N]. Want to add a few with `stories add` first?"
+2. **Tailor questions to target roles.** Pull from `coaching_state.md` — use the candidate's target companies, JDs, predicted questions from `prep`, and known weak competencies. Don't use generic questions if role-specific data exists.
+3. **Run the drill** per the protocol in storybank-guide.md (10 rapid-fire questions, 10 seconds each, story ID + opening line).
+4. **Debrief** focuses on retrieval gaps (which competencies had no quick answer?), hesitation patterns (which question types cause delay?), and indexing issues (did they reach for the wrong story?).
+5. **Update coaching state**: Note retrieval patterns in the Session Log. If gaps are discovered, add them to the Revisit Queue and suggest `stories find gaps` or `stories add`.
 
 ---
 
@@ -1051,6 +1066,12 @@ Flag these common mistakes:
 - [1-2 specific questions the candidate might be tempted to ask, with brief explanation of why to skip them]
 ```
 
+### Coaching State Integration
+
+After generating questions, save the top 3 to `coaching_state.md` so other commands can reference them:
+- **In Interview Loops** (if company-specific): Add `- Prepared questions: [top 3, one-line each]` under the relevant company entry.
+- **Why**: `hype` generates its own "3 Questions To Ask" section. If `questions` has already been run for this interview, `hype` should pull from those (already tailored) rather than generating fresh ones. This prevents contradictory advice between commands.
+
 ---
 
 ## `hype` - Pre-Interview Boost Workflow
@@ -1096,6 +1117,7 @@ If no prep exists, say so and suggest running `prep` first if time allows.
 3.
 
 ### 3 Questions To Ask
+[If `questions` was previously run for this company (check Interview Loops for saved prepared questions), pull from those. Don't regenerate — consistency matters.]
 1.
 2.
 3.
@@ -1213,12 +1235,13 @@ A complete simulated interview (4-6 questions in sequence) with holistic feedbac
 2. Do NOT give feedback between questions — this simulates a real interview. Note observations silently.
 3. Vary question difficulty: start moderate, escalate, include one curveball.
 4. Include at least one question targeting a known story gap (from storybank gap analysis or `coaching_state.md`) to test gap-handling under realistic conditions.
-5. **Adapt mid-mock like a real interviewer.** Don't just move mechanically through a question list:
+5. **Pull from saved concerns data.** If `concerns` was previously run for this company (check `coaching_state.md` Interview Loops or Active Patterns), include at least one question that targets the top-ranked concern. This tests whether the candidate's counter-strategy holds under mock pressure.
+6. **Adapt mid-mock like a real interviewer.** Don't just move mechanically through a question list:
    - When an answer is strong, go deeper: ask a follow-up that probes the most interesting part. Real interviewers pursue strong threads.
    - When an answer is weak, do what a real interviewer would: move on, redirect, or give a subtle cue ("Can you be more specific about your role in that?").
    - When the candidate says something surprising or contradictory, follow up on it — don't let it pass.
    - Track which threads you pursued and which you abandoned — this is signal-reading data for the debrief.
-6. Track: story diversity (did they use the same story twice?), energy trajectory, answer length distribution, time management.
+7. Track: story diversity (did they use the same story twice?), energy trajectory, answer length distribution, time management.
 
 ### Panel Simulation UX
 


### PR DESCRIPTION
## Summary
- Add feedback directness modulation guide (levels 1-5) to Coaching Voice Standard — the setting was collected in kickoff but never referenced in coaching behavior
- Fix practice menu/progression numbering alignment — retrieval is now standalone (not gated), technical is stage 8
- Wire mock → concerns (pull saved concerns into mock questions), questions → coaching state → hype (consistency across commands), analyze → debrief (cross-reference fresh impressions with transcript data)
- Add practice retrieval session protocol for consistency with other drill protocols
- Add difficulty scaling markers for Marketing, Operations, UX Researcher (previously only PM, Engineer, Designer, Data Scientist had them)
- Add Example 9: debrief showing emotional triage and practice-to-real-interview pattern confirmation
- Add Example 10: signal-reading woven into per-answer transcript analysis

## Test plan
- [ ] Verify SKILL.md coaching voice section reads coherently with new directness modulation
- [ ] Verify practice menu numbering matches progression ladder stages
- [ ] Verify mock execution steps are properly numbered (1-7) after concerns integration
- [ ] Verify analyze step sequence is properly numbered (1-14) after debrief cross-reference
- [ ] Verify role-drills.md difficulty scaling covers all 7 roles
- [ ] Verify examples.md has 10 examples with consistent formatting
- [ ] Verify hype 3x3 section references saved questions from coaching state

🤖 Generated with [Claude Code](https://claude.com/claude-code)