### PR TITLE
Final pedantic review: fix 6 issues across 6 files

### DIFF
--- a/references/commands/analyze.md
+++ b/references/commands/analyze.md
@@ -93,7 +93,7 @@ When rewriting:
 
 ## Triage Decision
 - Primary bottleneck dimension:
-- Coaching path chosen: [see decision tree below]
+- Coaching path chosen: [specific path based on bottleneck analysis]
 
 ## What Is Working
 1.

--- a/references/commands/help.md
+++ b/references/commands/help.md
@@ -41,7 +41,7 @@ When the user types `help`, generate a context-aware command guide — not just 
 | Command | What It Does |
 |---|---|
 | `practice` | Drill menu with 8 gated stages + standalone retrieval. Sub-commands: `ladder` (constraint drills), `pushback` (handle skepticism), `pivot` (redirect), `gap` (no-example moments), `role` (specialist scrutiny), `panel` (multiple personas), `stress` (high-pressure), `technical` (system design communication). Standalone: `retrieval` (rapid-fire story matching). Includes interviewer's perspective on every round. |
-| `mock [format]` | Full 4-6 question simulated interview with holistic arc feedback and interviewer's inner monologue. Formats: `behavioral`, `system design`, `case study`, `panel`, `technical+behavioral mix` |
+| `mock [format]` | Full 4-6 question simulated interview with holistic arc feedback and interviewer's inner monologue. Formats: `behavioral screen`, `deep behavioral`, `panel`, `bar raiser`, `system design/case study`, `technical+behavioral mix` |
 
 ### Analysis and Scoring
 | Command | What It Does |

--- a/references/commands/hype.md
+++ b/references/commands/hype.md
@@ -56,10 +56,10 @@ If no prep exists, say so and suggest running `prep` first if time allows.
 5. Reframe: "This is a conversation to see if there's mutual fit. I'm also interviewing them."
 
 ## If You Bomb an Answer Mid-Interview
-See Psychological Readiness Module — Mid-Interview Recovery.
+[Inlined recovery guidance — acknowledge, pivot, and re-engage]
 
 ## If You Get a Question You Have No Story For
-See Gap-Handling Module — Pattern 1: Adjacent Bridge.
+[Inlined gap-handling guidance — adjacent bridge technique]
 
 ## If You Have Back-to-Back Interviews
 - Between interviews: 5-minute reset. Don't review notes — your brain needs a break, not more input.

--- a/references/examples.md
+++ b/references/examples.md
@@ -413,7 +413,6 @@ The pattern here is clear and consistent with what we saw in practice: you skip 
 ```markdown
 ### Q2: "Tell me about a time you had to influence a decision without direct authority."
 - Scores: Substance 4 / Structure 4 / Relevance 4 / Credibility 3 / Differentiation 3
-- Hire Signal contribution: Positive
 - What worked: Strong specific example — you named the VP you influenced, the data you brought, and the meeting where the decision turned. Front-loaded the outcome ("I changed the roadmap priority for Q3") before the backstory.
 - Biggest gap: Credibility dips because you said "the team eventually came around" without explaining HOW you influenced them. The mechanism of influence is exactly what this question tests.
 - Root cause pattern: Reflexive "we" framing — "we aligned on the new direction" obscures that YOU drove the alignment.
@@ -425,7 +424,6 @@ The pattern here is clear and consistent with what we saw in practice: you skip 
 
 ### Q4: "Describe a situation where you disagreed with your manager's decision."
 - Scores: Substance 2 / Structure 3 / Relevance 2 / Credibility 2 / Differentiation 1
-- Hire Signal contribution: Negative
 - What worked: You structured the answer clearly — setup, disagreement, resolution. The bones were there.
 - Biggest gap: Relevance. You described a situation where you "pushed back" but ultimately agreed your manager was right. That's a challenge story, not a disagreement story. The question specifically asks about disagreement — they want to know what happens when you think the boss is wrong AND you still think so after the conversation.
 - Root cause pattern: Conflict avoidance — you selected a "safe" disagreement where you were the one who changed their mind, which avoids showing real tension.

--- a/references/storybank-guide.md
+++ b/references/storybank-guide.md
@@ -85,7 +85,7 @@ Create the table entry for each story. Be honest about strength scores:
 - **4**: Strong with good evidence, minor gaps
 - **3**: Solid but generic—others could tell similar stories
 - **2**: Thin evidence or weak outcome
-- **1**: Barely usable—retire candidate
+- **1**: Barely usable—retirement candidate
 
 ### Step 4: Gap Analysis
 

--- a/references/transcript-processing.md
+++ b/references/transcript-processing.md
@@ -157,7 +157,7 @@ ANTI-PATTERNS DETECTED:
 [List from Step 2.5 scan with Q# references]
 
 FINAL OUTPUT:
-- Overall impression: Strong Hire / Hire / Mixed / No Hire
+- Hire Signal: Strong Hire / Hire / Mixed / No Hire
 - 3 strongest answers (why they worked)
 - 3 weakest answers (specific gaps + root cause patterns)
 - Biggest concern about this candidate


### PR DESCRIPTION
## Summary
Last review before freeze. Six issues found and fixed:

- **hype.md**: Replaced "See Psychological Readiness Module" and "See Gap-Handling Module" inside output code block with fill-in placeholders — candidates shouldn't see internal module names
- **analyze.md**: Replaced `[see decision tree below]` (internal instruction, directionally wrong) with `[specific path based on bottleneck analysis]`
- **transcript-processing.md**: "Overall impression" → "Hire Signal" (last naming inconsistency)
- **examples.md**: Removed "Hire Signal contribution: Positive/Negative" from per-answer examples — this field doesn't exist in analyze.md's per-answer schema
- **storybank-guide.md**: "retire candidate" → "retirement candidate" (was ambiguous)
- **help.md**: Corrected mock format list to match mock.md: `behavioral screen`, `deep behavioral`, `panel`, `bar raiser`, `system design/case study`, `technical+behavioral mix`

## Test plan
- [ ] Verify hype.md code block has no module names — only fill-in placeholders
- [ ] Verify analyze.md triage decision has descriptive placeholder
- [ ] Verify transcript-processing.md uses "Hire Signal"
- [ ] Verify examples.md per-answer blocks match analyze.md schema (no extra fields)
- [ ] Verify storybank-guide.md strength score 1 says "retirement candidate"
- [ ] Verify help.md mock formats match mock.md exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)