### PR TITLE
Strengthen memory system for multi-month coaching

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -26,7 +26,7 @@ This skill maintains continuity across sessions using a persistent `coaching_sta
 
 At the beginning of every session:
 1. Read `coaching_state.md` if it exists.
-2. **If it exists**: Greet the candidate by context: "Welcome back. Last session we worked on [X]. Your current drill stage is [Y]. You have [Z] real interviews logged. Where do you want to pick up?" Do NOT re-run kickoff.
+2. **If it exists**: Run the Timeline Staleness Check (see below). Then greet the candidate by context: "Welcome back. Last session we worked on [X]. Your current drill stage is [Y]. You have [Z] real interviews logged. Where do you want to pick up?" Do NOT re-run kickoff. If the Score History or Session Log has grown large (15+ rows), run the archival protocol silently before continuing.
 3. **If it doesn't exist and the user hasn't already issued a command**: Treat as a new candidate. Suggest kickoff.
 4. **If it doesn't exist but the user has already issued a command** (e.g., they opened with `kickoff`): Execute the command directly — don't suggest what they've already asked for.
 
@@ -39,6 +39,16 @@ At the end of every session (or when the user says they're done, or after any ma
 ### Mid-Session Save Protocol
 
 Don't wait until the end to save. Write to `coaching_state.md` after any major workflow completes (analyze, mock debrief, practice rounds, storybank changes) — not just at session close. If a long session is interrupted, the candidate shouldn't lose everything. When saving mid-session, don't announce it — just write the file silently and continue. Only confirm saves at session end.
+
+After any session where the candidate reveals preferences, emotional patterns, or personal context relevant to coaching, capture 1-3 bullet points in the Coaching Notes section. These are things a great coach would remember: "candidate mentioned they freeze in panel formats," "prefers concrete examples over abstract frameworks," "interviews better in the morning." Don't over-capture — just things that would change how you coach.
+
+### Score History Archival
+
+When Score History exceeds 15 rows, summarize the oldest entries into a Historical Summary narrative and keep only the most recent 10 rows as individual entries. The summary should preserve: trend direction per dimension, inflection points (what caused jumps or drops), and what coaching changes triggered shifts. Run this check during `progress` or at session start when the file is large. Apply the same archival pattern to Session Log when it exceeds 15 rows — compress old sessions into a brief narrative, keep recent ones detailed. The goal is to keep the file readable and within reasonable context limits for months-long coaching engagements.
+
+### Timeline Staleness Check
+
+At session start, after reading `coaching_state.md`, check if the Profile's Interview timeline contains a specific date that has passed. If so, proactively ask: "Your interview timeline was set to [date], which has passed. Has anything changed? This affects whether we're in triage, focused, or full coaching mode." Update the Profile and adjust the time-aware coaching mode accordingly.
 
 ### COACHING_STATE Format
 
@@ -55,15 +65,37 @@ Last updated: [date]
 - Biggest concern:
 - Known interview formats: [e.g., "behavioral screen, system design (verbal walkthrough)" — updated by Format Discovery Protocol during prep/mock]
 
+## Resume Analysis
+- Positioning strengths: [the 2-3 signals a hiring manager sees in 30 seconds]
+- Likely interviewer concerns: [flagged from resume — gaps, short tenures, domain switches, seniority mismatches]
+- Career narrative gaps: [transitions that need a story ready]
+- Story seeds: [resume bullets with likely rich stories behind them]
+
 ## Storybank
 | ID | Title | Primary Skill | Earned Secret | Strength | Last Used |
 |----|-------|---------------|---------------|----------|-----------|
 [rows]
 
+### Story Details
+#### S001 — [Title]
+- Situation:
+- Task:
+- Action:
+- Result:
+- Earned Secret:
+- Deploy for: [one-line use case — e.g., "leadership under ambiguity questions"]
+- Version history: [date — what changed]
+
+[repeat for each story]
+
 ## Score History
+### Historical Summary (when table exceeds 15 rows, summarize older entries here)
+[Narrated trend summary of older sessions — direction per dimension, inflection points, what caused shifts]
+
+### Recent Scores
 | Date | Type | Context | Sub | Str | Rel | Cred | Diff | Signal | Self-Δ |
 |------|------|---------|-----|-----|-----|------|------|--------|--------|
-[rows — Type: interview/practice/mock, Self-Δ: over/under/accurate]
+[rows — Type: interview/practice/mock, Self-Δ: over/under/accurate. Keep most recent 10-15 rows.]
 
 ## Outcome Log
 | Date | Company | Role | Round | Result | Notes |
@@ -78,35 +110,58 @@ Last updated: [date]
 ## Interview Loops (active)
 ### [Company Name]
 - Rounds completed: [list with dates]
+- Round formats:
+  - Round 1: [format, duration, interviewer type — e.g., "Behavioral screen, 45min, recruiter"]
+  - Round 2: [format, duration, interviewer type]
 - Stories used: [S### per round]
 - Concerns surfaced: [from analyze or rejection feedback]
 - Interviewer intel: [LinkedIn URLs + key insights, linked to rounds]
+- Prepared questions: [top 3 from `questions` if run]
 - Next round: [date, format if known]
 
-## Active Patterns
-- Root causes detected: [list]
+## Active Coaching Strategy
 - Primary bottleneck: [dimension]
+- Current approach: [what we're working on and how]
+- Rationale: [why this approach — links to decision tree / data]
+- Pivot if: [conditions that would trigger a strategy change]
+- Root causes detected: [list]
 - Self-assessment tendency: [over-rater / under-rater / well-calibrated]
+- Previous approaches: [list of abandoned strategies with brief reason — e.g., "Structure drills — ceiling at 3.5, diminishing returns"]
+
+## Meta-Check Log
+| Session | Candidate Feedback | Adjustment Made |
+|---------|-------------------|-----------------|
+[rows — record every meta-check response and any coaching adjustment]
 
 ## Session Log
+### Historical Summary (when log exceeds 15 rows, summarize older entries here)
+[Brief narrative of earlier sessions]
+
+### Recent Sessions
 | Date | Commands Run | Key Outcomes |
 |------|-------------|--------------|
 [rows — brief, 1-line per session]
+
+## Coaching Notes
+[Freeform observations that don't fit structured fields — things the coach should remember between sessions]
+- [date]: [observation — e.g., "candidate freezes in panel formats," "gets defensive about short tenure at X," "prefers morning interviews," "mentioned they interview better after coffee"]
 ```
 
 ### State Update Triggers
 
 Write to `coaching_state.md` whenever:
-- kickoff creates a new profile
+- kickoff creates a new profile and populates Resume Analysis from resume analysis
 - research adds a new company entry (lightweight, in Interview Loops with status: Researched)
-- stories adds, improves, or retires stories
-- analyze, practice, or mock produces scores (add to Score History)
+- stories adds, improves, or retires stories (write full STAR text to Story Details, not just index row)
+- analyze, practice, or mock produces scores (add to Score History) — analyze also updates Active Coaching Strategy after triage decision
 - debrief captures post-interview data (add to Interview Loops, update storybank Last Used dates, add to Outcome Log as pending)
-- progress reviews trends (update Active Patterns)
+- progress reviews trends (update Active Coaching Strategy, check Score History archival)
 - User reports a real interview outcome (add to Outcome Log)
-- prep starts a new company loop or updates interviewer intel (add to Interview Loops)
+- prep starts a new company loop or updates interviewer intel and round formats (add to Interview Loops)
 - negotiate receives an offer (add to Outcome Log with Result: offer)
 - reflect archives the coaching state (add Status: Archived header)
+- Meta-check conversations (record candidate's response and any coaching adjustment to Meta-Check Log)
+- Any session where the candidate reveals coaching-relevant personal context — preferences, emotional patterns, interview anxieties, scheduling preferences, etc. (add to Coaching Notes)
 
 ---
 
@@ -120,7 +175,7 @@ Write to `coaching_state.md` whenever:
 6. **Deterministic outputs** using the schemas in each command's reference file (`references/commands/[command].md`).
 7. **End every workflow with next command suggestions**.
 8. **Triage, don't just report**. After scoring, branch coaching based on what the data reveals. Follow the decision trees defined in each workflow — every candidate gets a different path based on their actual patterns.
-9. **Coaching meta-checks**. Every 3rd session (or when the candidate seems disengaged, defensive, or stuck), run a meta-check: "Is this feedback landing? Are we working on the right things? What's not clicking?" Build this into progress automatically, and trigger it ad-hoc when patterns suggest the coaching relationship needs recalibration. **To count sessions**: check the Session Log rows in `coaching_state.md` at session start. If the row count is a multiple of 3, include a meta-check in that session regardless of which command is run.
+9. **Coaching meta-checks**. Every 3rd session (or when the candidate seems disengaged, defensive, or stuck), run a meta-check: "Is this feedback landing? Are we working on the right things? What's not clicking?" Build this into progress automatically, and trigger it ad-hoc when patterns suggest the coaching relationship needs recalibration. **To count sessions**: check the Session Log rows in `coaching_state.md` at session start. If the row count is a multiple of 3, include a meta-check in that session regardless of which command is run. **After every meta-check**, record the candidate's response and any coaching adjustment to the Meta-Check Log in `coaching_state.md`. Before running a meta-check, read the Meta-Check Log to reference previous feedback — build on past conversations rather than asking the same questions from scratch.
 10. **Surface the help command at key moments**. Users won't remember every command. Proactively remind them that `help` exists at these moments:
     - After kickoff completes: "By the way — type `help` anytime to see the full list of commands available to you."
     - After the first `analyze` or `practice` session: include a brief reminder in the Next Commands section.

--- a/references/commands/analyze.md
+++ b/references/commands/analyze.md
@@ -52,6 +52,7 @@ After scoring, identify bottleneck dimensions and branch. Most candidates have m
     - Values Alignment
     - Calibration (skip if Substance < 3 — premature optimization)
 14. Synthesize into delta plan with triage-informed priorities.
+15. **Update Active Coaching Strategy in `coaching_state.md`.** Write the chosen coaching path, rationale, and pivot conditions. If an Active Coaching Strategy already exists, check whether this analysis confirms or contradicts it. If the data suggests a different bottleneck than the current strategy targets, recommend updating the strategy and explain why: "Your previous coaching focus was Structure, but this transcript shows Structure at 4 while Differentiation is at 2. I'm updating the strategy to focus on Differentiation."
 
 ### Per-Answer Format (for each analyzed answer)
 

--- a/references/commands/concerns.md
+++ b/references/commands/concerns.md
@@ -60,7 +60,7 @@ Score each round and record to coaching state.
 
 ## Concern Tracking
 
-After generating, save the ranked concerns to `coaching_state.md` (in the Interview Loops section for the relevant company, or in Active Patterns if general). This allows:
+After generating, save the ranked concerns to `coaching_state.md` (in the Interview Loops section for the relevant company, or in Active Coaching Strategy if general). This allows:
 - `prep` to pull from previously generated concerns instead of re-deriving them
 - `hype` to reference the top concern + counter in the 3x3
 - `progress` to track whether concerns are being addressed over time

--- a/references/commands/kickoff.md
+++ b/references/commands/kickoff.md
@@ -47,9 +47,11 @@ Feed these findings into the Kickoff Summary output (Profile Snapshot section) a
 
 Write the initial `coaching_state.md` file (see SKILL.md Session State System for format) with:
 - Profile section populated from Steps 1-2
-- Empty storybank (or populated if initial stories were provided)
+- Resume Analysis section populated from Step 2.5 output (positioning strengths, likely concerns, career narrative gaps, story seeds). This is critical — every downstream command (`concerns`, `prep`, `stories`, `hype`) benefits from having the resume analysis persisted. Don't lose this work.
+- Empty storybank (or populated if initial stories were provided — if initial stories are provided, write full STAR text to the Story Details section)
 - Empty score history, outcome log, drill progression at Stage 1
 - Session log with kickoff entry
+- Coaching Notes with any relevant observations from the kickoff conversation (e.g., interview anxiety, communication style preferences, emotional state about the job search)
 
 ### Time-Aware Coaching
 

--- a/references/commands/mock.md
+++ b/references/commands/mock.md
@@ -19,7 +19,7 @@ A complete simulated interview (4-6 questions in sequence) with holistic feedbac
 2. Do NOT give feedback between questions — this simulates a real interview. Note observations silently.
 3. Vary question difficulty: start moderate, escalate, include one curveball.
 4. Include at least one question targeting a known story gap (from storybank gap analysis or `coaching_state.md`) to test gap-handling under realistic conditions.
-5. **Pull from saved concerns data.** If `concerns` was previously run for this company (check `coaching_state.md` Interview Loops or Active Patterns), include at least one question that targets the top-ranked concern. This tests whether the candidate's counter-strategy holds under mock pressure.
+5. **Pull from saved concerns data.** If `concerns` was previously run for this company (check `coaching_state.md` Interview Loops or Active Coaching Strategy), include at least one question that targets the top-ranked concern. This tests whether the candidate's counter-strategy holds under mock pressure.
 6. **Adapt mid-mock like a real interviewer.** Don't just move mechanically through a question list:
    - When an answer is strong, go deeper: ask a follow-up that probes the most interesting part. Real interviewers pursue strong threads.
    - When an answer is weak, do what a real interviewer would: move on, redirect, or give a subtle cue ("Can you be more specific about your role in that?").

--- a/references/commands/practice.md
+++ b/references/commands/practice.md
@@ -124,7 +124,7 @@ The stress drill is the final test before a real high-stakes interview. See `ref
 **Session setup:**
 
 1. **Gate check.** Confirm the candidate has completed Stages 1-5 in the progression ladder. If not, flag it: "The stress drill is designed for candidates who've built a solid foundation. Your current stage is [X]. Want to work on [prerequisite drill] first, or push ahead anyway?" Respect their choice.
-2. **Pull weaknesses from coaching state.** The stress drill should target known patterns (from Active Patterns and Revisit Queue), not random pressure. Tell the candidate: "I'm designing this drill around your specific patterns — the places where you've been most vulnerable in practice."
+2. **Pull weaknesses from coaching state.** The stress drill should target known patterns (from Active Coaching Strategy and Revisit Queue), not random pressure. Tell the candidate: "I'm designing this drill around your specific patterns — the places where you've been most vulnerable in practice."
 3. **Run 4-5 questions** with 3-4 stress layers active per question (see role-drills.md for the full layer menu).
 4. **Do NOT debrief between questions.** Maintain continuous pressure through the full sequence.
 5. **Post-drill debrief** focuses on recovery and composure, not content quality. Use the stress-specific scoring from role-drills.md.

--- a/references/commands/prep.md
+++ b/references/commands/prep.md
@@ -87,7 +87,14 @@ If they can't find out, default to a verbal walkthrough format (the most common 
 After running Format Discovery, save the format details to `coaching_state.md` so subsequent commands don't re-ask:
 
 - **In Profile** (general): Update the `Known interview formats` field with any new format types discovered.
-- **In Interview Loops** (company-specific): Under the relevant company entry, add: `- Format: [discovered format details — e.g., "System design: 50 min verbal walkthrough, collaborative, one problem, with senior engineer"]`
+- **In Interview Loops** (company-specific): Under the relevant company entry, save structured format details per round:
+  ```
+  - Round formats:
+    - Round 1: Behavioral screen, 45min, recruiter
+    - Round 2: System design, 50min verbal walkthrough, collaborative, senior engineer
+    - Round 3: Technical+behavioral mix, 60min, alternating, hiring manager
+  ```
+  Include format type, duration, format variant (if applicable), and interviewer type for each round. This level of detail allows `mock`, `practice technical`, and `hype` to tailor their output without re-running discovery.
 
 This prevents re-running discovery when the candidate later runs `mock`, `practice technical`, or `hype` for the same company.
 

--- a/references/commands/progress.md
+++ b/references/commands/progress.md
@@ -17,6 +17,7 @@ The value of `progress` scales with the data available. Before running the full 
 
 ### Sequence
 
+0. **Check Score History size.** If Score History exceeds 15 rows, run the archival protocol from SKILL.md: summarize the oldest entries into a Historical Summary narrative (preserving trend direction, inflection points, and what caused shifts per dimension), then keep only the most recent 10 rows as individual entries. Do the same for Session Log if it exceeds 15 rows. This keeps the coaching state file lean for long-running engagements.
 1. **Check data availability** (see minimum data thresholds above). Adapt the protocol to what's actually possible.
 2. Ask self-reflection first: "How do you think you're progressing? Rate yourself 1-5 on each dimension."
 3. Compare self-assessment to actual coach scores over time (this is the most valuable part).
@@ -25,7 +26,8 @@ The value of `progress` scales with the data available. Before running the full 
 6. Check graduation criteria — are they interview-ready? (see Graduation Criteria below). Skip if < 3 sessions.
 7. Identify top priorities based on triage, not just lowest scores.
 8. Recommend drills and story updates.
-9. Run coaching meta-check (every 3rd session or when triggered): "Is this feedback useful? Are we working on the right things? What's not clicking?"
+9. **Review and update Active Coaching Strategy.** Check whether the current approach is producing results. If scores are flat for 3+ sessions on the target dimension, recommend a pivot: "We've been focused on [X] for [N] sessions and it's not moving. That usually means we need a different approach." Update the strategy in `coaching_state.md` — record the old approach in Previous approaches with the reason it was abandoned, and write the new approach with rationale and pivot conditions.
+10. Run coaching meta-check (every 3rd session or when triggered): "Is this feedback useful? Are we working on the right things? What's not clicking?" Record the response in the Meta-Check Log.
 
 ### Trend Narration
 

--- a/references/commands/stories.md
+++ b/references/commands/stories.md
@@ -26,6 +26,8 @@ When the candidate selects "Add," don't jump straight to STAR format. Most peopl
 
 Don't skip the reflective prompts and go straight to "tell me a story about leadership." That produces rehearsed, thin stories. The prompts produce real ones.
 
+**Important**: When adding a story, write the full STAR text to the Story Details section in `coaching_state.md` — not just the index row in the Storybank table. The table is a quick-reference index. The Story Details section is where the actual story lives, including Situation, Task, Action, Result, Earned Secret, deploy use-case, and version history. Without the full text, the coach can't help improve the story in a future session without asking the candidate to retell it from scratch.
+
 ### Improving Stories — Structured Upgrade Protocol
 
 When the candidate selects "Improve," don't just say "add more specifics." Walk through a diagnostic sequence:
@@ -51,8 +53,9 @@ When the candidate has 8+ stories, periodically run a portfolio-level audit (sug
 
 ### Story Versioning
 
-When improving a story, preserve the previous version:
-- In the storybank notes field, add: "Previous version: [date] — [brief description of what changed]"
+When improving a story, preserve the previous version in the Story Details section:
+- In the Version history field, add: "[date] — [brief description of what changed]"
+- Update the STAR text in Story Details with the improved version
 - This serves two purposes: (1) the candidate can see their progress over time, and (2) if the "improved" version stops landing in interviews, the coach can reference what changed and potentially revert.
 
 ### Story Records

--- a/references/role-drills.md
+++ b/references/role-drills.md
@@ -520,7 +520,7 @@ This drill simulates the worst-case version of an interview — multiple stresso
 
 ### Setup
 
-1. **Pull the candidate's weakest patterns** from `coaching_state.md` — Active Patterns, Score History, and Revisit Queue. The stress drill should target known vulnerabilities, not random pressure.
+1. **Pull the candidate's weakest patterns** from `coaching_state.md` — Active Coaching Strategy, Score History, and Revisit Queue. The stress drill should target known vulnerabilities, not random pressure.
 2. **Select the role-specific drill** that matches their target (PM Six-Lens, Engineer Technical Depth, etc.). The stress drill layers pressure *on top of* the role-specific content.
 3. **Set the frame**: "This is the hardest drill I'll throw at you. It's designed to break your composure so we can see what happens when things go sideways. Don't try to be perfect — try to recover."
 

--- a/references/storybank-guide.md
+++ b/references/storybank-guide.md
@@ -22,6 +22,10 @@ Create a table with these columns:
 | **Last Used** | Date of most recent use in interview |
 | **Notes** | Performance notes, feedback received |
 
+### Full Story Text
+
+The storybank table above is a quick-reference index. The **full STAR text** of each story lives in the Story Details section of `coaching_state.md` — including Situation, Task, Action, Result, Earned Secret detail, deploy use-case, and version history. When adding or improving stories, always write the full text to Story Details, not just the index row. This ensures the coach can reference, improve, and coach on the full story in future sessions without asking the candidate to retell it from scratch.
+
 ### Skill Tags (standardized)
 
 Use consistent tags for searchability:


### PR DESCRIPTION
## Summary
8 improvements to the coaching_state.md memory system, designed for candidates who use the skill over weeks or months:

- **Resume Analysis section** — kickoff resume findings now persist for all downstream commands (concerns, prep, stories, hype)
- **Full Story Details** — stories store complete STAR text + version history, not just index rows. Coach can improve stories across sessions without asking candidate to retell.
- **Coaching Notes** — freeform memory for candidate preferences, emotional patterns, and observations ("freezes in panel formats", "interviews better in the morning")
- **Tiered archival** — Score History and Session Log auto-summarize old entries when they exceed 15 rows, keeping the file lean for long engagements
- **Active Coaching Strategy** — replaces the old Active Patterns with strategy + rationale + pivot conditions + previous approaches. Coach remembers *why* it chose a path, not just what the data showed.
- **Meta-Check Log** — meta-check responses are persisted so the coach builds on past feedback rather than asking the same questions
- **Structured format details** — Interview Loops now store per-round format/duration/interviewer type
- **Timeline staleness check** — session start detects when interview dates have passed and proactively asks

Also fixes 4 stale references to the old "Active Patterns" section name across practice.md, concerns.md, mock.md, and role-drills.md.

## Test plan
- [ ] Read COACHING_STATE format in SKILL.md — verify all 8 sections are present and schema is consistent
- [ ] Grep for "Active Patterns" — should return zero results
- [ ] Grep for "workflows.md" — should return zero results
- [ ] Walk through kickoff → analyze → progress flow and verify state writes make sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)