### PR TITLE
Add Interview Intelligence system and feedback command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Say `kickoff`, share your resume, and you're being coached in under 2 minutes.
 
 **Interview lifecycle** — Company research, role-specific prep briefs with interviewer intelligence, same-day post-interview debrief, outcome tracking that correlates practice scores with real results, and post-offer negotiation coaching with exact scripts.
 
-**Session continuity** — A persistent `coaching_state.md` file tracks your storybank, scores, patterns, drill progression, and interview loops across sessions. Pick up where you left off, weeks later. Saves are automatic.
+**Interview intelligence** — The system learns from your real interview experiences. Every transcript, debrief, and recruiter feedback adds to a personalized knowledge base: question patterns across companies, what works and what doesn't for you specifically, and feedback-outcome correlations. Over time, prep briefs are weighted by real questions you've seen, and progress reviews surface patterns only visible across multiple interviews.
+
+**Session continuity** — A persistent `coaching_state.md` file tracks your storybank, scores, patterns, drill progression, interview loops, and interview intelligence across sessions. Pick up where you left off, weeks later. Saves are automatic.
 
 **Differentiation** — Earned secrets and spiky POVs are a first-class dimension, not an afterthought. The system pushes you past "competent" toward "memorable."
 
@@ -65,7 +67,7 @@ The coach will ask for your resume, target role, and timeline — then build you
 | `analyze` | Analyze transcript with triage-based coaching | Per-answer 5-dimension scoring + decision tree + interview delta |
 | `debrief` | Post-interview rapid capture (same day) | Questions recalled, interviewer signals, stories used, coaching state updates |
 | `practice` | Run drill rounds (with progression gating) | Round debrief + self-assessment delta + targeted adjustment |
-| `mock [format]` | Full simulated interview (4-6 Qs) — behavioral, system design, case study, panel, technical+behavioral mix | Holistic arc feedback, signal-reading notes, energy trajectory |
+| `mock [format]` | Full simulated interview (4-6 Qs) — behavioral screen, deep behavioral, panel, bar raiser, system design/case study, technical+behavioral mix | Holistic arc feedback, signal-reading notes, energy trajectory |
 | `stories` | Build/manage storybank + rapid-retrieval drill | Story table + earned secrets + gap analysis + retrieval drill |
 | `concerns` | Anticipate interviewer concerns | Concern-counter-evidence map |
 | `questions` | Generate interviewer questions | 5 tailored, non-generic questions |
@@ -73,6 +75,7 @@ The coach will ask for your resume, target role, and timeline — then build you
 | `thankyou` | Post-interview follow-up drafts | Thank-you note + variants |
 | `progress` | Trends, self-calibration, outcome tracking | Self-assessment delta + outcome correlation + coaching meta-check |
 | `negotiate` | Post-offer negotiation coaching | Offer analysis + strategy + scripts + specific language |
+| `feedback` | Capture recruiter feedback, outcomes, corrections, context | State updates + next step suggestion |
 | `reflect` | Post-search retrospective + archive | Journey arc, breakthroughs, transferable skills, archived state |
 | `help` | Show command menu (context-aware) | Full command list + recommended next based on coaching state |
 
@@ -197,7 +200,7 @@ Expected output each round:
 mock behavioral Stripe
 ```
 
-Runs a complete 4-6 question interview simulation. Formats: behavioral, system design, case study, panel, technical+behavioral mix. Holistic feedback on:
+Runs a complete 4-6 question interview simulation. Formats: behavioral screen, deep behavioral, panel, bar raiser, system design/case study, technical+behavioral mix. Holistic feedback on:
 
 - Overall impression and hiring signal
 - Energy trajectory and pacing across the full arc
@@ -243,6 +246,7 @@ Best when running a multi-week search.
 - Drill progression with gating thresholds (8 stages + standalone retrieval)
 - Post-interview debrief and rapid capture
 - Outcome tracking (correlate practice with real results)
+- Interview intelligence — learns question patterns, what works/doesn't, and company-specific insights from your real interviews
 - Interview loop awareness across company rounds
 - Post-offer negotiation coaching
 - Post-search retrospective and archiving
@@ -275,6 +279,7 @@ interview-coach-skill/
     │   ├── thankyou.md
     │   ├── progress.md
     │   ├── negotiate.md
+    │   ├── feedback.md
     │   ├── reflect.md
     │   └── help.md
     ├── cross-cutting.md                # Shared modules: gap-handling, signal-reading, differentiation, cultural awareness, psychological readiness, cross-command dependencies
@@ -296,8 +301,9 @@ interview-coach-skill/
 4. Keep a living storybank with `stories`. Extract earned secrets for every story.
 5. Run `progress` weekly — it tracks your self-assessment accuracy, not just scores.
 6. After real interviews, log outcomes. The system correlates practice scores with real results.
-7. Run `mock` before important interviews. Individual drills build skills; mocks test the full arc.
-8. Use `debrief` the same day as a real interview — capture signals while they're fresh.
+7. When you hear back from a recruiter — good or bad — run `feedback` to capture it. The system learns from your real experiences over time.
+8. Run `mock` before important interviews. Individual drills build skills; mocks test the full arc.
+9. Use `debrief` the same day as a real interview — capture signals while they're fresh.
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -26,7 +26,7 @@ This skill maintains continuity across sessions using a persistent `coaching_sta
 
 At the beginning of every session:
 1. Read `coaching_state.md` if it exists.
-2. **If it exists**: Run the Timeline Staleness Check (see below). Then greet the candidate by context: "Welcome back. Last session we worked on [X]. Your current drill stage is [Y]. You have [Z] real interviews logged. Where do you want to pick up?" Do NOT re-run kickoff. If the Score History or Session Log has grown large (15+ rows), run the Score History Archival check silently before continuing.
+2. **If it exists**: Run the Timeline Staleness Check (see below). Then greet the candidate by context: "Welcome back. Last session we worked on [X]. Your current drill stage is [Y]. You have [Z] real interviews logged. Where do you want to pick up?" Do NOT re-run kickoff. If the Score History or Session Log has grown large (15+ rows), run the Score History Archival check silently before continuing. Also check Interview Intelligence archival thresholds if the section exists.
 3. **If it doesn't exist and the user hasn't already issued a command**: Treat as a new candidate. Suggest kickoff.
 4. **If it doesn't exist but the user has already issued a command** (e.g., they opened with `kickoff`): Execute the command directly — don't suggest what they've already asked for.
 
@@ -47,6 +47,12 @@ After any session (mid-session or end-of-session) where the candidate reveals pr
 ### Score History Archival
 
 When Score History exceeds 15 rows, summarize the oldest entries into a Historical Summary narrative and keep only the most recent 10 rows as individual entries. The summary should preserve: trend direction per dimension, inflection points (what caused jumps or drops), and what coaching changes triggered shifts. Run this check during `progress` or at session start when the file is large. Apply the same archival pattern to Session Log when it exceeds 15 rows — compress old sessions into a brief narrative, keep recent ones detailed. The goal is to keep the file readable and within reasonable context limits for months-long coaching engagements.
+
+**Interview Intelligence archival thresholds** (check during `progress` or session start):
+- Question Bank: 30 rows → summarize questions older than 3 months into Historical Intelligence Summary, keep 20 recent
+- Effective/Ineffective Patterns: 10 entries → consolidate to 3-5 summary patterns in Historical Intelligence Summary
+- Recruiter/Interviewer Feedback: 15 rows → summarize older feedback into Company Patterns, keep 10 recent
+- Company Patterns for closed loops (Status: Archived or Closed) → compress to 2-3 lines
 
 ### Timeline Staleness Check
 
@@ -106,6 +112,34 @@ Last updated: [date]
 |------|---------|------|-------|--------|-------|
 [rows — Result: advanced/rejected/pending/offer]
 
+## Interview Intelligence
+
+### Question Bank
+| Date | Company | Role | Round Type | Question | Competency | Score | Outcome |
+[Round Type: behavioral/technical/system-design/case-study/bar-raiser/culture-fit.
+ Score: average across 5 dims (e.g., 3.4), or "recall-only" for debrief-captured questions.
+ Outcome: advanced/rejected/pending/unknown — updated when known.]
+
+### Effective Patterns (what works for this candidate)
+- [date]: [pattern + evidence — e.g., "Leading with counterintuitive choice in prioritization stories scores 4+ on Differentiation (CompanyA R1, CompanyB R2)"]
+
+### Ineffective Patterns (what keeps not working)
+- [date]: [pattern + evidence — e.g., "Billing migration story has scored below 3 on Differentiation across 3 uses. Retire or rework."]
+
+### Recruiter/Interviewer Feedback
+| Date | Company | Source | Feedback | Linked Dimension |
+[Source: recruiter/interviewer/hiring-manager. Keep verbatim when possible.]
+
+### Company Patterns (learned from real experience)
+#### [Company Name]
+- Questions observed: [types and frequency]
+- What seems to matter: [observations from real data]
+- Stories that landed / didn't: [S### IDs]
+- Last updated: [date]
+
+### Historical Intelligence Summary
+[Narrated summary when subsections exceed archival thresholds]
+
 ## Drill Progression
 - Current stage: [1-8]
 - Gates passed: [list]
@@ -161,11 +195,12 @@ Write to `coaching_state.md` whenever:
 - kickoff creates a new profile and populates Resume Analysis from resume analysis. Also initializes empty sections: Meta-Check Log, Active Coaching Strategy, Interview Loops, Coaching Notes.
 - research adds a new company entry (lightweight, in Interview Loops with Status: Researched, plus fit assessment, key signals, and date)
 - stories adds, improves, or retires stories (write full STAR text to Story Details, not just index row)
-- analyze, practice, or mock produces scores (add to Score History — practice sub-commands that use the 5-dimension rubric add to Score History; retrieval drills log to Session Log only) — analyze also updates Active Coaching Strategy after triage decision. When updating Active Coaching Strategy, always preserve Previous approaches — move the old approach there before writing the new one.
+- analyze, practice, or mock produces scores (add to Score History — practice sub-commands that use the 5-dimension rubric add to Score History; retrieval drills log to Session Log only) — analyze also updates Active Coaching Strategy after triage decision. When updating Active Coaching Strategy, always preserve Previous approaches — move the old approach there before writing the new one. Analyze also extracts questions and scores to Interview Intelligence Question Bank, updates Effective/Ineffective Patterns if 3+ data points reveal a pattern, and updates Company Patterns.
 - concerns generates ranked concerns (save to Interview Loops under the relevant company's Concerns surfaced, or to Active Coaching Strategy if general)
 - questions generates tailored questions (save top 3 to Interview Loops under Prepared questions for the relevant company)
-- debrief captures post-interview data (add to Interview Loops, update storybank Last Used dates, add to Outcome Log as pending)
-- progress reviews trends (update Active Coaching Strategy, check Score History archival)
+- debrief captures post-interview data (add to Interview Loops, update storybank Last Used dates, add to Outcome Log as pending). Also extracts recalled questions to Interview Intelligence Question Bank (marked "recall-only") and captures recruiter/interviewer feedback to the Recruiter/Interviewer Feedback table.
+- feedback captures ad-hoc input: recruiter feedback (add to Recruiter/Interviewer Feedback), outcomes (update Outcome Log + Question Bank Outcome column), corrections (evaluate and adjust if warranted — may update Score History or Storybank ratings, record in Coaching Notes), post-session memories (route to Question Bank, Storybank, Interview Loops, or Company Patterns as appropriate), and meta-feedback (record in Meta-Check Log)
+- progress reviews trends (update Active Coaching Strategy, check Score History archival, check Interview Intelligence archival thresholds)
 - User reports a real interview outcome (add to Outcome Log)
 - prep starts a new company loop or updates interviewer intel and round formats (add to Interview Loops)
 - negotiate receives an offer (add to Outcome Log with Result: offer)
@@ -193,6 +228,7 @@ Write to `coaching_state.md` whenever:
     - Every ~3 sessions if they haven't used it: weave a light reminder into the session close.
     - Keep it natural — one sentence, not a sales pitch. Vary the wording so it doesn't feel robotic.
 11. **Name what you can and can't coach.** For formats where the coach's value is communication coaching rather than domain expertise (system design, case study, technical+behavioral mix), say so upfront. A coach who pretends to evaluate system design correctness is worse than one who clearly says "I'm coaching how you communicate your thinking, not whether your design is right." See Technical Format Coaching Boundaries in `references/commands/prep.md` for specifics.
+12. **Light-touch intelligence referencing.** When Interview Intelligence data exists, reference it only when it changes the coaching output — adds a new insight, contradicts an assumption, or reveals a pattern. The test: "Would I give different advice without this data?" If no, don't mention it.
 
 ## Command Registry
 
@@ -215,6 +251,7 @@ Execute commands immediately when detected. Before executing, **read the referen
 | `progress` | Trend review, self-calibration, outcomes |
 | `negotiate` | Post-offer negotiation coaching |
 | `reflect` | Post-search retrospective + archive |
+| `feedback` | Capture recruiter feedback, report outcomes, correct assessments, add context |
 | `help` | Show this command list |
 
 ### File Routing
@@ -225,6 +262,7 @@ When executing a command, read the required reference files first:
 - **`analyze`**: Also read `references/transcript-processing.md`, `references/rubrics-detailed.md`, `references/examples.md`, and `references/differentiation.md` (when Differentiation is the bottleneck).
 - **`practice`**, **`mock`**: Also read `references/role-drills.md`.
 - **`stories`**: Also read `references/storybank-guide.md` and `references/differentiation.md`.
+- **`feedback`**: Read `references/commands/feedback.md`.
 
 ## Evidence Sourcing Standard
 
@@ -299,16 +337,17 @@ Use first match:
 
 1. Explicit command
 2. Transcript present -> `analyze`
-3. "Just had an interview" / "just finished" / post-interview context -> `debrief`
-4. Company + JD context -> `prep`
-5. Company name only (no JD, no interview scheduled) -> `research`
-6. Story-building / storybank intent -> `stories`
-7. System design / case study / technical interview practice intent -> `practice technical` (sub-command of `practice`)
-8. Practice intent -> `practice`
-9. Progress/pattern intent -> `progress`
-10. "I got an offer" / offer details present -> `negotiate`
-11. "I'm done" / "accepted" / "wrapping up" -> `reflect`
-12. Otherwise -> ask whether to run `kickoff` or `help`
+3. Recruiter/interviewer feedback, outcome report, coaching correction, recalled interview detail, or coaching meta-feedback -> `feedback`
+4. "Just had an interview" / "just finished" / post-interview context -> `debrief`
+5. Company + JD context -> `prep`
+6. Company name only (no JD, no interview scheduled) -> `research`
+7. Story-building / storybank intent -> `stories`
+8. System design / case study / technical interview practice intent -> `practice technical` (sub-command of `practice`)
+9. Practice intent -> `practice`
+10. Progress/pattern intent -> `progress`
+11. "I got an offer" / offer details present -> `negotiate`
+12. "I'm done" / "accepted" / "wrapping up" -> `reflect`
+13. Otherwise -> ask whether to run `kickoff` or `help`
 
 ---
 

--- a/references/commands/analyze.md
+++ b/references/commands/analyze.md
@@ -24,9 +24,9 @@ If a candidate drops a transcript without having run `kickoff` first, don't refu
 9. **Signal-reading analysis.** Scan the transcript for interviewer behavior patterns using the Signal-Reading Module in `references/cross-cutting.md`. Include observations in the per-answer analysis and in the overall debrief.
 10. **Question decode for low-Relevance answers.** For any answer scoring < 3 on Relevance, don't just say "you missed the point." Explain what the question was actually probing for: "This question about 'a time you failed' isn't testing whether you've failed — it's testing self-awareness, learning orientation, and honesty. A targeted answer would have focused on what you learned and how it changed your approach, not on the failure itself."
 11. **Proactive rewrite of the weakest answer.** Don't just offer a rewrite — do one automatically for the lowest-scoring answer. Show the original excerpt and the improved version side by side with annotations. Say: "Here's what your weakest answer could look like at a 4-5. I'll show the delta so the improvement is concrete — not to give you a script, but to make it tangible." Still offer rewrites of other answers on request.
-12. **Triage — identify primary bottleneck and branch:**
+12. **Triage — identify primary bottleneck and branch** using the Post-Scoring Decision Tree below.
 
-### Post-Scoring Decision Tree
+#### Post-Scoring Decision Tree (Step 12 detail)
 
 After scoring, identify bottleneck dimensions and branch. Most candidates have multiple weak dimensions — use the priority stack below to determine which to address first.
 
@@ -53,6 +53,11 @@ After scoring, identify bottleneck dimensions and branch. Most candidates have m
     - Calibration (skip if Substance < 3 — premature optimization)
 14. Synthesize into delta plan with triage-informed priorities.
 15. **Update Active Coaching Strategy in `coaching_state.md`.** Write the chosen coaching path, rationale, and pivot conditions. If an Active Coaching Strategy already exists, check whether this analysis confirms or contradicts it. If the data suggests a different bottleneck than the current strategy targets, **move the old approach to Previous approaches** (with brief reason for the change) before writing the new one: "Your previous coaching focus was Structure, but this transcript shows Structure at 4 while Differentiation is at 2. I'm updating the strategy to focus on Differentiation." Always preserve the history of what was tried and why it was abandoned — this prevents the coach from cycling back to strategies that already failed.
+16. **Update Interview Intelligence.** Extract each scored question to the Question Bank (date, company, role, round type, question, competency, score as 5-dim average, outcome). Then cross-reference with existing Question Bank data — but only surface cross-references when they're meaningful:
+    - Score trajectory on a repeated competency (3+ instances) — e.g., "Your Differentiation on leadership questions has gone 2.2 → 2.8 → 3.4 across three interviews."
+    - Same question type appearing at the same company across rounds
+    - A pattern that changes the coaching recommendation
+    Update Effective/Ineffective Patterns only when 3+ data points support the pattern. Update Company Patterns with question types observed and what seems to matter based on this interview.
 
 ### Per-Answer Format (for each analyzed answer)
 
@@ -62,6 +67,7 @@ After scoring, identify bottleneck dimensions and branch. Most candidates have m
 - What worked:
 - Biggest gap:
 - Root cause pattern (if detected):
+- Intelligence cross-reference (only when past data changes the coaching):
 - Tight rewrite direction:
 - Evidence:
 ```
@@ -128,6 +134,11 @@ When rewriting:
 ## Reflection Prompts
 - How does this feedback compare to your gut feeling about the interview?
 - Of the growth areas above, which feels most within your control?
+
+## Intelligence Updates
+- Questions added to Question Bank: [count]
+- Patterns observed: [new effective/ineffective patterns, or "not enough data yet"]
+- Company learning: [new observations about this company's interview patterns, or "first interview at this company"]
 
 ## Confidence
 - Score confidence:

--- a/references/commands/debrief.md
+++ b/references/commands/debrief.md
@@ -18,7 +18,9 @@ Captures what happened in a real interview while it's still fresh. This is the b
 5. **Surprise capture.** "Was there anything you didn't expect? A question you weren't prepared for, a format difference, something about the interviewer or environment?" Unexpected moments are often the most informative for coaching.
 6. **Story usage log.** "Which stories did you use? Did any of them land differently than in practice?" Cross-reference with storybank — update `Last Used` dates and add performance notes.
 7. **Immediate tactical notes.** "Is there anything you want to do differently for the next round, based on this one?" Capture their own coaching instinct.
-8. **Transcript availability check.** "Do you have a recording or transcript? If so, we can do a full `analyze` later. If not, I'll work from what you've captured here."
+8. **Recruiter/interviewer feedback capture.** "Did you get any feedback from the recruiter about this round? Even informal comments — 'they really liked your background' or 'the interviewer had some concerns about X' — are valuable signal." If feedback exists, record it for the Recruiter/Interviewer Feedback table in Interview Intelligence.
+9. **Past question similarity check.** Scan the Interview Intelligence Question Bank for questions similar to what the candidate recalled. If matches exist, note them briefly: "You've seen a prioritization question like Q2 before — at [Company] in Round [N]. Your score on that one was [X]." Only surface matches that are useful (same competency tested, score trajectory, or company pattern). Don't force connections.
+10. **Transcript availability check.** "Do you have a recording or transcript? If so, we can do a full `analyze` later. If not, I'll work from what you've captured here."
 
 ### With vs. Without Transcript
 
@@ -74,6 +76,17 @@ Based on the emotional check in step 1, adapt:
 - What to do differently:
 - What worked:
 
+## Feedback Received
+- Date:
+- Company:
+- Source: [recruiter / interviewer / hiring manager / none]
+- Feedback: [verbatim or close to it]
+- Linked dimension: [if mappable]
+
+## Intelligence Notes
+- Questions matched from past interviews: [any Question Bank matches, or "no prior data"]
+- Company pattern observations: [anything learned about this company's interview approach]
+
 ## Transcript Status
 - [ ] Transcript available → run `analyze` when ready
 - [ ] No transcript → directional analysis above is what we have
@@ -87,3 +100,4 @@ Update `coaching_state.md` per the State Update Triggers in SKILL.md:
 - Storybank updates: Last Used dates, performance notes
 - Interview Loop updates: round completed, stories used, signals noted
 - Outcome Log: add entry with Result: pending
+- Interview Intelligence updates: recalled questions to Question Bank (marked "recall-only"), recruiter/interviewer feedback to Recruiter/Interviewer Feedback table, Company Patterns if new observations emerged

--- a/references/commands/feedback.md
+++ b/references/commands/feedback.md
@@ -1,0 +1,124 @@
+# feedback — Capture Feedback, Outcomes, and Corrections
+
+A lightweight command for capturing information that arrives between structured workflows. Feedback does **capture**, not analysis. Analysis happens in `analyze`, `progress`, and `prep` when the data becomes relevant.
+
+### When to Use
+
+- Recruiter or interviewer sends feedback (formal or informal)
+- Candidate learns an interview outcome (advanced, rejected, offer)
+- Candidate wants to correct or adjust a previous coaching assessment
+- Candidate remembers something from a past interview they want to log
+- Candidate has meta-feedback about the coaching itself
+
+### Input Type Detection
+
+Classify the candidate's input into one of five types. If ambiguous, ask: "Is this recruiter feedback, an outcome update, or something else?"
+
+---
+
+### Type A: Recruiter/Interviewer Feedback
+
+**Trigger**: Candidate shares feedback received from a recruiter, interviewer, or hiring manager.
+
+**Capture process**:
+1. Record the feedback as close to verbatim as possible. Ask: "Can you share exactly what they said? Even rough wording helps — paraphrasing loses signal."
+2. Identify the source: recruiter, interviewer, or hiring manager.
+3. Map the feedback to the most relevant scoring dimension(s) — but hold this lightly. Some feedback maps cleanly ("your answers were hard to follow" → Structure), some doesn't ("we went with a candidate with more domain experience" → external factor, not a coaching gap).
+4. If the feedback contradicts the coach's assessment, note the discrepancy — don't dismiss it. External feedback is higher-signal than internal scoring.
+
+**State updates**:
+- Add to Interview Intelligence → Recruiter/Interviewer Feedback table (Date, Company, Source, Feedback, Linked Dimension)
+- Update Company Patterns if this reveals something about what the company values
+- If feedback references a specific round, cross-reference with Question Bank entries for that round
+
+**Output**: Brief confirmation of what was captured, the dimension mapping, and any discrepancy with previous coaching assessment. If the feedback suggests a coaching pivot, say so: "This feedback suggests [X] matters more than we've been prioritizing. Worth revisiting in your next `progress` review."
+
+---
+
+### Type B: Outcome Report
+
+**Trigger**: Candidate reports advancing, being rejected, receiving an offer, or any status change in an active interview loop.
+
+**Capture process**:
+1. Confirm the company, role, and round.
+2. Record the outcome: advanced / rejected / offer / withdrawn.
+3. If rejected, ask: "Did they give any reason? Even 'no feedback provided' is worth recording."
+4. If advanced, ask: "Do you know what's next? Format, timeline, interviewer?"
+
+**State updates**:
+- Update Outcome Log (Date, Company, Role, Round, Result, Notes)
+- Update Interview Loops → relevant company entry (Status, Rounds completed)
+- Update Interview Intelligence → Question Bank Outcome column for all questions from this company/round
+- If advanced with next-round details, update Interview Loops → Next round
+
+**Output**: Brief confirmation of the update. If outcome data now meets the threshold for outcome-score correlation (3+ real interviews), mention it: "You now have enough real interview data for `progress` to show outcome patterns. Worth running when you're ready."
+
+---
+
+### Type C: Coaching Correction
+
+**Trigger**: Candidate disagrees with a previous score, assessment, or coaching recommendation.
+
+**Capture process**:
+1. Understand what they're correcting and why. Don't get defensive — the candidate has information the coach doesn't.
+2. Evaluate the correction against the evidence:
+   - **If the correction is warranted** (candidate provides new information, points out something missed): Acknowledge it, adjust the assessment, and update the relevant state. "You're right — I missed that context. That changes the Credibility read from a 3 to a 4."
+   - **If the correction reflects a calibration gap** (candidate rates themselves higher than evidence supports): Hold the line on the assessment but acknowledge their perspective. "I hear you, and I understand why you see it differently. Here's what the evidence shows — [specifics]. Let's use this as a data point for your self-assessment calibration."
+   - **If it's ambiguous**: Name it. "This could go either way. Here's the case for each read. I'll note your perspective alongside my assessment."
+3. Record the exchange regardless of outcome — corrections reveal how the candidate processes feedback.
+
+**State updates**:
+- If assessment adjusted: update the relevant Score History entry or Storybank rating
+- Record in Coaching Notes (Date, what was corrected, outcome)
+- If pattern emerges (candidate consistently corrects in one direction), note in Active Coaching Strategy → Self-assessment tendency
+
+**Output**: Acknowledgment of the correction, the evaluation, and what (if anything) changed. No defensiveness, no rubber-stamping.
+
+---
+
+### Type D: Post-Session Memory
+
+**Trigger**: Candidate remembers a question, story detail, interviewer behavior, or other interview data after the debrief or analysis session has closed.
+
+**Capture process**:
+1. Identify what type of information it is:
+   - A question they forgot during debrief → route to Question Bank
+   - A story detail or new story → route to Storybank (suggest `stories` for full development)
+   - An interviewer signal they remembered → route to Interview Loops
+   - A company culture observation → route to Company Patterns
+2. Capture it in the appropriate section.
+
+**State updates**:
+- Route to the appropriate section as identified above
+- If it's a question, add to Interview Intelligence → Question Bank with score "recall-only"
+- If it changes a previous assessment meaningfully, flag it
+
+**Output**: Brief confirmation of where the information was captured. If it changes something meaningful, say so. If it would benefit from further development, suggest the relevant command: "Captured that question. If you want to prep an answer for it, `practice` can drill you on it."
+
+---
+
+### Type E: Coaching Meta-Feedback
+
+**Trigger**: Candidate provides feedback about the coaching itself — what's working, what isn't, what they want more or less of.
+
+**Capture process**:
+1. Listen without defensiveness. This is the most valuable type of feedback for improving the coaching relationship.
+2. Classify: Is this about delivery (too direct, not direct enough), content (wrong focus area, missing something), or process (too structured, not structured enough)?
+3. Identify any immediate adjustment that can be made.
+
+**State updates**:
+- Record in Meta-Check Log (Session, Candidate Feedback, Adjustment Made)
+- If delivery feedback, consider adjusting Feedback Directness level in Profile
+- If content feedback, evaluate against Active Coaching Strategy — does this warrant a pivot?
+- Record in Coaching Notes if it reveals a preference the coach should remember
+
+**Output**: Acknowledgment, any immediate adjustment made, and what will change going forward. "Got it — you want me to focus less on Structure and more on the stories themselves. I'll adjust. For the record, your Structure scores are strong enough that this makes sense."
+
+---
+
+### Design Principles
+
+- **Capture first, analyze later.** Feedback captures data; `analyze`, `progress`, and `prep` are where that data becomes actionable. Don't over-analyze in the moment — confirm what was captured and move on.
+- **Flexible output.** There's no fixed output schema for `feedback`. The confirmation adapts to the input type — sometimes it's one line, sometimes it's a paragraph. Match the weight of the output to the weight of the input.
+- **Optional next step.** After capturing, suggest the most natural next command if one is relevant. Don't force it.
+- **Don't duplicate existing workflows.** If the candidate starts a full debrief during `feedback`, redirect: "This sounds like a full debrief — want to switch to `debrief` so we capture everything systematically?" Same for detailed corrections that become re-analysis — redirect to `analyze`.

--- a/references/commands/help.md
+++ b/references/commands/help.md
@@ -15,6 +15,7 @@ When the user types `help`, generate a context-aware command guide — not just 
    - If 3+ scored sessions exist: highlight `progress`
    - If an offer was received: highlight `negotiate`
    - If drill progression shows the candidate hasn't completed Stage 1: highlight `practice ladder`
+   - If the candidate mentions recruiter feedback or an outcome in conversation but hasn't used `feedback`: highlight `feedback`
 4. **Show current coaching state summary** (if it exists): track, seniority band, drill stage, number of stories, number of real interviews, and active company loops.
 5. **End with a prompt**: "What would you like to work on?"
 
@@ -32,7 +33,7 @@ When the user types `help`, generate a context-aware command guide — not just 
 | Command | What It Does |
 |---|---|
 | `research [company]` | Lightweight company research + fit assessment before committing to full prep |
-| `prep [company]` | Full prep brief — format guidance, culture read, interviewer intelligence (from LinkedIn URLs), predicted questions, story mapping, and a day-of cheat sheet |
+| `prep [company]` | Full prep brief — format guidance, culture read, interviewer intelligence (from LinkedIn URLs), predicted questions (weighted by real questions from past interviews when available), story mapping, and a day-of cheat sheet |
 | `concerns` | Anticipate likely interviewer concerns about your profile + counter-evidence strategies |
 | `questions` | Generate 5 tailored, non-generic questions to ask your interviewer |
 | `hype` | Pre-interview boost — 60-second hype reel, 3x3 sheet (concerns + counters + questions), warmup routine, and mid-interview recovery playbook |
@@ -46,8 +47,8 @@ When the user types `help`, generate a context-aware command guide — not just 
 ### Analysis and Scoring
 | Command | What It Does |
 |---|---|
-| `analyze` | Paste a transcript for per-answer 5-dimension scoring, triage-based coaching (branches based on YOUR bottleneck), answer rewrites showing what a 4-5 version looks like, and a specific recommended next step |
-| `debrief` | Post-interview rapid capture — works same-day with or without a transcript. Captures questions, interviewer signals, stories used, and updates your coaching state |
+| `analyze` | Paste a transcript for per-answer 5-dimension scoring, triage-based coaching (branches based on YOUR bottleneck), answer rewrites showing what a 4-5 version looks like, intelligence updates (tracks questions and patterns across interviews), and a specific recommended next step |
+| `debrief` | Post-interview rapid capture — works same-day with or without a transcript. Captures questions, interviewer signals, stories used, recruiter feedback, and checks for question patterns from past interviews |
 
 ### Storybank
 | Command | What It Does |
@@ -57,11 +58,12 @@ When the user types `help`, generate a context-aware command guide — not just 
 ### Progress and Tracking
 | Command | What It Does |
 |---|---|
-| `progress` | Score trends, self-assessment calibration (are you an over-rater or under-rater?), storybank health, outcome tracking (correlates practice scores with real interview results), and coaching meta-check |
+| `progress` | Score trends, self-assessment calibration (are you an over-rater or under-rater?), storybank health, outcome tracking (correlates practice scores with real interview results), question-type performance analysis, accumulated patterns from real interviews, and coaching meta-check |
 
 ### Post-Interview
 | Command | What It Does |
 |---|---|
+| `feedback` | Capture recruiter feedback, report outcomes (advanced/rejected/offer), correct assessments, or add context the system should remember. The system learns from your real interview experiences over time. |
 | `thankyou` | Thank-you note and follow-up drafts tailored to the interview |
 | `negotiate` | Post-offer negotiation coaching — market analysis, strategy, exact scripts, and fallback language |
 | `reflect` | Post-search retrospective — journey arc, breakthroughs, transferable skills, archived coaching state |
@@ -86,6 +88,7 @@ Based on where you are:
 ## Tips
 - Share a real resume during `kickoff` — it powers everything downstream (concerns, positioning, story seeds)
 - Use `debrief` the same day as a real interview — capture signals while they're fresh
+- When you hear back from a recruiter — good or bad — run `feedback` to capture it. The system learns from your real interview experiences over time.
 - Run `progress` weekly — it tracks your self-assessment accuracy, not just scores
 - After real interviews, log outcomes — the system correlates practice scores with real results
 - Set your feedback directness level (1-5) during `kickoff` — the diagnosis stays the same, only the delivery changes

--- a/references/commands/prep.md
+++ b/references/commands/prep.md
@@ -186,6 +186,11 @@ If `coaching_state.md` shows previous rounds at the same company, this is a cont
 - Review what concerns likely surfaced from previous round analysis.
 - Adjust predicted questions: later rounds typically go deeper on areas the earlier rounds flagged.
 - Note: "You used S003 and S007 in Round 1. For Round 2, prioritize S### and S### to show range. Based on your Round 1 analysis, they'll likely probe deeper on [area]."
+- **Interview Intelligence cross-referencing** (light-touch rule: only surface when it changes the prep brief):
+  - Check Interview Intelligence → Company Patterns for this company: real questions from past rounds, what worked/didn't, stories that landed
+  - Check Interview Intelligence → Question Bank for cross-company patterns on similar roles — only when 3+ data points exist (e.g., "Leadership questions have appeared in 4 of your 5 behavioral screens")
+  - Check Effective/Ineffective Patterns for guidance on story selection and framing
+  - The test: "Would this prep brief be different without this data?" If yes, include it. If no, skip it.
 
 ### Interviewer Intelligence
 
@@ -263,6 +268,7 @@ When the candidate provides interviewer LinkedIn URLs or profile links, analyze 
    Evidence:
 
 ## Predicted Questions (7-10)
+[If Interview Intelligence has real questions from past rounds at this company, list those first, flagged as "Asked in Round N". Use cross-company competency frequency from the Question Bank to weight remaining predictions — competencies that appear frequently across the candidate's interviews are more likely to appear again.]
 1. Question - Competency:
 ...
 

--- a/references/commands/progress.md
+++ b/references/commands/progress.md
@@ -17,7 +17,7 @@ The value of `progress` scales with the data available. Before running the full 
 
 ### Sequence
 
-0. **Check Score History size.** If Score History exceeds 15 rows, run the archival protocol from SKILL.md: summarize the oldest entries into a Historical Summary narrative (preserving trend direction, inflection points, and what caused shifts per dimension), then keep only the most recent 10 rows as individual entries. Do the same for Session Log if it exceeds 15 rows. This keeps the coaching state file lean for long-running engagements.
+0. **Check Score History and Intelligence size.** If Score History exceeds 15 rows, run the archival protocol from SKILL.md: summarize the oldest entries into a Historical Summary narrative (preserving trend direction, inflection points, and what caused shifts per dimension), then keep only the most recent 10 rows as individual entries. Do the same for Session Log if it exceeds 15 rows. Also check Interview Intelligence archival thresholds (defined in SKILL.md): Question Bank at 30 rows, Effective/Ineffective Patterns at 10 entries, Recruiter/Interviewer Feedback at 15 rows, Company Patterns for closed loops. This keeps the coaching state file lean for long-running engagements.
 1. **Check data availability** (see minimum data thresholds above). Adapt the protocol to what's actually possible.
 2. Ask self-reflection first: "How do you think you're progressing? Rate yourself 1-5 on each dimension."
 3. Compare self-assessment to actual coach scores over time (this is the most valuable part).
@@ -90,6 +90,19 @@ When 3+ real interview outcomes exist, run a direct correlation analysis:
 
 **Present as a narrative, not a table:**
 > "You've done 5 real interviews. You advanced in 3 and were rejected from 2. Looking at the pattern: the 3 advances all came after sessions where your Differentiation was 4+. The 2 rejections both happened when your most recent practice had Differentiation at 2-3. For your target roles, standing out seems to matter more than being polished. Let's prioritize earned secrets and spiky POVs over structure refinement."
+
+### Intelligence-Enriched Analysis
+
+When Interview Intelligence data exists, enrich the progress review — but only when it adds insight beyond what dimension-level trends already show. Apply the light-touch rule: skip this section entirely if dimension-level trends tell the full story.
+
+**Question Type Performance** (requires 5+ Question Bank entries):
+Group Question Bank entries by competency. Show where the candidate is strong vs. where gaps persist: "Your leadership questions average 3.8, but prioritization questions average 2.6 across 4 instances. That's a specific gap worth targeting."
+
+**Feedback-Outcome Correlation** (requires 3+ Recruiter/Interviewer Feedback entries):
+Map recruiter/interviewer feedback to outcomes. Look for patterns: "Both rejections included feedback about unclear impact — that maps directly to your Substance scores."
+
+**Accumulated Patterns** (requires 3+ data points per pattern):
+Surface Effective and Ineffective Patterns that have enough evidence to be reliable. Present as actionable guidance: "Pattern confirmed across 4 interviews: when you lead with the counterintuitive choice, your Differentiation scores jump. Keep doing this."
 
 ### Graduation Criteria
 
@@ -167,6 +180,16 @@ This is hard but important. If after sustained effort, scores remain at 2-3 acro
 - Competitive-ready criteria: __ of 6 met (if applicable)
 - Assessment: [Not yet ready / Ready for interviews / Ready for competitive processes]
 - What's between you and ready: [specific gaps]
+
+## Question Type Performance (if 5+ Question Bank entries exist)
+- Strongest competency areas: [competency — avg score — count]
+- Weakest competency areas: [competency — avg score — count]
+- Targeting recommendation: [specific competency to drill, if gap is actionable]
+
+## Accumulated Patterns (if 3+ data points per pattern)
+- Confirmed effective patterns: [from Interview Intelligence]
+- Confirmed ineffective patterns: [from Interview Intelligence]
+- Feedback-outcome correlation: [if sufficient data]
 
 ## Pattern Signals
 - Repeating strengths:

--- a/references/cross-cutting.md
+++ b/references/cross-cutting.md
@@ -152,9 +152,10 @@ Commands produce better output when they have data from other commands. This tab
 |---|---|---|---|
 | `kickoff` | — | Everything — this is the entry point | — |
 | `research` | Profile from `kickoff` | Profile (gives generic fit assessment) | Company name |
-| `prep` | Storybank, coaching state profile, interviewer links | Storybank (can't do story mapping, flags the gap), profile (infers from JD) | Company + JD |
+| `prep` | Storybank, coaching state profile, interviewer links, Interview Intelligence (Company Patterns, Question Bank) | Storybank (can't do story mapping, flags the gap), profile (infers from JD), Interview Intelligence (loses real-question weighting and company pattern data) | Company + Role/seniority + JD |
 | `analyze` | Coaching state (seniority band, storybank for story matching) | Seniority band (asks for it), storybank (skips story mapping) | Transcript |
-| `debrief` | Storybank (for Last Used updates), Interview Loops (for context) | Both (captures data without cross-referencing) | — |
+| `feedback` | Interview Intelligence (for cross-referencing feedback with existing data), Interview Loops, Score History | All (captures data without cross-referencing) | — |
+| `debrief` | Storybank (for Last Used updates), Interview Loops (for context), Interview Intelligence Question Bank (for past question similarity checks) | All (captures data without cross-referencing) | — |
 | `practice` | Score history (to set drill stage), storybank (for tailored questions), prep data (for company-specific drills), Drill Progression (for current stage) | All (uses generic questions, starts at Stage 1) | — |
 | `mock` | Prep data, storybank, score history, interviewer intel, concerns data (for targeted questions) | All (uses generic questions and personas) | Format |
 | `stories` | Resume analysis from kickoff (for story seeds) | Resume (uses reflective prompts instead) | — |
@@ -162,7 +163,7 @@ Commands produce better output when they have data from other commands. This tab
 | `questions` | Prep data, interviewer intel, interview stage | All (generates generic questions) | — |
 | `hype` | Score history, storybank, prep brief, concerns, resume analysis | All (falls back to resume-based hype — explicitly flagged) | — |
 | `thankyou` | Debrief data, Interview Loops, interviewer intel | All (asks candidate for callbacks) | — |
-| `progress` | 3+ scored sessions, outcome data | Works with 1-2 sessions (reduced — see minimum data thresholds) | At least 1 scored session |
+| `progress` | 3+ scored sessions, outcome data, Interview Intelligence (Question Bank, Feedback, Patterns) | Works with 1-2 sessions (reduced — see minimum data thresholds), Interview Intelligence (loses question-type performance and accumulated pattern analysis) | At least 1 scored session |
 | `negotiate` | Interview Loops, outcome log | Both (collects offer details fresh) | Offer details |
 | `reflect` | Full coaching state with score history and outcomes | Score history (narrates from limited data) | — |
 


### PR DESCRIPTION
## Summary

- Adds an **Interview Intelligence** section to the coaching state that learns from each candidate's real interview experience — tracking questions across companies, effective/ineffective patterns, recruiter feedback, and company-specific insights
- Adds a new **`feedback` command** for capturing recruiter feedback, outcomes, coaching corrections, post-session memories, and meta-feedback between structured workflows
- Enhances **`analyze`**, **`debrief`**, **`prep`**, **`progress`**, and **`help`** to produce and consume Intelligence data with a light-touch rule (only surface when it changes the coaching output)
- Updates **README** and **cross-cutting dependencies** to reflect all changes

## Test plan

- [ ] Verify `SKILL.md` coaching_state.md schema has Interview Intelligence between Outcome Log and Drill Progression
- [ ] Verify all state update triggers reference Intelligence correctly (analyze, debrief, feedback, progress)
- [ ] Verify `feedback` appears in command registry, mode detection (position 3), and file routing
- [ ] Read `feedback.md` end-to-end — confirm all 5 input types (A-E) are covered with triggers, capture process, state updates, and output
- [ ] Verify `analyze.md` Step 16 extracts to Question Bank format, per-answer has Intelligence cross-ref field, delta output has Intelligence Updates
- [ ] Verify `debrief.md` steps 8-10 are correctly numbered, output schema has Feedback Received (with Date/Company) and Intelligence Notes
- [ ] Verify `prep.md` and `progress.md` Intelligence references follow the light-touch rule
- [ ] Verify `progress.md` Step 0 includes Intelligence archival thresholds
- [ ] Verify `help.md` lists `feedback` in Post-Interview section with updated descriptions for analyze/debrief/prep/progress
- [ ] Verify `cross-cutting.md` dependency table includes `feedback` row and updated prep/progress/debrief rows
- [ ] Verify `README.md` has feedback in command table, repo structure, best results, and Full System track; mock formats list is complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)