### PR TITLE
Final review: fix 5 issues before launch freeze

### DIFF
--- a/references/commands/analyze.md
+++ b/references/commands/analyze.md
@@ -134,12 +134,16 @@ When rewriting:
 - Data quality notes:
 
 ## Recommended Next Step
-[Prescribe ONE specific command based on the triage decision — not a generic menu. Examples:]
-[- Relevance bottleneck: "Your biggest gap is answering the wrong question. I'd recommend `practice pivot` to drill question-decoding — want to start now?"]
-[- Substance bottleneck: "You need stronger raw material. Let's run `stories improve S###` on your weakest story, or `stories add` to surface new ones."]
-[- Differentiation bottleneck: "Your answers are solid but generic. Let's run `stories` to extract earned secrets from your existing stories."]
-[- Storybank changes needed: "I flagged 2 stories to rework and 1 gap to fill. Want to jump into `stories` to handle those now?"]
-[- Strong performance: "Your scores are solid. Run `progress` to see how this compares to your trend, or `mock [format]` for a full simulation."]
+[One specific command recommendation based on the triage decision above]
 
 **Other commands**: `practice`, `stories`, `progress`, `concerns`
 ```
+
+#### Recommended Next Step Logic
+
+Prescribe ONE specific command based on the triage decision — not a generic menu:
+- Relevance bottleneck → recommend `practice pivot` to drill question-decoding
+- Substance bottleneck → recommend `stories improve S###` on weakest story, or `stories add` to surface new ones
+- Differentiation bottleneck → recommend `stories` to extract earned secrets from existing stories
+- Storybank changes needed → recommend `stories` to handle reworks and gaps
+- Strong performance → recommend `progress` for trend comparison, or `mock [format]` for full simulation

--- a/references/commands/hype.md
+++ b/references/commands/hype.md
@@ -41,7 +41,6 @@ If no prep exists, say so and suggest running `prep` first if time allows.
 3.
 
 ### 3 Questions To Ask
-[If `questions` was previously run for this company (check Interview Loops for saved prepared questions), pull from those. Don't regenerate — consistency matters.]
 1.
 2.
 3.
@@ -57,10 +56,10 @@ If no prep exists, say so and suggest running `prep` first if time allows.
 5. Reframe: "This is a conversation to see if there's mutual fit. I'm also interviewing them."
 
 ## If You Bomb an Answer Mid-Interview
-See Psychological Readiness Module in `references/cross-cutting.md` — Mid-Interview Recovery.
+See Psychological Readiness Module — Mid-Interview Recovery.
 
 ## If You Get a Question You Have No Story For
-See Gap-Handling Module in `references/cross-cutting.md` — Pattern 1: Adjacent Bridge.
+See Gap-Handling Module — Pattern 1: Adjacent Bridge.
 
 ## If You Have Back-to-Back Interviews
 - Between interviews: 5-minute reset. Don't review notes — your brain needs a break, not more input.
@@ -72,3 +71,11 @@ See Gap-Handling Module in `references/cross-cutting.md` — Pattern 1: Adjacent
 
 **Next commands**: `practice ladder`, `questions`, `mock [format]`, `debrief`
 ```
+
+#### Questions Sourcing
+
+If `questions` was previously run for this company (check Interview Loops for saved prepared questions), pull from those for the 3x3. Don't regenerate — consistency matters.
+
+#### Recovery Section Sourcing
+
+For "If You Bomb an Answer Mid-Interview," inline key guidance from the Psychological Readiness Module (Mid-Interview Recovery) in `references/cross-cutting.md`. For "If You Get a Question You Have No Story For," inline key guidance from the Gap-Handling Module (Pattern 1: Adjacent Bridge) in `references/cross-cutting.md`.

--- a/references/commands/mock.md
+++ b/references/commands/mock.md
@@ -107,7 +107,7 @@ Record their responses and compare to your independent assessment in the debrief
 ## Mock Interview Debrief: [Format] - [Company/Role]
 
 ## Overall Impression
-- Hiring signal: Strong Hire / Hire / Mixed / No Hire
+- Hire Signal: Strong Hire / Hire / Mixed / No Hire
 - One-sentence summary of how this interview would land:
 
 ## Arc Analysis

--- a/references/examples.md
+++ b/references/examples.md
@@ -242,7 +242,7 @@ Your rejection pattern suggests a specific bottleneck — let's find it fast.
 ## Mock Interview Debrief: Behavioral Screen — GrowthCo PM
 
 ## Overall Impression
-- Hiring signal: Mixed
+- Hire Signal: Mixed
 - One-sentence summary: Strong individual answers but the full interview felt like five separate stories rather than a cohesive narrative about who you are as a PM.
 
 ## Arc Analysis


### PR DESCRIPTION
## Summary
- **"Hiring signal" → "Hire Signal"** in mock.md output schema and examples.md mock example (matching SKILL.md, analyze.md, and rest of mock.md)
- **analyze.md**: Moved triage prescription examples out of output code block into separate `#### Recommended Next Step Logic` section — candidate would have seen branching instructions
- **hype.md**: Moved questions-sourcing instruction (`[If questions was previously run...]`) out of output code block into `#### Questions Sourcing` section
- **hype.md**: Replaced internal file paths (`references/cross-cutting.md`) in recovery sections with module names only; added `#### Recovery Section Sourcing` with file references outside code block

## Test plan
- [ ] Verify mock.md line 110 now says "Hire Signal"
- [ ] Verify examples.md mock example says "Hire Signal"
- [ ] Verify analyze.md output code block has clean placeholder, triage logic is below the block
- [ ] Verify hype.md output code block has no bracketed coach instructions or file paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)