### PR TITLE
Add narrative identity, interviewer monologue, help overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Say `kickoff`, share your resume, and you're coaching in under 2 minutes.
 
 **Adaptive coaching** — After scoring, a decision tree triages your bottleneck and branches to the right drill. If Relevance is your gap, you get question-decoding practice. If Substance, you build raw material. The system doesn't cycle through the same sequence for every candidate.
 
-**Storybank** — Structured story management with full STAR text, earned secrets, strength ratings, and rapid-retrieval drills so you can access the right story under time pressure.
+**Storybank** — Structured story management with full STAR text, earned secrets, strength ratings, and rapid-retrieval drills so you can access the right story under time pressure. Narrative identity extraction finds the 2-3 core themes across your stories so every answer reinforces a coherent thesis about who you are.
 
-**Practice and mocks** — 8-stage drill progression (constraint ladders, pushback handling, pivot drills, panel simulations, stress tests) plus full 4-6 question mock interviews in behavioral, system design, case study, panel, and technical+behavioral formats.
+**Practice and mocks** — 8-stage drill progression (constraint ladders, pushback handling, pivot drills, panel simulations, stress tests) plus full 4-6 question mock interviews in behavioral, system design, case study, panel, and technical+behavioral formats. Every round includes the interviewer's perspective — what they were actually thinking when you spoke.
 
 **Interview lifecycle** — Company research, role-specific prep briefs with interviewer intelligence, same-day post-interview debrief, outcome tracking that correlates practice scores with real results, and post-offer negotiation coaching with exact scripts.
 

--- a/references/commands/help.md
+++ b/references/commands/help.md
@@ -5,10 +5,11 @@
 When the user types `help`, generate a context-aware command guide — not just a static list.
 
 1. **Read `coaching_state.md`** to understand where the candidate is in their coaching journey.
-2. **Show the full command table** (from SKILL.md Command Registry).
+2. **Show the full command guide** (see Output Schema below) with sub-commands and key features for each command.
 3. **Highlight the 2-3 most relevant commands right now** based on coaching state:
    - If no coaching state exists: highlight `kickoff`
    - If storybank is empty: highlight `stories`
+   - If storybank has 5+ stories but no narrative identity analysis: highlight `stories` (mention option 7)
    - If an interview is scheduled within 48 hours: highlight `hype` and `prep`
    - If transcripts exist but haven't been analyzed: highlight `analyze`
    - If 3+ scored sessions exist: highlight `progress`
@@ -20,34 +21,75 @@ When the user types `help`, generate a context-aware command guide — not just 
 ### Output Schema
 
 ```markdown
-## Available Commands
+## Command Guide
 
-| Command | Purpose |
+### Getting Started
+| Command | What It Does |
 |---|---|
-| `kickoff` | Initialize coaching profile |
-| `research [company]` | Lightweight company research + fit assessment |
-| `prep [company]` | Company + role prep brief |
-| `analyze` | Transcript analysis and scoring |
-| `debrief` | Post-interview rapid capture (same day) |
-| `practice` | Practice drill menu and rounds |
-| `mock [format]` | Full simulated interview (4-6 Qs) |
-| `stories` | Build/manage storybank |
-| `concerns` | Generate likely concerns + counters |
-| `questions` | Generate tailored interviewer questions |
-| `hype` | Pre-interview confidence and 3x3 plan |
-| `thankyou` | Thank-you note / follow-up drafts |
-| `progress` | Trend review, self-calibration, outcomes |
-| `negotiate` | Post-offer negotiation coaching |
-| `reflect` | Post-search retrospective + archive |
-| `help` | Show this command list |
+| `kickoff` | Set up your profile, choose a track (Quick Prep or Full System), and get a prioritized action plan based on your timeline |
+
+### Interview Prep
+| Command | What It Does |
+|---|---|
+| `research [company]` | Lightweight company research + fit assessment before committing to full prep |
+| `prep [company]` | Full prep brief — format guidance, culture read, interviewer intelligence (from LinkedIn URLs), predicted questions, story mapping, and a day-of cheat sheet |
+| `concerns` | Anticipate likely interviewer concerns about your profile + counter-evidence strategies |
+| `questions` | Generate 5 tailored, non-generic questions to ask your interviewer |
+| `hype` | Pre-interview boost — 60-second hype reel, 3x3 sheet (concerns + counters + questions), warmup routine, and mid-interview recovery playbook |
+
+### Practice and Simulation
+| Command | What It Does |
+|---|---|
+| `practice` | Drill menu with 8 gated stages + standalone retrieval. Sub-commands: `ladder` (constraint drills), `pushback` (handle skepticism), `pivot` (redirect), `gap` (no-example moments), `role` (specialist scrutiny), `panel` (multiple personas), `stress` (high-pressure), `technical` (system design communication). Standalone: `retrieval` (rapid-fire story matching). Includes interviewer's perspective on every round. |
+| `mock [format]` | Full 4-6 question simulated interview with holistic arc feedback and interviewer's inner monologue. Formats: `behavioral`, `system design`, `case study`, `panel`, `technical+behavioral mix` |
+
+### Analysis and Scoring
+| Command | What It Does |
+|---|---|
+| `analyze` | Paste a transcript for per-answer 5-dimension scoring, triage-based coaching (branches based on YOUR bottleneck), answer rewrites showing what a 4-5 version looks like, and a specific recommended next step |
+| `debrief` | Post-interview rapid capture — works same-day with or without a transcript. Captures questions, interviewer signals, stories used, and updates your coaching state |
+
+### Storybank
+| Command | What It Does |
+|---|---|
+| `stories` | Full storybank management. Options: `view`, `add` (guided discovery, not just "tell me a story"), `improve` (structured upgrade with before/after), `find gaps` (prioritized by target roles), `retire`, `drill` (rapid-fire retrieval practice), `narrative identity` (extract your 2-3 core career themes and see how every story connects) |
+
+### Progress and Tracking
+| Command | What It Does |
+|---|---|
+| `progress` | Score trends, self-assessment calibration (are you an over-rater or under-rater?), storybank health, outcome tracking (correlates practice scores with real interview results), and coaching meta-check |
+
+### Post-Interview
+| Command | What It Does |
+|---|---|
+| `thankyou` | Thank-you note and follow-up drafts tailored to the interview |
+| `negotiate` | Post-offer negotiation coaching — market analysis, strategy, exact scripts, and fallback language |
+| `reflect` | Post-search retrospective — journey arc, breakthroughs, transferable skills, archived coaching state |
+
+### Meta
+| Command | What It Does |
+|---|---|
+| `help` | This command guide (context-aware recommendations based on where you are) |
+
+---
 
 ## Where You Are Now
-[Brief coaching state summary — or "No coaching state found. Run `kickoff` to get started."]
+[Brief coaching state summary — track, seniority, drill stage, story count, active company loops — or "No coaching state found. Run `kickoff` to get started."]
 
 ## Recommended Next
 Based on where you are:
 1. **[command]** — [why this is the highest-leverage move right now]
 2. **[command]** — [secondary recommendation]
+
+---
+
+## Tips
+- Share a real resume during `kickoff` — it powers everything downstream (concerns, positioning, story seeds)
+- Use `debrief` the same day as a real interview — capture signals while they're fresh
+- Run `progress` weekly — it tracks your self-assessment accuracy, not just scores
+- After real interviews, log outcomes — the system correlates practice scores with real results
+- Set your feedback directness level (1-5) during `kickoff` — the diagnosis stays the same, only the delivery changes
+- Everything saves automatically to `coaching_state.md` — pick up where you left off, even weeks later
 
 What would you like to work on?
 ```

--- a/references/commands/mock.md
+++ b/references/commands/mock.md
@@ -136,11 +136,8 @@ Record their responses and compare to your independent assessment in the debrief
 - Questions where interviewer moved on quickly (negative signal):
 - Questions where interviewer redirected (answer wasn't landing):
 
-## Interviewer Perspective (what I was thinking at key moments)
-Replay 3-4 key moments from the interviewer's point of view. This teaches candidates to read what's happening on the other side of the table:
-- "When you said [X], I was thinking [Y] — that's why I followed up with [Z]."
-- "On Q3, I moved on quickly because [reason] — a real interviewer would likely do the same."
-- "Your answer on Q5 made me want to hear more about [specific thing] — but you pivoted to [other thing] instead. That was a missed opportunity to go deeper on your strongest material."
+## Interviewer's Inner Monologue
+[Replay key moments from the interviewer's real-time perspective — what they were thinking, feeling, and evaluating as the candidate spoke. Include both positive and negative reactions.]
 
 ## Format-Specific Debrief (include when applicable)
 
@@ -173,3 +170,19 @@ After the mock debrief:
 1. **Add scores to Score History** — Type: mock. Include the Hire Signal.
 2. **Record self-assessment delta** — Self-Δ: over/under/accurate based on the pre-debrief self-assessment.
 3. **Update Active Coaching Strategy** if the mock reveals new patterns or confirms/contradicts the current strategy. Preserve Previous approaches when updating — move the old approach there before writing the new one.
+
+### Interviewer's Inner Monologue — How To Write It
+
+The monologue is the most powerful teaching tool in the debrief. It shows the candidate what they can't normally see — the evaluative reactions happening in real time on the other side of the table.
+
+**Ground every beat in the candidate's actual words.** Don't write generic reactions. Quote what they said, then show the reaction:
+- "When you said 'we decided to pivot the strategy,' my first thought was: who is 'we'? Did you drive this or observe it? I'd follow up to find out."
+- "The moment you said 'we reduced churn by 40%' — that's the first concrete number in four answers. My confidence in everything you've told me just went up."
+
+**Include both positive and negative reactions.** The monologue isn't just a critique. Show what impressed, what created doubt, and what made the interviewer want to hear more.
+
+**Show the pivot points** — the specific moments where the interviewer's overall impression shifted. "Up until Q3, I was leaning Hire. Then your answer on the conflict question felt rehearsed — you described the situation but never named what was actually hard about it. That's when I started wondering if the rest of your stories were also surface-level."
+
+**Connect to signal-reading.** The monologue should explain the interviewer behaviors the candidate would have seen: "This is why I followed up on Q2 — I was genuinely curious, that's a positive signal. And why I moved on quickly from Q4 — I'd already made my assessment and it wasn't favorable."
+
+**Calibrate to the mock format.** A startup CEO's inner monologue sounds different from a FAANG bar raiser's. Match the evaluative lens to the company and role context.

--- a/references/commands/practice.md
+++ b/references/commands/practice.md
@@ -98,11 +98,26 @@ The first round of every practice session is explicitly **unscored**. Its purpos
 - Coach scored: __
 - Calibration gap (if any):
 
+## Interviewer's Read
+[1-2 key moments from this round, told from the interviewer's perspective]
+
 ## Next Round Adjustment
 - Try this single change:
 
 **Next commands**: `practice [next drill]`, `stories`, `mock [format]`, `progress`
 ```
+
+#### Interviewer's Read — How To Write It
+
+Keep it to 1-2 moments per round — practice rounds are short, so be selective. Pick the moments with the highest teaching value.
+
+**Always include at least one positive moment** — what would have genuinely impressed an interviewer, and why. Candidates need to know what's working, not just what's failing.
+
+**Ground in the candidate's actual words.** Quote what they said, then show the evaluative reaction:
+- "When you said '[specific quote],' an interviewer would be thinking: [reaction]."
+- "The moment that landed strongest was when you [specific moment] — that's the kind of detail that makes an interviewer lean in."
+
+**Connect to the scoring.** The Interviewer's Read should make the scorecard *make sense*. If Structure scored a 2, the monologue should show what that felt like from the other side of the table: "I was 30 seconds in and still didn't know where this was going. That uncertainty is what a 2 on Structure feels like to an interviewer."
 
 ### Coaching State Integration
 

--- a/references/commands/stories.md
+++ b/references/commands/stories.md
@@ -12,6 +12,7 @@ Storybank Menu
 4) Find gaps
 5) Retire/archive
 6) Drill — rapid-fire retrieval practice
+7) Narrative identity — extract your career themes and see how stories connect
 ```
 
 ### Adding Stories — Guided Discovery
@@ -84,6 +85,46 @@ When adding or improving stories, force specificity on:
 ### Rapid-Retrieval Drill (`stories drill`)
 
 See `references/storybank-guide.md` (Rapid-Retrieval Drill section) for the full protocol, scoring criteria, and progression rounds. In brief: 10 rapid-fire questions, 10 seconds each, candidate responds with story ID + opening line. Debrief focuses on retrieval gaps and hesitation patterns. Also available via `practice retrieval`.
+
+### Narrative Identity — Theme Extraction
+
+Requires 5+ stories in the storybank. If fewer exist, redirect: "Narrative identity works best with 5+ stories to find patterns across. You have [N]. Want to add a few more with `stories add` first?"
+
+#### Analysis Protocol
+
+1. Read every story's full STAR text, earned secret, and deploy use-case from `coaching_state.md`.
+2. Cluster stories by **underlying theme** — not surface skill. Surface skills are things like "leadership" or "communication." Themes are specific patterns like "building systems where none existed," "translating between worlds that don't naturally talk to each other," or "making unpopular bets that paid off." If the theme could describe a generic candidate, go deeper.
+3. Identify 2-3 dominant themes. Most candidates have 2. Three is rare and usually means one is weak.
+4. Name the **sharpest edge** — the theme that is most distinctive to this candidate, hardest to replicate, and most likely to make an interviewer remember them.
+5. Flag **orphan stories** — stories that don't connect to any theme. These dilute the narrative and may be retirement candidates.
+6. Flag **fragile themes** — themes with only 1 story supporting them. One story is an anecdote; two or more is a pattern.
+7. Connect to differentiation: themes ARE the candidate's earned perspective made visible across their career arc. A strong narrative identity is how a candidate scores 4-5 on Differentiation consistently — not by forcing earned secrets into individual answers, but by having every answer reinforce the same coherent thesis about who they are.
+
+#### Output Schema
+
+```markdown
+## Your Narrative Identity
+
+### Core Themes
+1. **[Theme]** — [one-line description of the pattern]. Stories: S###, S###, S###
+2. **[Theme]** — [one-line description]. Stories: S###, S###
+3. **[Theme]** — [one-line description]. Stories: S###
+
+### Your Sharpest Edge
+[Which theme is most distinctive to you — the one an interviewer would remember. How many of your stories currently leverage it vs. how many could. This is your highest-leverage positioning move.]
+
+### Theme Coverage
+- Stories reinforcing a theme: __ of __
+- Orphan stories (no clear theme connection): [list with S### IDs — consider retiring or reframing]
+- Fragile themes (only 1 story): [list — need reinforcement]
+
+### How To Use This
+- **In answers**: [Specific advice on connecting answers back to core themes without being heavy-handed]
+- **In questions you ask**: [How to ask questions that reinforce your themes]
+- **In positioning**: [How themes inform your "why this role / why this company" narrative]
+
+**Next commands**: `stories improve S###`, `stories add`, `practice`, `prep [company]`
+```
 
 ### Output Schema (per action)
 


### PR DESCRIPTION
## Summary
Three high-impact additions before launch freeze:

- **Narrative Identity Extraction** (`stories` menu option 7): Analyzes 5+ stories to extract 2-3 core career themes, identifies the candidate's sharpest edge, flags orphan stories and fragile themes. Teaches candidates to present a thesis about who they are, not just a collection of decent answers.
- **Interviewer's Inner Monologue** (enriched in `mock`, new in `practice`): Shows what the interviewer was actually thinking at key moments — grounded in the candidate's specific words. Mock debrief section expanded from brief bullets to detailed perspective with pivot points and signal-reading connections. Practice rounds get a new "Interviewer's Read" section (1-2 moments per round).
- **Help command overhaul**: Expanded from sparse 2-column table to grouped command guide with sub-commands, key features, format options, and a Tips section. Context-aware recommendations now include narrative identity awareness.

Also updates README "What It Does" section to mention both new features.

## Test plan
- [ ] Verify stories.md has 7 menu options and Narrative Identity section with output schema in code block, coach instructions outside
- [ ] Verify mock.md has "Interviewer's Inner Monologue" in output schema and "How To Write It" instructions outside code block
- [ ] Verify practice.md has "Interviewer's Read" in round output schema and instructions outside code block
- [ ] Verify help.md has grouped command table with sub-commands, Tips section, and context-aware logic
- [ ] Verify README mentions narrative identity and interviewer perspective

🤖 Generated with [Claude Code](https://claude.com/claude-code)