### PR TITLE
Fix stale references to deleted workflows.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -13,7 +13,7 @@ When instructions compete for attention, follow this priority order:
 
 1. **Session state**: Load and update COACHING_STATE if available. Everything else builds on continuity.
 2. **Triage before template**: Branch coaching based on what the data reveals. Never run the same assembly line for every candidate.
-3. **Evidence enforcement**: Don't make claims you can't back. Silence is better than confident-sounding guesses. This is especially critical for company-specific claims (culture, interview process, values) — see the Company Knowledge Sourcing rules in `references/workflows.md` under `prep`.
+3. **Evidence enforcement**: Don't make claims you can't back. Silence is better than confident-sounding guesses. This is especially critical for company-specific claims (culture, interview process, values) — see the Company Knowledge Sourcing rules in `references/commands/prep.md`.
 4. **One question at a time**: Sequencing is non-negotiable.
 5. **Coaching voice**: Direct, strengths-first, self-reflection before critique.
 6. **Schema compliance**: Follow output schemas, but the schemas serve the coaching — not the other way around.
@@ -117,7 +117,7 @@ Write to `coaching_state.md` whenever:
 3. **Strengths first, then gaps** in every feedback block.
 4. **Evidence-tagged claims only**. If evidence is weak, say so. (See Evidence Sourcing Standard below for how to present evidence naturally.)
 5. **No fake certainty**. Use confidence labels: High / Medium / Low.
-6. **Deterministic outputs** using the schemas in `references/workflows.md`.
+6. **Deterministic outputs** using the schemas in each command's reference file (`references/commands/[command].md`).
 7. **End every workflow with next command suggestions**.
 8. **Triage, don't just report**. After scoring, branch coaching based on what the data reveals. Follow the decision trees defined in each workflow — every candidate gets a different path based on their actual patterns.
 9. **Coaching meta-checks**. Every 3rd session (or when the candidate seems disengaged, defensive, or stuck), run a meta-check: "Is this feedback landing? Are we working on the right things? What's not clicking?" Build this into progress automatically, and trigger it ad-hoc when patterns suggest the coaching relationship needs recalibration. **To count sessions**: check the Session Log rows in `coaching_state.md` at session start. If the row count is a multiple of 3, include a meta-check in that session regardless of which command is run.
@@ -127,7 +127,7 @@ Write to `coaching_state.md` whenever:
     - When the user seems unsure what to do next or asks a vague question: "Not sure where to go from here? Type `help` to see everything we can work on."
     - Every ~3 sessions if they haven't used it: weave a light reminder into the session close.
     - Keep it natural — one sentence, not a sales pitch. Vary the wording so it doesn't feel robotic.
-11. **Name what you can and can't coach.** For formats where the coach's value is communication coaching rather than domain expertise (system design, case study, technical+behavioral mix), say so upfront. A coach who pretends to evaluate system design correctness is worse than one who clearly says "I'm coaching how you communicate your thinking, not whether your design is right." See Technical Format Coaching Boundaries in `references/workflows.md` for specifics.
+11. **Name what you can and can't coach.** For formats where the coach's value is communication coaching rather than domain expertise (system design, case study, technical+behavioral mix), say so upfront. A coach who pretends to evaluate system design correctness is worse than one who clearly says "I'm coaching how you communicate your thinking, not whether your design is right." See Technical Format Coaching Boundaries in `references/commands/prep.md` for specifics.
 
 ## Command Registry
 

--- a/references/role-drills.md
+++ b/references/role-drills.md
@@ -309,9 +309,9 @@ These drills simulate the scrutiny candidates face from specialists in their fie
 
 ## Technical Communication Drills
 
-These drills target the communication skills needed for system design, case study, and mixed-format interviews. They are **not domain-specific technical practice** — they coach how you communicate technical thinking, not what you know. Use alongside the Format Discovery Protocol and Technical Format Coaching Boundaries defined in `references/workflows.md`.
+These drills target the communication skills needed for system design, case study, and mixed-format interviews. They are **not domain-specific technical practice** — they coach how you communicate technical thinking, not what you know. Use alongside the Format Discovery Protocol and Technical Format Coaching Boundaries defined in `references/commands/prep.md`.
 
-See `references/workflows.md` for the `practice technical` menu entry and progression ladder placement.
+See `references/commands/practice.md` for the `practice technical` menu entry and progression ladder placement.
 
 ### Thinking Out Loud Drill
 

--- a/references/transcript-processing.md
+++ b/references/transcript-processing.md
@@ -120,7 +120,7 @@ After scanning, include detected anti-patterns in the analysis output. Each dete
 
 ## Step 3: Multi-Lens Scoring
 
-Run the parsed transcript through evaluative lenses. **Important**: Which lenses you run depends on the post-scoring decision tree in `references/workflows.md` (under `analyze`). If a primary bottleneck is identified after initial scoring, scope the analysis accordingly rather than running all four lenses mechanically. Always follow the evidence sourcing standard from SKILL.md. **For Quick Prep track**: Run only Lens 1 and skip to delta sheet.
+Run the parsed transcript through evaluative lenses. **Important**: Which lenses you run depends on the post-scoring decision tree in `references/commands/analyze.md`. If a primary bottleneck is identified after initial scoring, scope the analysis accordingly rather than running all four lenses mechanically. Always follow the evidence sourcing standard from SKILL.md. **For Quick Prep track**: Run only Lens 1 and skip to delta sheet.
 
 ### Lens 1: Hiring Manager Perspective
 


### PR DESCRIPTION
## Summary
- Fixed 6 stale references to `workflows.md` (now deleted) across 3 files
- `SKILL.md` (3 refs): now points to `references/commands/prep.md` and `references/commands/[command].md`
- `references/transcript-processing.md` (1 ref): now points to `references/commands/analyze.md`
- `references/role-drills.md` (2 refs): now points to `references/commands/prep.md` and `references/commands/practice.md`

## Test plan
- [ ] Grep for `workflows.md` across the repo — should return zero results
- [ ] Run `analyze` with a transcript — verify transcript-processing.md cross-reference works
- [ ] Run `practice technical` — verify role-drills.md cross-reference works

🤖 Generated with [Claude Code](https://claude.com/claude-code)