### PR TITLE
Add Coaching Depth v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,23 @@ Say `kickoff`, share your resume, and you're being coached in under 2 minutes.
 
 **Adaptive coaching** — After scoring, a decision tree triages your bottleneck and branches to the right drill. If Relevance is your gap, you get question-decoding practice. If Substance, you build raw material. The system doesn't cycle through the same sequence for every candidate.
 
-**Storybank** — Structured story management with full STAR text, earned secrets, strength ratings, and rapid-retrieval drills so you can access the right story under time pressure. Narrative identity extraction finds the 2-3 core themes across your stories so every answer reinforces a coherent thesis about who you are.
+**Multi-format transcript analysis** — Paste raw transcripts from Otter, Zoom, Grain, Google Meet, Teams, Tactiq, Granola, or any other tool. The system auto-detects the format and normalizes it. Analysis adapts to interview type: behavioral interviews get Q&A parsing, system design gets phase-based analysis (scoping, approach, deep-dive, tradeoff, adaptation), panel interviews track cross-interviewer dynamics, and mixed formats handle mode-switching between technical and behavioral segments. Each format gets its own anti-pattern detection and additional scoring dimensions.
 
-**Practice and mocks** — 8-stage drill progression (constraint ladders, pushback handling, pivot drills, panel simulations, stress tests) plus full 4-6 question mock interviews in behavioral, system design, case study, panel, and technical+behavioral formats. Every round includes the interviewer's perspective — what they were actually thinking when you spoke.
+**Storybank with portfolio optimization** — Structured story management with full STAR text, earned secrets, strength ratings, and rapid-retrieval drills. Story-to-question mapping uses a 4-level fit scoring system (Strong Fit, Workable, Stretch, Gap) with portfolio optimization that resolves conflicts when multiple questions compete for the same story, tracks freshness and overuse, and prioritizes stories with strong earned secrets. Narrative identity extraction finds the 2-3 core themes across your stories so every answer reinforces a coherent thesis about who you are.
+
+**Practice and mocks** — 8-stage drill progression (constraint ladders, pushback handling, pivot drills, panel simulations, stress tests) plus full 4-6 question mock interviews in behavioral, system design, case study, panel, and technical+behavioral formats. Every round includes the interviewer's perspective — what they were actually thinking when you spoke. Role-drill scores map to core dimensions so specialized practice feeds into overall trend analysis.
+
+**Outcome calibration** — The system tracks whether its practice scores actually predict real interview outcomes. After 3+ real interviews, it runs scoring drift detection, identifies when external feedback contradicts coach scoring, and recalibrates. Cross-dimension root causes (like "conflict avoidance" affecting both Substance and Differentiation) get unified treatment instead of separate drills. The system also learns from successes — tracking which stories, dimensions, and patterns correlate with advancement.
+
+**Role-fit assessment** — Structured evaluation of candidate-role fit across five dimensions (requirement coverage, seniority alignment, domain relevance, competency overlap, trajectory coherence). Distinguishes strong fits from investable stretches and long shots, so candidates focus their energy on roles where they're competitive. Over time, rejection patterns reveal targeting insights that no amount of practice can fix.
+
+**Enhanced company intelligence** — Three research depth levels (Quick Scan, Standard, Deep Dive) with a structured search protocol and claim verification. Every company-specific claim maps to a source tier (verified, general knowledge, or unknown). Prep briefs include targeted web research before applying company knowledge, with source attribution for every finding.
 
 **Interview lifecycle** — Company research, role-specific prep briefs with interviewer intelligence, same-day post-interview debrief, outcome tracking that correlates practice scores with real results, and post-offer negotiation coaching with exact scripts.
 
-**Interview intelligence** — The system learns from your real interview experiences. Every transcript, debrief, and recruiter feedback adds to a personalized knowledge base: question patterns across companies, what works and what doesn't for you specifically, and feedback-outcome correlations. Over time, prep briefs are weighted by real questions you've seen, and progress reviews surface patterns only visible across multiple interviews.
+**Interview intelligence** — The system learns from your real interview experiences. Every transcript, debrief, and recruiter feedback adds to a personalized knowledge base: question patterns across companies, what works and what doesn't for you specifically, and feedback-outcome correlations. Intelligence data has temporal decay — stale data is flagged, not silently relied on.
 
-**Session continuity** — A persistent `coaching_state.md` file tracks your storybank, scores, patterns, drill progression, interview loops, and interview intelligence across sessions. Pick up where you left off, weeks later. Saves are automatic.
+**Session continuity** — A persistent `coaching_state.md` file tracks your storybank, scores, patterns, drill progression, interview loops, interview intelligence, and calibration state across sessions. Pick up where you left off, weeks later. Saves are automatic.
 
 **Differentiation** — Earned secrets and spiky POVs are a first-class dimension, not an afterthought. The system pushes you past "competent" toward "memorable."
 
@@ -62,9 +70,9 @@ The coach will ask for your resume, target role, and timeline — then build you
 | Command | Purpose | Typical Output |
 |---|---|---|
 | `kickoff` | Setup profile, track, and preferences | Kickoff summary + time-aware action plan |
-| `research [company]` | Lightweight company research + fit assessment | Company snapshot, culture signals, fit assessment |
-| `prep [company]` | Build role-specific prep brief (format-aware, culture-aware) | Format guidance, culture read, interviewer intelligence, competencies, predicted Qs, story mapping |
-| `analyze` | Analyze transcript with triage-based coaching | Per-answer 5-dimension scoring + decision tree + interview delta |
+| `research [company]` | Company research + structured fit assessment (3 depth levels) | Company snapshot, culture signals, fit assessment, claim-verified findings |
+| `prep [company]` | Build role-specific prep brief (format-aware, culture-aware, role-fit assessment) | Format guidance, culture read, role-fit assessment, interviewer intelligence, competencies, predicted Qs, story mapping |
+| `analyze` | Analyze transcript with format-aware parsing and triage-based coaching | Auto-detected format, per-unit scoring (Q&A/phases/exchanges), format-specific dimensions, decision tree + interview delta |
 | `debrief` | Post-interview rapid capture (same day) | Questions recalled, interviewer signals, stories used, coaching state updates |
 | `practice` | Run drill rounds (with progression gating) | Round debrief + self-assessment delta + targeted adjustment |
 | `mock [format]` | Full simulated interview (4-6 Qs) — behavioral screen, deep behavioral, panel, bar raiser, system design/case study, technical+behavioral mix | Holistic arc feedback, signal-reading notes, energy trajectory |
@@ -73,7 +81,7 @@ The coach will ask for your resume, target role, and timeline — then build you
 | `questions` | Generate interviewer questions | 5 tailored, non-generic questions |
 | `hype` | Pre-interview confidence + psychological warmup | 60-second reel + 3x3 sheet + focus cue + recovery playbook |
 | `thankyou` | Post-interview follow-up drafts | Thank-you note + variants |
-| `progress` | Trends, self-calibration, outcome tracking | Self-assessment delta + outcome correlation + coaching meta-check |
+| `progress` | Trends, self-calibration, outcome tracking, scoring calibration | Self-assessment delta + outcome correlation + scoring drift detection + root cause tracking + coaching meta-check |
 | `negotiate` | Post-offer negotiation coaching | Offer analysis + strategy + scripts + specific language |
 | `feedback` | Capture recruiter feedback, outcomes, corrections, context | State updates + next step suggestion |
 | `reflect` | Post-search retrospective + archive | Journey arc, breakthroughs, transferable skills, archived state |
@@ -104,9 +112,11 @@ research Notion
 
 Expected output:
 
-- Company snapshot (stage, size, culture signals)
+- Company snapshot (stage, size, culture signals — claim-verified with source tiers)
 - Fit assessment against your profile
 - "If you decide to apply" next steps
+
+For high-priority targets, mention you want a deep dive: "Do a deep dive on Notion" — gets you employee posts, product reviews, competitor analysis, and leadership profiles on top of the standard research.
 
 ### 3) Before an interview
 
@@ -152,11 +162,12 @@ Rapid capture while details are fresh — works with or without a transcript. Ge
 analyze
 ```
 
-Then paste transcript text.
+Then paste raw transcript text from any tool (Otter, Zoom, Grain, Teams, etc.). The system auto-detects the format and normalizes it.
 
 Expected output:
 
-- Per-answer score blocks
+- Format detection and normalization
+- Per-unit score blocks (Q# for behavioral, P# for system design phases, E# for panel exchanges)
 - `Scorecard`
 - `Triage Decision` (data-driven coaching path based on your patterns)
 - `What Is Working`
@@ -238,15 +249,15 @@ Best when interview timeline is short.
 
 Best when running a multi-week search.
 
-- Storybank management with rapid-retrieval drills
-- Multi-lens transcript analysis with decision tree triage
+- Storybank management with rapid-retrieval drills and portfolio-optimized story mapping
+- Multi-format transcript analysis (behavioral, system design, panel, mixed) with decision tree triage
 - Pattern and trend tracking with self-assessment calibration
 - Differentiation coaching integrated into all workflows
 - Full mock interview simulations (behavioral, system design, case study, panel, technical+behavioral mix)
 - Drill progression with gating thresholds (8 stages + standalone retrieval)
 - Post-interview debrief and rapid capture
-- Outcome tracking (correlate practice with real results)
-- Interview intelligence — learns question patterns, what works/doesn't, and company-specific insights from your real interviews
+- Outcome tracking (correlate practice with real results) with scoring calibration (drift detection, recalibration)
+- Interview intelligence — learns question patterns, what works/doesn't, and company-specific insights from your real interviews, with temporal decay on stale data
 - Interview loop awareness across company rounds
 - Post-offer negotiation coaching
 - Post-search retrospective and archiving
@@ -286,9 +297,12 @@ interview-coach-skill/
     ├── rubrics-detailed.md             # Scoring anchors, root causes, seniority calibration
     ├── role-drills.md                  # Role-specific drills + interviewer archetypes
     ├── differentiation.md              # Earned secrets, spiky POVs, clarity under pressure
-    ├── transcript-processing.md        # Step-by-step transcript analysis guide
+    ├── transcript-processing.md        # Step-by-step transcript analysis guide (format-aware parsing)
+    ├── transcript-formats.md           # Format detection + per-format normalization (Otter, Zoom, Grain, etc.)
     ├── storybank-guide.md              # Story management + rapid-retrieval drill
-    └── examples.md                     # Worked examples: scored answers, triage, rewrites
+    ├── story-mapping-engine.md         # Portfolio-optimized story mapping with fit scoring
+    ├── calibration-engine.md           # Scoring drift detection, root cause tracking, success patterns
+    └── examples.md                     # Worked examples: scored answers, triage, rewrites, system design analysis
 ```
 
 ---

--- a/SKILL.md
+++ b/SKILL.md
@@ -82,9 +82,9 @@ Last updated: [date]
 - Story seeds: [resume bullets with likely rich stories behind them]
 
 ## Storybank
-| ID | Title | Primary Skill | Earned Secret | Strength | Last Used |
-|----|-------|---------------|---------------|----------|-----------|
-[rows — compact index. Full column spec in references/storybank-guide.md — the guide adds Secondary Skill, Impact, Domain, Risk/Stakes, and Notes. Add extra columns as stories are enriched.]
+| ID | Title | Primary Skill | Secondary Skill | Earned Secret | Strength | Use Count | Last Used |
+|----|-------|---------------|-----------------|---------------|----------|-----------|-----------|
+[rows — compact index. Use Count tracks total times used in real interviews (incremented via debrief). Full column spec in references/storybank-guide.md — the guide adds Impact, Domain, Risk/Stakes, and Notes. Add extra columns as stories are enriched.]
 
 ### Story Details
 #### S001 — [Title]
@@ -157,8 +157,10 @@ Last updated: [date]
 - Interviewer intel: [LinkedIn URLs + key insights, linked to rounds]
 - Prepared questions: [top 3 from `questions` if run]
 - Next round: [date, format if known]
-- Fit assessment: [from `research` if run — strong / moderate / weak]
-- Key signals: [from `research` — 1-2 lines]
+- Fit verdict: [from research or prep — Strong / Investable Stretch / Long-Shot Stretch / Weak]
+- Fit confidence: [Limited — no JD / Medium — JD + resume / High — JD + resume + storybank]
+- Fit signals: [1-2 lines on what drove the verdict]
+- Structural gaps: [gaps that can't be bridged with narrative, if any]
 - Date researched: [date, if `research` was run]
 
 ## Active Coaching Strategy
@@ -169,6 +171,25 @@ Last updated: [date]
 - Root causes detected: [list]
 - Self-assessment tendency: [over-rater / under-rater / well-calibrated]
 - Previous approaches: [list of abandoned strategies with brief reason — e.g., "Structure drills — ceiling at 3.5, diminishing returns"]
+
+## Calibration State
+
+### Calibration Status
+- Current calibration: [uncalibrated / calibrating / calibrated / miscalibrated]
+- Last calibration check: [date]
+- Data points available: [N] real interviews with outcomes
+
+### Scoring Drift Log
+| Date | Dimension | Direction | Evidence | Adjustment |
+
+### Calibration Adjustments
+| Date | Trigger | What Changed | Rationale |
+
+### Cross-Dimension Root Causes (active)
+| Root Cause | Affected Dimensions | First Detected | Status | Treatment |
+
+### Unmeasured Factor Investigations
+| Date | Trigger | Hypothesis | Investigation | Finding | Action |
 
 ## Meta-Check Log
 | Session | Candidate Feedback | Adjustment Made |
@@ -193,16 +214,16 @@ Last updated: [date]
 
 Write to `coaching_state.md` whenever:
 - kickoff creates a new profile and populates Resume Analysis from resume analysis. Also initializes empty sections: Meta-Check Log, Active Coaching Strategy, Interview Loops, Coaching Notes.
-- research adds a new company entry (lightweight, in Interview Loops with Status: Researched, plus fit assessment, key signals, and date)
+- research adds a new company entry (lightweight, in Interview Loops with Status: Researched, plus fit verdict, fit confidence, fit signals, structural gaps, and date)
 - stories adds, improves, or retires stories (write full STAR text to Story Details, not just index row)
-- analyze, practice, or mock produces scores (add to Score History — practice sub-commands that use the 5-dimension rubric add to Score History; retrieval drills log to Session Log only) — analyze also updates Active Coaching Strategy after triage decision. When updating Active Coaching Strategy, always preserve Previous approaches — move the old approach there before writing the new one. Analyze also extracts questions and scores to Interview Intelligence Question Bank, updates Effective/Ineffective Patterns if 3+ data points reveal a pattern, and updates Company Patterns.
+- analyze, practice, or mock produces scores (add to Score History — practice sub-commands that use the 5-dimension rubric add to Score History; retrieval drills log to Session Log only) — analyze also updates Active Coaching Strategy after triage decision. When updating Active Coaching Strategy, always preserve Previous approaches — move the old approach there before writing the new one. Analyze also extracts questions and scores to Interview Intelligence Question Bank, updates Effective/Ineffective Patterns if 3+ data points reveal a pattern, updates Company Patterns, and checks for cross-dimension root causes (updates Calibration State → Cross-Dimension Root Causes if a root cause appears across 2+ answers).
 - concerns generates ranked concerns (save to Interview Loops under the relevant company's Concerns surfaced, or to Active Coaching Strategy if general)
 - questions generates tailored questions (save top 3 to Interview Loops under Prepared questions for the relevant company)
-- debrief captures post-interview data (add to Interview Loops, update storybank Last Used dates, add to Outcome Log as pending). Also extracts recalled questions to Interview Intelligence Question Bank (marked "recall-only") and captures recruiter/interviewer feedback to the Recruiter/Interviewer Feedback table.
-- feedback captures ad-hoc input: recruiter feedback (add to Recruiter/Interviewer Feedback), outcomes (update Outcome Log + Question Bank Outcome column), corrections (evaluate and adjust if warranted — may update Score History or Storybank ratings, record in Coaching Notes), post-session memories (route to Question Bank, Storybank, Interview Loops, or Company Patterns as appropriate), and meta-feedback (record in Meta-Check Log)
-- progress reviews trends (update Active Coaching Strategy, check Score History archival, check Interview Intelligence archival thresholds)
+- debrief captures post-interview data (add to Interview Loops, update storybank Last Used dates and increment Use Count for each story used, add to Outcome Log as pending). Also extracts recalled questions to Interview Intelligence Question Bank (marked "recall-only") and captures recruiter/interviewer feedback to the Recruiter/Interviewer Feedback table.
+- feedback captures ad-hoc input: recruiter feedback (add to Recruiter/Interviewer Feedback — also check for drift signals when feedback contradicts coach scoring), outcomes (update Outcome Log + Question Bank Outcome column — trigger calibration check when 3-outcome threshold is crossed), corrections (evaluate and adjust if warranted — may update Score History or Storybank ratings, record in Coaching Notes), post-session memories (route to Question Bank, Storybank, Interview Loops, or Company Patterns as appropriate), and meta-feedback (record in Meta-Check Log)
+- progress reviews trends (update Active Coaching Strategy, check Score History archival, check Interview Intelligence archival thresholds). Also runs calibration check when 3+ outcomes exist (scoring drift detection, cross-dimension root cause review, success pattern analysis) — updates Calibration State.
 - User reports a real interview outcome (add to Outcome Log)
-- prep starts a new company loop or updates interviewer intel and round formats (add to Interview Loops)
+- prep starts a new company loop or updates interviewer intel, round formats, fit verdict, fit confidence, and structural gaps (add to Interview Loops)
 - negotiate receives an offer (add to Outcome Log with Result: offer)
 - reflect archives the coaching state (add Status: Archived header)
 - Meta-check conversations (record candidate's response and any coaching adjustment to Meta-Check Log)
@@ -259,9 +280,11 @@ Execute commands immediately when detected. Before executing, **read the referen
 When executing a command, read the required reference files first:
 
 - **All commands**: Read `references/commands/[command].md` for that command's workflow, and `references/cross-cutting.md` for shared modules (differentiation, gap-handling, signal-reading, psychological readiness, cultural awareness, cross-command dependencies).
-- **`analyze`**: Also read `references/transcript-processing.md`, `references/rubrics-detailed.md`, `references/examples.md`, and `references/differentiation.md` (when Differentiation is the bottleneck).
+- **`analyze`**: Also read `references/transcript-processing.md`, `references/transcript-formats.md`, `references/rubrics-detailed.md`, `references/examples.md`, `references/calibration-engine.md`, and `references/differentiation.md` (when Differentiation is the bottleneck).
 - **`practice`**, **`mock`**: Also read `references/role-drills.md`.
+- **`prep`**: Also read `references/story-mapping-engine.md` when storybank exists.
 - **`stories`**: Also read `references/storybank-guide.md` and `references/differentiation.md`.
+- **`progress`**: Also read `references/calibration-engine.md`.
 - **`feedback`**: Read `references/commands/feedback.md`.
 
 ## Evidence Sourcing Standard

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,0 +1,99 @@
+# Version Roadmap
+
+Each version has a clear thesis — not a feature grab bag.
+
+---
+
+## v1: Foundation (shipped)
+
+**Thesis**: Build a broad, rigorous interview coaching system that adapts to each candidate.
+
+- 16 commands covering the full interview lifecycle (kickoff through reflect)
+- 5-dimension scoring rubric (Substance, Structure, Relevance, Credibility, Differentiation) with seniority calibration
+- Root cause taxonomy mapping failures to targeted fixes
+- Storybank management with STAR text, earned secrets, strength ratings, and rapid-retrieval drills
+- Narrative identity extraction (2-3 core themes across stories)
+- 8-stage drill progression with gating thresholds
+- Full mock interviews in behavioral, system design, case study, panel, and technical+behavioral formats
+- Role-fit assessment across 5 dimensions (requirement coverage, seniority alignment, domain relevance, competency overlap, trajectory coherence)
+- Interview intelligence that learns from real experiences (question patterns, effective/ineffective patterns, company patterns)
+- Persistent session state via `coaching_state.md` with mid-session saves
+- Cross-cutting modules: differentiation, gap-handling, signal-reading, psychological readiness, cultural awareness
+- Role-specific drills for PM, Engineering, Design, Data Science, Research, Operations, Marketing
+- Technical format coaching boundaries (communication coaching, not domain evaluation)
+
+---
+
+## v2: Coaching Depth (shipped)
+
+**Thesis**: The system is broad but shallow in places. Make it significantly better at its core job before expanding surface area.
+
+### Feature 1: Transcript Format Support
+Candidates no longer need to manually reformat transcripts. The system auto-detects and normalizes 8 transcript formats (Otter.ai, Grain, Google Meet, Zoom VTT, Granola, Microsoft Teams, Tactiq, Manual/generic) with disambiguation rules and quality signal reporting.
+
+**Key files**: `references/transcript-formats.md` (new), `references/transcript-processing.md` (Step 0.5), `references/commands/analyze.md` (Step 3.5)
+
+### Feature 2: Multi-Format Transcript Analysis
+All transcripts were previously force-parsed as behavioral Q&A pairs. Now the system branches into 5 format-aware parsing paths: behavioral (Q&A pairs), panel (exchanges with cross-interviewer dynamics), system design (phase-based: scoping, approach, deep-dive, tradeoff, adaptation), technical+behavioral mix (segmented mode-switching), and case study (candidate-driven stages). Each format gets its own anti-patterns, additional scoring dimensions, and delta sheet sections.
+
+**Key files**: `references/transcript-processing.md` (Step 2 overhaul, Step 2.5 extensions, Step 3 scoring, Step 4 delta), `references/commands/analyze.md` (format-aware dispatch/scoring/triage), `references/examples.md` (Example 11: system design analysis)
+
+### Feature 3: Smarter Story Mapping
+Story-to-question mapping was heuristic and question-by-question. Now uses a portfolio optimization engine with 4-level fit scoring (Strong Fit, Workable, Stretch, Gap), 7-step conflict resolution, freshness/overuse tracking, earned-secret-aware selection, and secondary skill utilization.
+
+**Key files**: `references/story-mapping-engine.md` (new), `references/commands/prep.md` (storybank health gate, expanded output schema), `references/storybank-guide.md` (health metrics), `references/commands/stories.md` (enhanced gap analysis)
+
+### Feature 4: Outcome Calibration Loop
+The system detected miscalibration but didn't self-correct. Now includes scoring drift detection (do practice scores predict outcomes?), cross-dimension root cause tracking with unified treatment (one intervention per root cause, not per dimension), temporal decay for intelligence data, role-drill integration with core dimensions, success pattern capture, and structured unmeasured factor investigation.
+
+**Key files**: `references/calibration-engine.md` (new), `references/commands/progress.md` (Steps 5a/5b/5c), `references/commands/analyze.md` (Step 12a), `references/commands/feedback.md` (calibration triggers), `references/commands/practice.md` (role-drill mapping), `references/rubrics-detailed.md` (root cause persistence)
+
+### Feature 5: Enhanced Company Intelligence
+Company research was unstructured. Now includes 3 depth levels (Quick Scan, Standard, Deep Dive), a structured 7-step search protocol, and a claim verification protocol with source tiers (verified, general knowledge, unknown).
+
+**Key files**: `references/commands/research.md` (depth levels, search protocol, verification), `references/commands/prep.md` (structured research step)
+
+---
+
+## v3: Interaction Model (planned)
+
+**Thesis**: Now that the coaching brain is strong, change *how* candidates interact with it.
+
+### Voice Mode for Practice/Mock
+Scoped tightly to `practice`, `mock`, and `hype` warmups. The candidate speaks, the system listens, scores delivery alongside content (filler words, pacing, confidence, hedging language). Doesn't replace text for `prep` or `progress` — those need structured output. But practice and mocks become dramatically more realistic with voice.
+
+### Session Replay
+After a mock or practice round, let the candidate replay the exchange with inline coaching annotations. "Right here you hedged for 8 seconds before getting to the point. Here's what a tighter version sounds like."
+
+### Lightweight Companion UI
+Not replacing Claude Code, but a read-only dashboard that visualizes `coaching_state.md`: score trends over time, storybank coverage heatmap, interview loop status, drill progression. Think of it as a `progress` command you can glance at without running anything. Could be a simple local web server that reads the markdown file.
+
+### Calendar Awareness
+Connect to Google Calendar / Outlook. When an interview is 24 hours out, auto-trigger `hype`. When it's a week out and no `prep` has been run, nudge. Time-aware coaching exists in v1 but requires the candidate to self-report timelines.
+
+### Collaborative Storybank Building
+A friend or mentor can review your storybank and leave comments. Still file-based, but with a lightweight review protocol. Most candidates build stories in isolation — a second pair of eyes catches blind spots the coach can't.
+
+---
+
+## v4: Platform (planned)
+
+**Thesis**: The coaching engine is proven. Now make it accessible to people who'll never touch a CLI.
+
+### Full Web App
+Backend, auth, database replacing `coaching_state.md`, real UI for all commands. The skill files become the system prompt for an API-based product. The reference architecture is already modular enough to port — each command file maps to an API endpoint.
+
+### Coaching Marketplace
+Let experienced interviewers or career coaches customize the rubrics, add company-specific intelligence, and offer specialized coaching tracks (e.g., "FAANG PM prep" with insider-calibrated scoring). The cross-cutting module architecture already supports this — new modules slot in without rewriting commands.
+
+### Team/Org Mode
+Companies use this to prep internal candidates for promotion panels, or recruiting teams use it to train interviewers (flip the perspective — coach the person *giving* the interview). Same 5 dimensions, different lens.
+
+### Anonymized Intelligence Network
+With enough users, the system can surface patterns across candidates: "Candidates who get offers at Stripe tend to score 4+ on Differentiation. Candidates rejected at Amazon most often fail on Structure." No individual data shared — just aggregate signals that improve everyone's prep.
+
+---
+
+## Version Tension
+
+v2 is clearly the right step after v1 — it makes the product meaningfully better for current users without architectural risk. v3 is exciting but expensive (voice, UI, integrations). v4 is a different company. The mistake would be jumping to v3/v4 before v2 has proven that the coaching engine actually moves candidate outcomes.

--- a/references/calibration-engine.md
+++ b/references/calibration-engine.md
@@ -1,0 +1,228 @@
+# Calibration Engine
+
+Centralizes calibration logic for scoring accuracy, root cause tracking, and learning from outcomes. Referenced by `progress`, `analyze`, `feedback`, and `practice`.
+
+---
+
+## Section 1: Calibration Metadata Schema
+
+The Calibration State section in `coaching_state.md` tracks:
+
+```markdown
+## Calibration State
+
+### Calibration Status
+- Current calibration: [uncalibrated / calibrating / calibrated / miscalibrated]
+- Last calibration check: [date]
+- Data points available: [N] real interviews with outcomes
+
+### Scoring Drift Log
+| Date | Dimension | Direction | Evidence | Adjustment |
+
+### Calibration Adjustments
+| Date | Trigger | What Changed | Rationale |
+
+### Cross-Dimension Root Causes (active)
+| Root Cause | Affected Dimensions | First Detected | Status | Treatment |
+
+### Unmeasured Factor Investigations
+| Date | Trigger | Hypothesis | Investigation | Finding | Action |
+```
+
+**Status definitions:**
+- **Uncalibrated**: Fewer than 3 real interview outcomes. Not enough data for calibration. The system operates normally but cannot verify its own accuracy.
+- **Calibrating**: 3+ outcomes exist, first calibration check in progress. System is building its accuracy model.
+- **Calibrated**: Calibration check completed, practice scores reasonably predict outcomes (correlation exists). System confidence is high.
+- **Miscalibrated**: Practice scores do not predict outcomes, or external feedback consistently contradicts coach scoring. System is actively investigating and adjusting.
+
+---
+
+## Section 2: Scoring Drift Detection Protocol
+
+Runs during `progress` when 3+ real interview outcomes exist in the Outcome Log.
+
+### Step 1: Build Outcome-Score Matrix
+For each real interview with a known outcome, pull:
+- The most recent practice scores before that interview (from Score History)
+- The interview analysis scores (if a transcript was analyzed)
+- The outcome (advanced / rejected / offer)
+- Any recruiter/interviewer feedback received
+
+### Step 2: Check for Systematic Drift Per Dimension
+For each of the 5 dimensions:
+- Compare average practice scores for interviews where the candidate advanced vs. where they were rejected
+- Look for dimensions where practice scores are consistently HIGH but outcomes are poor (the system is over-scoring)
+- Look for dimensions where practice scores are LOW but outcomes are good (the system is under-scoring or the dimension doesn't matter for this candidate's targets)
+
+### Step 3: Check for Feedback Contradictions
+Cross-reference external feedback with coach scores:
+- If recruiter feedback says "great storytelling, hard to follow" but the coach scored Structure at 4, that's a drift signal
+- If feedback says "polished but generic" but the coach scored Differentiation at 3+, that's a drift signal
+- Weight external feedback higher than internal scoring — the interviewer is the ground truth
+
+### Step 4: Generate Drift Report
+For each dimension showing drift:
+- **Direction**: Over-scoring or under-scoring
+- **Evidence**: Specific interviews where the prediction failed
+- **Magnitude**: How far off (e.g., "Structure scores averaged 3.8 but 3 of 4 rejections cited unclear answers")
+- **Proposed adjustment**: Concrete change (e.g., "Tighten Structure scoring by 0.5 — what I've been scoring as 4 is landing as 3 with real interviewers")
+
+### Step 5: Present to Candidate
+Frame drift corrections as improved predictive accuracy, NOT as goalpost-moving:
+- "I've been scoring your Structure at 4, but interviewer feedback consistently suggests it's landing at 3. I'm recalibrating so my scores better predict how real interviewers will evaluate you. This isn't a downgrade — it's a more accurate picture."
+- Record the adjustment in the Scoring Drift Log and Calibration Adjustments tables
+
+---
+
+## Section 3: Cross-Dimension Root Cause Tracking
+
+### Lifecycle
+
+**Detection**: When the same root cause appears in 2+ consecutive sessions (or across 2+ answers in the same session), it graduates from "per-answer observation" to "active root cause" in the Calibration State table.
+
+Example: "Conflict avoidance" detected in Session 3 (affecting Substance on Q2 and Q5) and Session 4 (affecting Substance on Q1 and Differentiation on Q3) → create entry:
+
+| Root Cause | Affected Dimensions | First Detected | Status | Treatment |
+|---|---|---|---|---|
+| Conflict avoidance | Substance, Differentiation | Session 3 | Active | Tension-mining drill on top 3 stories |
+
+**Unified Treatment**: Prescribe ONE intervention targeting the root cause itself, not each affected dimension separately. "Conflict avoidance" gets tension-mining drills — not separate Substance drills AND Differentiation drills. This is more efficient and addresses the actual problem.
+
+**Progress Tracking**: In subsequent sessions, check whether ALL affected dimensions are improving in tandem. If Substance improves but Differentiation doesn't, the root cause may be partially resolved or the treatment needs adjustment.
+
+**Resolution Criteria**: A root cause is resolved when:
+- All affected dimensions show 1+ point sustained improvement over 3+ sessions
+- The pattern no longer appears in new analyses
+- Update status to "Resolved" with date and what worked
+
+---
+
+## Section 4: Temporal Decay for Intelligence Data
+
+Apply these freshness rules when referencing intelligence data in prep, progress, or any workflow:
+
+| Data Type | Current | Historical | Archive |
+|---|---|---|---|
+| **Question Bank entries** | < 3 months old | 3-6 months old — flag as "historical, may not reflect current process" | > 6 months old — archive only, don't weight in predictions |
+| **Effective/Ineffective Patterns** | < 3 months old | 3+ months old — re-test before relying. "This pattern was confirmed 4 months ago. Let's check if it still holds." | N/A — patterns don't expire, but confidence decays |
+| **Company Patterns** | < 6 months old | > 6 months old — flag: "Company data is from [date]. Processes and culture may have changed." | > 12 months — treat as background context only |
+| **Recruiter/Interviewer Feedback** | Current loop (active interview process) = high-signal | Closed loops = context only, not actionable | N/A |
+
+**Application**: When referencing intelligence data, check its age. If stale, note it:
+- "The last data point for this company is 5 months old — their process may have changed."
+- "This effective pattern was confirmed in [month]. Worth re-testing to make sure it still holds."
+
+---
+
+## Section 5: Role-Drill Integration with Core Dimensions
+
+Role-specific drills (from `references/role-drills.md`) use native scoring axes that don't map 1:1 to the core 5 dimensions. This section provides the explicit mapping so role-drill performance feeds into trend analysis and calibration.
+
+### Mapping Table
+
+| Role | Drill Axis | Maps To Core Dimension(s) |
+|---|---|---|
+| PM | Acknowledging tension | Credibility |
+| PM | Specific evidence | Substance |
+| PM | Decision rationale | Substance + Structure |
+| PM | Stakeholder awareness | Relevance |
+| PM | Trade-off articulation | Substance + Differentiation |
+| Engineer | Depth of understanding | Substance + Credibility |
+| Engineer | Explaining technical decisions | Structure |
+| Engineer | Acknowledging constraints | Credibility |
+| Engineer | Systems thinking | Substance |
+| Designer | Rationale clarity | Structure |
+| Designer | User evidence | Substance + Credibility |
+| Designer | Design trade-offs | Substance + Differentiation |
+| Designer | Process articulation | Structure |
+| Data Science | Statistical rigor | Substance + Credibility |
+| Data Science | Business translation | Relevance + Structure |
+| Data Science | Methodology defense | Credibility + Differentiation |
+| Research | Evidence quality | Substance |
+| Research | Insight articulation | Differentiation |
+| Research | Stakeholder translation | Relevance + Structure |
+| Marketing | Metric articulation | Substance + Credibility |
+| Marketing | Creative rationale | Differentiation + Structure |
+| Operations | Process thinking | Structure |
+| Operations | Scale articulation | Substance |
+| Operations | Constraint navigation | Credibility + Differentiation |
+
+### After Scoring a Role Drill
+
+1. Score using the native drill axes (as defined in role-drills.md)
+2. Map each axis score to core dimensions using the table above
+3. When a drill axis maps to multiple core dimensions, use the axis score for both (blended input)
+4. Record the blended scores in Score History alongside the native drill scores
+5. This ensures role-drill performance feeds into trend analysis, calibration checks, and graduation criteria
+
+---
+
+## Section 6: Learning from Successes
+
+When the Outcome Log shows "advanced" or "offer":
+
+### Step 1: Validate Fit Assessment
+If a fit assessment was recorded in Interview Loops:
+- Was the verdict correct? (Did a "Strong Fit" actually advance? Did a "Stretch" actually get rejected?)
+- What signals drove the assessment? Were they accurate?
+- Update fit assessment heuristics based on what actually predicted outcomes
+
+### Step 2: Track Dimension-Outcome Correlation (Positive)
+- Which dimension scores coincide with advancement?
+- Is there a minimum threshold? (e.g., "Every advancement had Differentiation 3.5+")
+- Record positive correlations alongside negative ones — the system should know what works, not just what fails
+
+### Step 3: Track Story Success
+- Update storybank Notes for stories used in successful interviews: "Contributed to advancement at [Company], Round [N]"
+- If a story has been part of 2+ advancements, flag it as a "proven performer"
+- These annotations help future story selection — proven performers get priority in competitive preps
+
+### Step 4: Extract Success Patterns
+When 3+ successes exist, look for commonalities:
+- Same stories used?
+- Same dimensions strong?
+- Same company type or interview format?
+- What was the candidate's emotional state? (from debrief data)
+- Record confirmed success patterns in Interview Intelligence → Effective Patterns
+
+---
+
+## Section 7: Structured Unmeasured Factor Investigation
+
+When practice scores don't predict outcomes (high practice scores + rejections, or low practice scores + advancements), investigate factors outside the scoring rubric.
+
+### Step 1: Candidate Debrief Questions
+Ask the candidate about the interviews where prediction failed:
+- "How was your energy level going into [the interview that went well despite low practice scores]?"
+- "Did the conversation feel natural or forced?"
+- "Did you ask good questions at the end? How did the interviewer respond?"
+- "Was anything different about the environment — time of day, format, who was in the room?"
+
+### Step 2: Common Factor Taxonomy
+
+| Factor | Signals | How to Test |
+|---|---|---|
+| **Energy/enthusiasm** | Candidate reports feeling "on" vs. "flat"; interviewer feedback mentions "excited about the role" | Practice at different energy levels. Track correlation. |
+| **Rapport** | Candidate found common ground, conversation felt natural, interviewer shared personal stories | Practice with different persona styles. Track which interactions feel natural. |
+| **Pacing/timing** | Answers felt too long or too short relative to the interview format | Time practice answers. Compare to format norms. |
+| **Question quality** | The questions the candidate asked at the end; interviewer engagement with those questions | Practice generating questions. Score them. |
+| **Format comfort** | Performance varies by interview format (behavioral vs. panel vs. system design) | Track scores by format. Identify format-specific gaps. |
+| **Physical/emotional state** | Time of day, sleep, stress level, preparation routine | Note environmental factors in debrief. Look for patterns. |
+
+### Step 3: Hypothesis Testing
+1. Form a specific hypothesis: "Energy level is driving outcomes more than content quality"
+2. Design a targeted drill or tracking approach: "For the next 3 practice sessions, vary energy level and see if scores change"
+3. Track results explicitly in the Unmeasured Factor Investigations table
+
+### Step 4: Resolution
+- **Confirmed**: The factor is real. Add it to Effective Patterns (or Ineffective Patterns). Integrate into coaching: "Before your next interview, do a 10-minute warmup — your energy level matters as much as your content."
+- **Inconclusive**: Not enough data. Continue tracking.
+- **Closed**: The hypothesis didn't hold. Remove from active investigation.
+
+---
+
+## Integration with Story Mapping Engine
+
+- When scoring drift adjusts a dimension score, flag stories in the storybank whose strength ratings were heavily influenced by that dimension. They may need re-evaluation. Example: "Your Substance scores have been recalibrated down by 0.5. S003 and S007 were rated based on Substance evidence — consider re-scoring them."
+- When calibration shows Differentiation predicts advancement, upgrade earned-secret-aware selection in the story mapping engine from conditional to default mode.
+- When calibration links a specific dimension to rejections (e.g., "every rejection correlates with Credibility < 3"), elevate story mapping gaps in that dimension's competencies to "Calibration-Urgent" priority level.

--- a/references/commands/analyze.md
+++ b/references/commands/analyze.md
@@ -16,10 +16,11 @@ If a candidate drops a transcript without having run `kickoff` first, don't refu
 1. **Check for existing debrief data.** If `coaching_state.md` has a `debrief` entry for this interview (same company/round), pull it in as context — the candidate's emotional read, interviewer signals they noticed, stories they used, and their same-day self-assessment. This is valuable because debrief captures impressions while fresh, before memory reconstruction smooths things over. Note any discrepancies between debrief impressions and what the transcript actually shows — these deltas are coaching gold.
 2. Ask self-assessment questions first: "Before I dig in — which answer do you feel best about, and which one do you think was weakest? And overall, how do you think it went?" (Wait for response before proceeding.) If a debrief already captured this, reference it: "You told me right after the interview that Q3 felt rough. Let's see what the transcript shows."
 3. **Set the self-assessment aside.** Do NOT let the candidate's answer influence your scoring. Analyze the transcript independently — score first, form your own conclusions, then compare to what they said.
-4. Clean transcript minimally.
-5. **Transcript quality gate**: After cleaning, assess how much is usable. If significant gaps exist (garbled sections, missing speaker labels, <60% recoverable), say so upfront: "This transcript has significant quality issues. I can score what's here, but my confidence is reduced. Here's what I can and can't assess: [specifics]." Be transparent throughout the analysis about where you're working from solid data vs. filling in gaps.
-6. Parse into Q&A pairs.
-7. Score each answer on 5 dimensions (including Differentiation).
+3.5. **Format detection and normalization.** Before cleaning, run the format detection protocol from `references/transcript-formats.md`. Identify the transcript source tool (Otter, Grain, Zoom VTT, etc.) and normalize to the standard internal representation. If Interview Loops has round format info for this company, use it to confirm or override the transcript format detection.
+4. Clean the normalized transcript (content-level cleaning — timestamps should already be stripped by normalization).
+5. **Transcript quality gate**: After cleaning, assess how much is usable. Incorporate format-derived quality signals (speaker label coverage, normalization confidence, multi-speaker detection). If significant gaps exist (garbled sections, missing speaker labels, <60% recoverable), say so upfront: "This transcript has significant quality issues. I can score what's here, but my confidence is reduced. Here's what I can and can't assess: [specifics]." Be transparent throughout the analysis about where you're working from solid data vs. filling in gaps.
+6. **Format-aware parsing.** Dispatch to the appropriate parsing path from `references/transcript-processing.md` Step 2 based on the detected interview format: Path A (Behavioral — default), Path B (Panel), Path C (System Design/Case Study), Path D (Technical+Behavioral Mix), or Path E (Case Study, candidate-driven).
+7. Score each unit on 5 core dimensions (including Differentiation). For non-behavioral formats, also score the format-specific additional dimensions (see Step 3 scoring extensions in `references/transcript-processing.md`).
 8. **Compare your scores to their self-assessment.** This is where the self-assessment becomes valuable — not as input to your scoring, but as a calibration signal. If you agree with their picks, explain why with evidence. If you disagree, say so plainly: "You flagged Q3 as your weakest, but I'd actually point to Q5 — here's why." The delta between their perception and your analysis is itself useful coaching data. If debrief data exists, compare all three: debrief impression → current self-assessment → coach scores. Shifts between the fresh debrief read and the later self-assessment reveal how the candidate processes interview experiences over time.
 9. **Signal-reading analysis.** Scan the transcript for interviewer behavior patterns using the Signal-Reading Module in `references/cross-cutting.md`. Include observations in the per-answer analysis and in the overall debrief.
 10. **Question decode for low-Relevance answers.** For any answer scoring < 3 on Relevance, don't just say "you missed the point." Explain what the question was actually probing for: "This question about 'a time you failed' isn't testing whether you've failed — it's testing self-awareness, learning orientation, and honesty. A targeted answer would have focused on what you learned and how it changed your approach, not on the failure itself."
@@ -46,6 +47,13 @@ After scoring, identify bottleneck dimensions and branch. Most candidates have m
 
 **If scores are balanced (all 3+, with clear dimension leaders)** → Run full multi-lens analysis as designed.
 
+**Format-aware triage rules** (apply on top of the standard priority stack):
+- System design/case study: If Process Visibility < 3, prioritize it over standard dimensions — the candidate's thinking process isn't visible, which undermines everything else.
+- Panel: If Interviewer Adaptation < 3 or Energy Consistency < 3, these become primary coaching targets alongside the weakest core dimension.
+- Technical+behavioral mix: If Mode-Switching Fluidity < 3, address it before optimizing either mode individually.
+- Case study: If the candidate made zero information requests or zero hypothesis statements, flag scoping/hypothesis behavior as the primary bottleneck.
+
+12a. **Cross-Dimension Root Cause Check.** After scoring all units, scan for root causes that appear across 2+ answers (e.g., "conflict avoidance" affecting both Substance and Differentiation). Cross-reference with `coaching_state.md` → Calibration State → Cross-Dimension Root Causes (active). If a detected root cause already exists as an active entry, update its status and note whether affected dimensions are improving. If a new root cause is detected (same pattern in 2+ answers), create a new entry in the Calibration State table with a unified treatment recommendation. This ensures recurring root causes are tracked as systemic issues, not re-diagnosed per session.
 13. Run multi-lens analysis (scoped by triage decision):
     - Hiring Manager
     - Skeptical Specialist
@@ -59,11 +67,14 @@ After scoring, identify bottleneck dimensions and branch. Most candidates have m
     - A pattern that changes the coaching recommendation
     Update Effective/Ineffective Patterns only when 3+ data points support the pattern. Update Company Patterns with question types observed and what seems to matter based on this interview.
 
-### Per-Answer Format (for each analyzed answer)
+### Per-Unit Format (for each analyzed unit)
+
+Use the appropriate unit ID based on interview format: Q# for behavioral, E# for panel exchanges, P# for system design phases, S# for case study stages. Mixed-format interviews use the relevant ID per segment.
 
 ```markdown
-### Q#
+### [Q#/E#/P#/S#]
 - Scores: Substance __ / Structure __ / Relevance __ / Credibility __ / Differentiation __
+- Format-specific scores (if applicable): [e.g., Process Visibility __ / Scoping Quality __]
 - What worked:
 - Biggest gap:
 - Root cause pattern (if detected):
@@ -88,12 +99,20 @@ When rewriting:
 ```markdown
 ## Interview Delta
 
+## Interview Format
+- Detected format: [behavioral / panel / system design / technical+behavioral mix / case study]
+- Format source: [coaching state / candidate / transcript inference / default]
+- Scoring weight adjustments: [which dimensions are weighted highest for this format]
+- Format-specific dimensions scored: [list any additional dimensions, or "N/A — standard behavioral"]
+- Coaching scope: [for non-behavioral formats, note coaching boundaries per SKILL.md Rule 11]
+
 ## Scorecard
 - Substance:
 - Structure:
 - Relevance:
 - Credibility:
 - Differentiation:
+- Format-specific scores: [if applicable — e.g., Process Visibility, Scoping Quality, etc.]
 - Calibration band used:
 - Hire Signal: Strong Hire / Hire / Mixed / No Hire
 

--- a/references/commands/debrief.md
+++ b/references/commands/debrief.md
@@ -20,7 +20,7 @@ Captures what happened in a real interview while it's still fresh. This is the b
 7. **Immediate tactical notes.** "Is there anything you want to do differently for the next round, based on this one?" Capture their own coaching instinct.
 8. **Recruiter/interviewer feedback capture.** "Did you get any feedback from the recruiter about this round? Even informal comments — 'they really liked your background' or 'the interviewer had some concerns about X' — are valuable signal." If feedback exists, record it for the Recruiter/Interviewer Feedback table in Interview Intelligence.
 9. **Past question similarity check.** Scan the Interview Intelligence Question Bank for questions similar to what the candidate recalled. If matches exist, note them briefly: "You've seen a prioritization question like Q2 before — at [Company] in Round [N]. Your score on that one was [X]." Only surface matches that are useful (same competency tested, score trajectory, or company pattern). Don't force connections.
-10. **Transcript availability check.** "Do you have a recording or transcript? If so, we can do a full `analyze` later. If not, I'll work from what you've captured here."
+10. **Transcript availability check.** "Do you have a recording or transcript? If so, we can do a full `analyze` later. If not, I'll work from what you've captured here." If they do have a transcript, mention the tool it came from so they know they can paste raw output: "You can paste the raw transcript directly from Otter, Zoom, Grain, or whatever tool you used — I'll detect the format and clean it up automatically."
 
 ### With vs. Without Transcript
 

--- a/references/commands/feedback.md
+++ b/references/commands/feedback.md
@@ -24,12 +24,13 @@ Classify the candidate's input into one of five types. If ambiguous, ask: "Is th
 1. Record the feedback as close to verbatim as possible. Ask: "Can you share exactly what they said? Even rough wording helps — paraphrasing loses signal."
 2. Identify the source: recruiter, interviewer, or hiring manager.
 3. Map the feedback to the most relevant scoring dimension(s) — but hold this lightly. Some feedback maps cleanly ("your answers were hard to follow" → Structure), some doesn't ("we went with a candidate with more domain experience" → external factor, not a coaching gap).
-4. If the feedback contradicts the coach's assessment, note the discrepancy — don't dismiss it. External feedback is higher-signal than internal scoring.
+4. If the feedback contradicts the coach's assessment, note the discrepancy — don't dismiss it. External feedback is higher-signal than internal scoring. **This is a drift signal** — check whether the contradiction is isolated or part of a pattern. If 2+ pieces of external feedback contradict coach scoring on the same dimension, log it in `coaching_state.md` → Calibration State → Scoring Drift Log and flag for the next `progress` calibration check.
 
 **State updates**:
 - Add to Interview Intelligence → Recruiter/Interviewer Feedback table (Date, Company, Source, Feedback, Linked Dimension)
 - Update Company Patterns if this reveals something about what the company values
 - If feedback references a specific round, cross-reference with Question Bank entries for that round
+- If feedback contradicts coach scoring, log the discrepancy in Calibration State → Scoring Drift Log
 
 **Output**: Brief confirmation of what was captured, the dimension mapping, and any discrepancy with previous coaching assessment. If the feedback suggests a coaching pivot, say so: "This feedback suggests [X] matters more than we've been prioritizing. Worth revisiting in your next `progress` review."
 
@@ -52,6 +53,8 @@ Classify the candidate's input into one of five types. If ambiguous, ask: "Is th
 - If advanced with next-round details, update Interview Loops → Next round
 
 **Output**: Brief confirmation of the update. If outcome data now meets the threshold for outcome-score correlation (3+ real interviews), mention it: "You now have enough real interview data for `progress` to show outcome patterns. Worth running when you're ready."
+
+**Calibration trigger**: When the 3-outcome threshold is crossed, note that calibration is now possible: "With 3+ real interview outcomes, the system can now check whether practice scores are predicting real results. Run `progress` to see the calibration analysis." Update Calibration State → Calibration Status to "calibrating" if it was "uncalibrated."
 
 ---
 

--- a/references/commands/help.md
+++ b/references/commands/help.md
@@ -32,8 +32,8 @@ When the user types `help`, generate a context-aware command guide — not just 
 ### Interview Prep
 | Command | What It Does |
 |---|---|
-| `research [company]` | Lightweight company research + fit assessment before committing to full prep |
-| `prep [company]` | Full prep brief — format guidance, culture read, interviewer intelligence (from LinkedIn URLs), predicted questions (weighted by real questions from past interviews when available), story mapping, and a day-of cheat sheet |
+| `research [company]` | Company research + structured fit assessment (seniority, domain, trajectory) before committing to full prep. Three depth levels: Quick Scan (target list building), Standard (default), Deep Dive (high-priority targets). Includes structured search protocol and claim verification. |
+| `prep [company]` | Full prep brief — role-fit assessment (5 dimensions — identifies frameable vs. structural gaps), format guidance, culture read, interviewer intelligence (from LinkedIn URLs), predicted questions (weighted by real questions from past interviews when available), story mapping, and a day-of cheat sheet |
 | `concerns` | Anticipate likely interviewer concerns about your profile + counter-evidence strategies |
 | `questions` | Generate 5 tailored, non-generic questions to ask your interviewer |
 | `hype` | Pre-interview boost — 60-second hype reel, 3x3 sheet (concerns + counters + questions), warmup routine, and mid-interview recovery playbook |
@@ -58,7 +58,7 @@ When the user types `help`, generate a context-aware command guide — not just 
 ### Progress and Tracking
 | Command | What It Does |
 |---|---|
-| `progress` | Score trends, self-assessment calibration (are you an over-rater or under-rater?), storybank health, outcome tracking (correlates practice scores with real interview results), question-type performance analysis, accumulated patterns from real interviews, and coaching meta-check |
+| `progress` | Score trends, self-assessment calibration (are you an over-rater or under-rater?), storybank health, outcome tracking (correlates practice scores with real interview results), targeting insights (correlates rejection patterns with company type and fit assessments), question-type performance analysis, accumulated patterns from real interviews, and coaching meta-check |
 
 ### Post-Interview
 | Command | What It Does |
@@ -92,6 +92,9 @@ Based on where you are:
 - Run `progress` weekly — it tracks your self-assessment accuracy, not just scores
 - After real interviews, log outcomes — the system correlates practice scores with real results
 - Set your feedback directness level (1-5) during `kickoff` — the diagnosis stays the same, only the delivery changes
+- Run `research` before applying — the fit assessment helps you focus on roles where you're competitive, and flags stretch targets that need extra prep
+- For high-priority targets, ask for a deep dive research — `research [company]` and mention you want comprehensive intelligence
+- Paste raw transcripts from any tool (Otter, Zoom, Grain, etc.) — the system auto-detects the format and cleans it up
 - Everything saves automatically to `coaching_state.md` — pick up where you left off, even weeks later
 
 What would you like to work on?

--- a/references/commands/kickoff.md
+++ b/references/commands/kickoff.md
@@ -43,6 +43,23 @@ Don't just file the resume — analyze it for coaching-relevant signals:
 
 Feed these findings into the Kickoff Summary output (Profile Snapshot section) and into the initial coaching plan.
 
+### Step 2.6: Target Reality Check
+
+After resume analysis, cross-reference the candidate's profile against their stated target role(s). This is NOT a full fit assessment — it's a quick sanity check that fires only when clear mismatches are visible from the resume alone.
+
+**Fire the check if any of these are true:**
+- Seniority gap of 2+ levels (e.g., IC targeting VP, or junior targeting Staff)
+- Zero domain experience for a domain-specific role (e.g., no healthcare experience targeting a healthcare PM role at a regulated company)
+- Function switch without an obvious bridge (e.g., marketing → engineering, with nothing on the resume connecting the two)
+- Target role requires hard skills the candidate demonstrably doesn't have (e.g., "5+ years of ML experience required" with no ML on resume)
+
+**When triggered**, surface it directly but without gatekeeping:
+"Looking at your resume against your target of [role], I want to flag something: [specific gap]. This doesn't mean you shouldn't go for it — but it means we should build a deliberate strategy for addressing this gap. Want to talk through your thinking on this target, or should we proceed and build the strongest case possible?"
+
+**When NOT triggered**, say nothing. Don't manufacture concerns. Most candidates have realistic targets.
+
+**If the candidate has multiple targets**, check each one. It's common for one target to be a strong fit and another to be a stretch — name this: "Your [Role A] target looks like a natural fit. Your [Role B] target is more of a stretch because [reason]. Both are worth pursuing, but they need different prep strategies."
+
 ### Step 3: Initialize Coaching State
 
 Write the initial `coaching_state.md` file (see SKILL.md Session State System for format) with:
@@ -76,6 +93,7 @@ Return exactly:
 - Seniority band:
 - Timeline:
 - Interview history: [first-time / active but not advancing / experienced but rusty]
+- Target fit assessment: [realistic / stretch — details below / flagged concerns — see below]
 - Feedback Directness:
 - Time-aware coaching mode: [triage / focused / full]
 
@@ -90,6 +108,12 @@ Based on interview history and profile:
 - Current readiness: [not started / has foundation but gaps / strong base needs polish]
 - Biggest risk going in: [the single most important thing to address]
 - Biggest asset going in: [the single strongest thing to build on]
+
+## Target Reality Check (only if concerns flagged)
+- Target: [role]
+- Gap identified: [specific gap]
+- Gap type: [seniority / domain / function switch / hard skill]
+- Recommendation: [proceed with gap-bridging strategy / consider alternative targets / discuss]
 
 ## First Plan
 [Adjusted to timeline and interview history — a first-timer gets a different plan than someone actively interviewing]

--- a/references/commands/practice.md
+++ b/references/commands/practice.md
@@ -66,6 +66,7 @@ The first round of every practice session is explicitly **unscored**. Its purpos
 4. Ask self-reflection (with specific score self-estimate).
 5. Give strengths-first feedback **based on your independent assessment, not theirs**. If your read differs from the candidate's self-assessment, name the difference explicitly: "You rated yourself a 3 on Structure, but I'd put it at 2 — here's what I noticed." Never quietly adjust your scores to match theirs.
 6. Score using 5-dimension rubric.
+6a. **Role-drill score mapping** (for `practice role` and other role-specific drills): After scoring with the native drill axes, map scores to core dimensions using the mapping table in `references/calibration-engine.md` Section 5. Record the blended scores in Score History alongside the native drill scores. This ensures role-drill performance feeds into trend analysis, calibration checks, and graduation criteria.
 7. Record self-assessment vs. coach-assessment delta.
 8. **Cross-reference peak moments.** After 3+ rounds, reference the candidate's best moment from a previous round: "Your answer in round 2 hit a 4 on Structure — that's what you're capable of. The goal is making that your floor, not your ceiling." This builds confidence and gives a concrete target.
 9. Set one specific change for next round.

--- a/references/commands/prep.md
+++ b/references/commands/prep.md
@@ -20,8 +20,16 @@
 4. Identify company interviewing culture (see company archetype intelligence below).
 5. Infer top evaluation criteria (adjusted for format + culture).
 6. Map candidate strengths and risks — incorporate interviewer-specific adjustments if intel available.
-7. **Check storybank status.** If the candidate hasn't built a storybank yet (no `coaching_state.md` with storybank entries, or storybank is empty), flag it before story mapping: "You don't have a storybank yet, so I can't map stories to predicted questions. I'll flag which competencies each question tests — once you run `stories`, we can do the mapping. Want to build your storybank now, or continue with the rest of the prep?" If a storybank exists, proceed with mapping.
-8. Generate likely questions and story mapping (or competency mapping if no storybank).
+6.5. **Role-Fit Assessment** — With the JD parsed and candidate profile available, run the full 5-dimension fit assessment from the Role-Fit Assessment Module (`references/cross-cutting.md`). See Step 6.5 below.
+7. **Check storybank status and health.** If the candidate hasn't built a storybank yet (no `coaching_state.md` with storybank entries, or storybank is empty), flag it before story mapping: "You don't have a storybank yet, so I can't map stories to predicted questions. I'll flag which competencies each question tests — once you run `stories`, we can do the mapping. Want to build your storybank now, or continue with the rest of the prep?" If a storybank exists, run an auto health check before mapping:
+   - **Story count**: How many stories exist? Target: 8-12. Flag if < 6.
+   - **Strength distribution**: How many at 4+? Target: at least 60%. Flag if majority are 3 or below.
+   - **Earned secret coverage**: How many stories have real earned secrets vs. placeholders? Flag if < 50% have extracted earned secrets.
+   - **Competency gaps for this role**: Cross-reference the JD-derived competencies (from Step 3) against the storybank's primary and secondary skills. Flag any critical competency with no story or only weak stories.
+   - **Overuse risk**: Flag stories with Use Count 3+ in the current job search.
+   - **Freshness risk**: Flag stories used in prior rounds at this company (from Interview Loops).
+   Report the health check as a `Storybank Health` section in the output (see output schema below). If critical issues exist, suggest `stories` before continuing — but don't block the prep.
+8. **Generate likely questions and story mapping.** Use `references/story-mapping-engine.md` for the full portfolio optimization protocol. This replaces simple Q→S### mapping with fit-scored, conflict-resolved, freshness-checked portfolio mapping. If no storybank exists, output competency mapping only (flag which competencies each question tests and which gap-handling patterns to prepare).
 9. Generate non-generic interviewer questions.
 
 ### JD Parsing Guide
@@ -139,6 +147,16 @@ Don't quietly skip these topics — name the boundary so the candidate knows whe
 
 Companies have interviewing cultures that transcend individual JDs. When a known company is specified, apply culture-specific coaching — **but only from verified sources**.
 
+#### Structured Research Step
+
+Before applying company knowledge sourcing tiers, run a targeted search to ground the prep brief in current data:
+1. Search for the company's current careers page and extract their stated values/principles.
+2. Search for recent news (last 6 months) — funding, layoffs, product launches change interview culture.
+3. If the candidate provided interviewer LinkedIn URLs, research each one using the Interviewer Intelligence protocol below.
+4. Cross-reference findings with what the candidate has already told you.
+
+Present findings with source attribution: "From their careers page: [finding]" not "This company values [finding]." Follow the Claim Verification Protocol from `references/commands/research.md` — every claim maps to Tier 1, 2, or 3.
+
 #### Company Knowledge Sourcing (Critical)
 
 This is a high-stakes area. Telling a candidate "Stripe values X in interviews" when you're guessing can actively hurt them. Every company-specific claim must be sourced to one of three tiers:
@@ -215,6 +233,29 @@ When the candidate provides interviewer LinkedIn URLs or profile links, analyze 
 
 **Privacy guardrail**: Only use publicly available professional information. Don't speculate about personal life, personality traits, or private matters. Stick to what the profile says and what they've published.
 
+### Step 6.5: Role-Fit Assessment
+
+With the JD parsed and candidate profile available, run the full 5-dimension fit assessment from the Role-Fit Assessment Module (`references/cross-cutting.md`).
+
+**Assess all 5 dimensions:**
+1. **Requirement Coverage**: Map JD requirements to resume. Count matches vs. gaps. Distinguish hard requirements from wish-list items.
+2. **Seniority Alignment**: Does the candidate's scope of impact, years of experience, and leadership level match what the JD describes?
+3. **Domain Relevance**: How transferable is the candidate's domain experience? Direct overlap, adjacent, or distant?
+4. **Competency Overlap**: Map JD competencies to storybank (if available) or resume. Which competencies have strong evidence? Which are gaps?
+5. **Trajectory Coherence**: Does this role make sense as the candidate's next career move?
+
+**Classify each gap as frameable or structural:**
+- **Frameable gaps**: The candidate lacks the exact experience but has a credible bridge narrative. These become concern counters. Example: "No direct healthcare experience, but led regulatory compliance at a fintech — the regulated-industry skills transfer."
+- **Structural gaps**: Real limitations that narrative can't fully bridge. These should be named honestly. Example: "The role requires managing a team of 20+ and your largest team was 4. That's a real gap interviewers will probe."
+
+**Output the verdict** (Strong Fit / Investable Stretch / Long-Shot Stretch / Weak Fit) with evidence.
+
+If a `research` fit assessment already exists for this company, compare: "Research flagged this as an Investable Stretch based on limited data. Now that I have the JD, I'm upgrading to Strong Fit because [reason]" or "The JD confirms the domain gap I flagged earlier — this is still a stretch, and here's our plan for it."
+
+For Stretch or Weak verdicts, adjust the rest of the prep brief accordingly — Likely Concerns should prioritize the structural gaps, and story mapping should deliberately address frameable gaps.
+
+When generating Likely Concerns, pull from the Role-Fit Assessment's gap classification. Frameable gaps get full counter-evidence strategies. Structural gaps get honest framing + what the candidate brings instead (Pattern 3 from Gap-Handling Module).
+
 ### Output Schema
 
 ```markdown
@@ -256,6 +297,21 @@ When the candidate provides interviewer LinkedIn URLs or profile links, analyze 
 - Supporting proof:
 - Earned secret to deploy:
 
+## Role-Fit Assessment
+- Verdict: [Strong Fit / Investable Stretch / Long-Shot Stretch / Weak Fit]
+- vs. research assessment (if exists): [confirmed / upgraded / downgraded — why]
+
+| Dimension | Rating | Evidence |
+|---|---|---|
+| Requirement Coverage | Strong / Moderate / Weak | [brief] |
+| Seniority Alignment | Strong / Moderate / Weak | [brief] |
+| Domain Relevance | Strong / Moderate / Weak | [brief] |
+| Competency Overlap | Strong / Moderate / Weak | [brief] |
+| Trajectory Coherence | Strong / Moderate / Weak | [brief] |
+
+- Frameable gaps (build counter-narratives): [list]
+- Structural gaps (name honestly, prepare for probing): [list]
+
 ## Likely Concerns + Counters
 1. Concern:
    Counter:
@@ -267,15 +323,38 @@ When the candidate provides interviewer LinkedIn URLs or profile links, analyze 
    Counter:
    Evidence:
 
+## Storybank Health (if storybank exists)
+- Total stories: __ (target: 8-12)
+- Strong stories (4-5): __ (target: at least 60%)
+- Earned secret coverage: __ of __ stories have extracted earned secrets
+- Competency coverage for this role: [critical gaps flagged]
+- Overuse warnings: [stories with Use Count 3+]
+- Freshness warnings: [stories used in prior rounds at this company]
+- Assessment: [Healthy / Needs work / Critical gaps — with specific recommendations]
+
 ## Predicted Questions (7-10)
 [If Interview Intelligence has real questions from past rounds at this company, list those first, flagged as "Asked in Round N". Use cross-company competency frequency from the Question Bank to weight remaining predictions — competencies that appear frequently across the candidate's interviews are more likely to appear again.]
 1. Question - Competency:
 ...
 
 ## Story Mapping
-- Q1 -> Story S###
-- Q2 -> Story S###
-- Gaps (questions where no strong story exists — see Gap-Handling Module):
+
+### Mapping Matrix
+| Question | Primary Story | Fit | Backup Story | Fit | Notes |
+|----------|--------------|-----|--------------|-----|-------|
+
+### Portfolio Health
+- Unique stories used: N of M mapped
+- Conflicts resolved: [details]
+- Strength warnings: [stories rated <3 in mapping]
+- Freshness warnings: [stories used in prior rounds]
+- Overuse warnings: [stories used 3+ times in search]
+
+### Gaps
+- [Competency]: best available is [story] ([fit level]). Gap-handling: [pattern]. Consider developing new story.
+
+### Strength Warnings
+- [Question] -> [Story]: rated strength [N]. [specific guidance]
 
 ## Questions To Ask Them (5)
 1.

--- a/references/commands/progress.md
+++ b/references/commands/progress.md
@@ -23,6 +23,10 @@ The value of `progress` scales with the data available. Before running the full 
 3. Compare self-assessment to actual coach scores over time (this is the most valuable part).
 4. Narrate the trend trajectory (see Trend Narration below — don't just show numbers). Skip if < 3 sessions.
 5. Check for outcome data and correlate with practice scores (see outcome tracking below). Skip if < 3 real interviews.
+5a. **Scoring Drift Detection** (requires 3+ outcomes). Run the Scoring Drift Detection Protocol from `references/calibration-engine.md`: build the outcome-score matrix, check for systematic drift per dimension, check for feedback contradictions, generate drift report, present adjustments to candidate. Update `coaching_state.md` → Calibration State. Skip if < 3 outcomes.
+5b. **Cross-Dimension Root Cause Review**. Check Calibration State → Cross-Dimension Root Causes (active). For each active root cause: assess treatment effectiveness (are affected dimensions improving in tandem?), check if resolution criteria are met (1+ point improvement sustained over 3+ sessions), update status. If a root cause isn't responding to treatment, recommend a pivot: "We've been treating [root cause] with [treatment] for [N] sessions. Affected dimensions aren't improving together. Let's try a different approach."
+5c. **Success Pattern Analysis** (requires 1+ advancement or offer). Run the Learning from Successes protocol from `references/calibration-engine.md`: validate fit assessments, track positive dimension-outcome correlation, update storybank with success annotations, extract success patterns from 3+ successes. This ensures the system learns from what it got right, not just what it got wrong.
+5.5. **Outcome-Based Targeting Insights** — When 3+ real interview outcomes exist, analyze rejection patterns for targeting signals. See Step 5.5 below. Also validate fit assessment accuracy: if fit assessments were recorded, check whether they predicted outcomes — learn from correct verdicts as well as incorrect ones. Skip if < 3 outcomes.
 6. Check graduation criteria — are they interview-ready? (see Graduation Criteria below). Skip if < 3 sessions.
 7. Identify top priorities based on triage, not just lowest scores.
 8. Recommend drills and story updates.
@@ -104,6 +108,26 @@ Map recruiter/interviewer feedback to outcomes. Look for patterns: "Both rejecti
 **Accumulated Patterns** (requires 3+ data points per pattern):
 Surface Effective and Ineffective Patterns that have enough evidence to be reliable. Present as actionable guidance: "Pattern confirmed across 4 interviews: when you lead with the counterintuitive choice, your Differentiation scores jump. Keep doing this."
 
+### Step 5.5: Outcome-Based Targeting Insights
+
+When 3+ real interview outcomes exist, analyze rejection patterns for targeting signals. Skip if < 3 outcomes.
+
+**Rejection clustering**: Are rejections concentrated at specific company types, seniority levels, or domains? If 3 of 4 rejections are at enterprise companies but the candidate advances at startups, that's a targeting signal, not a skill gap.
+
+**Stage analysis**: Where in the funnel do rejections cluster?
+- Not hearing back → resume/positioning problem, or targeting roles where the candidate doesn't meet basic requirements
+- First-round rejections → possible fit mismatch (wrong level, wrong domain) or fundamental skill gaps
+- Final-round rejections → closer to fit, but differentiation or specific competency gaps
+
+**Feedback mining**: Cross-reference Recruiter/Interviewer Feedback from Interview Intelligence with rejection patterns. If multiple rejections mention "not enough experience at scale," that's a targeting signal.
+
+**Fit assessment accuracy**: If fit assessments were recorded in Interview Loops, check whether they predicted outcomes. If "Strong Fit" verdicts still resulted in rejections, investigate — the assessment framework may need recalibration, or the issue is performance rather than fit.
+
+**Present as a narrative:**
+> "You've applied to 6 roles. You advanced at the 3 mid-stage startups and were rejected by all 3 enterprise companies. The enterprise rejections all mentioned 'experience at scale.' This isn't a practice problem — it's a targeting pattern. Your skills are landing where they fit. Consider focusing your pipeline on growth-stage companies while building the enterprise narrative for later."
+
+**When the pattern suggests retargeting**, don't prescribe — inform and offer: "The data suggests a pattern. Want to discuss whether adjusting your target companies would help, or do you want to keep pushing on the current targets?"
+
 ### Graduation Criteria
 
 
@@ -132,6 +156,8 @@ If after 5+ sessions, scores are flat on any dimension:
 - Consider: Is the candidate practicing between sessions? Is the drill targeting the right sub-skill? Is there an emotional blocker (see Psychological Readiness)?
 
 **When to say "this might not be the right target":**
+**Data-driven trigger**: If Outcome-Based Targeting Insights (Step 5.5) reveals a clear pattern — rejections clustered by company type, seniority level, or domain — reference it here instead of waiting for scores to plateau. Targeting issues often masquerade as skill gaps.
+
 This is hard but important. If after sustained effort, scores remain at 2-3 across multiple dimensions for a target role that requires 4+, have the honest conversation: "Your growth on [dimension] has been steady but the bar for [specific company/role] is very high. You have two options: invest more time to close the gap, or target roles where your current strengths are a better fit. Both are valid — which feels right to you?"
 
 ### Output Schema
@@ -169,6 +195,13 @@ This is hard but important. If after sustained effort, scores remain at 2-3 acro
 - Feedback-to-dimension mapping:
 - Unmeasured factors to investigate:
 
+## Targeting Insights (if 3+ outcomes exist)
+- Rejection pattern: [clustered by company type / seniority / domain / stage — or no pattern]
+- Stage analysis: [where in the funnel rejections cluster]
+- Feedback signals: [recurring themes from recruiter/interviewer feedback]
+- Fit assessment accuracy: [did fit verdicts predict outcomes?]
+- Recommendation: [continue current targeting / consider adjusting — with specifics]
+
 ## Graduation Check
 - Interview-ready criteria: __ of 6 met
   - [ ] 3+ scores of 4+ across dimensions
@@ -186,9 +219,27 @@ This is hard but important. If after sustained effort, scores remain at 2-3 acro
 - Weakest competency areas: [competency — avg score — count]
 - Targeting recommendation: [specific competency to drill, if gap is actionable]
 
+## Calibration Check (if 3+ outcomes exist)
+- Calibration status: [uncalibrated / calibrating / calibrated / miscalibrated]
+- Drift detected: [per dimension — direction and magnitude, or "no drift detected"]
+- Adjustments made this review: [any scoring recalibrations, or "none needed"]
+- Candidate framing: [how drift was presented — improved predictive accuracy, not goalpost-moving]
+
+## Active Root Causes
+| Root Cause | Affected Dimensions | Status | Treatment | Progress |
+|---|---|---|---|---|
+[from Calibration State — only active root causes, with treatment effectiveness assessment]
+
+## Intelligence Freshness
+- Question Bank entries flagged as historical (3-6 months): [count]
+- Question Bank entries archived (>6 months): [count]
+- Company Patterns flagged as stale (>6 months): [list companies]
+- Patterns needing re-test (>3 months old): [list]
+
 ## Accumulated Patterns (if 3+ data points per pattern)
 - Confirmed effective patterns: [from Interview Intelligence]
 - Confirmed ineffective patterns: [from Interview Intelligence]
+- Confirmed success patterns: [from calibration — what correlates with advancement]
 - Feedback-outcome correlation: [if sufficient data]
 
 ## Pattern Signals

--- a/references/commands/research.md
+++ b/references/commands/research.md
@@ -19,21 +19,66 @@ A lightweight alternative to `prep` for when the candidate wants to understand a
 3. Assess fit against the candidate's profile (from `coaching_state.md` if available, or from what they've told you).
 4. Output the research brief.
 
+### Research Depth Levels
+
+| Level | When to Use | What to Do | Time Investment |
+|---|---|---|---|
+| **Quick Scan** | Building a target list, evaluating 5+ companies at once | Company website + careers page + recent news. Enough for a basic fit assessment. | 5-10 min |
+| **Standard** | Evaluating whether to apply. Default for `research`. | Full protocol: website, careers, news, Glassdoor, LinkedIn, blog. Produces a complete research brief. | 15-20 min |
+| **Deep Dive** | High-priority target, interview scheduled, want maximum intelligence | Standard + employee posts/talks, product reviews, competitor analysis, leadership team profiles. | 30+ min |
+
+Default to **Standard**. Suggest **Deep Dive** when:
+- The candidate has an interview scheduled at this company
+- The candidate explicitly asks for comprehensive intelligence
+- The company is in the candidate's top 3 targets
+
+### Structured Search Protocol
+
+Search for information in this order. Each step builds on the previous ones:
+
+1. `[Company] careers` → careers page, open roles, stated values/principles, engineering/product blog links
+2. `[Company] about` or `[Company] mission` → stage, funding, size, founding story
+3. `[Company] news [current year]` → recent events (funding, layoffs, product launches, leadership changes). **Note**: Recent events change interview culture — a company that just laid off 20% is hiring differently than one that just raised Series C.
+4. `[Company] interview process [role type]` → Glassdoor/Blind interview reviews (label as crowd-sourced, not verified)
+5. `[Company] engineering blog` or `[Company] product blog` → culture signals, technical maturity, how they think about problems
+6. `[Company] culture` → employee reviews, culture deck, values page, recent employee posts
+7. (Deep Dive only) `[Company] [leader name]` → leadership profiles, talks, posts, published perspectives
+
+### Claim Verification Protocol
+
+Every company-specific claim in the research output must map to a source tier:
+
+- **Tier 1 — Verified**: Information directly retrieved from the company's own website, careers page, blog, or from the job description/candidate-provided context. Cite the source.
+- **Tier 2 — General knowledge**: Widely documented public information about well-known companies (e.g., Amazon's Leadership Principles, Google's Googleyness). Label clearly.
+- **Tier 3 — Unknown**: Information that couldn't be verified. State this explicitly — don't guess.
+
+**Rules:**
+- When web search returns conflicting information, present both sides and note the conflict: "Source A says [X], but Source B says [Y]. Worth verifying directly."
+- When information is dated (>12 months), flag it: "This is from [date] — verify it's still current. Companies change."
+- Never synthesize multiple uncertain sources into a confident claim. If 3 Glassdoor reviews each say something slightly different, present the range, not a false consensus.
+
 ### What to Research
 
 Pull from publicly available sources only:
 - **Company careers page**: Open roles, values, culture signals, engineering/product/design blog
 - **Company "About" page**: Mission, stage, funding, size
-- **Recent news**: Funding rounds, product launches, leadership changes, layoffs (these shape interview culture — a company that just laid off 20% is hiring differently than one that just raised Series C)
+- **Recent news**: Funding rounds, product launches, leadership changes, layoffs
 - **Glassdoor/Blind signals**: Interview process info, culture reviews (label as crowd-sourced, not verified)
 - **LinkedIn company page**: Growth trajectory, team composition
 
 ### Fit Assessment
 
-Cross-reference what you find with the candidate's profile:
-- **Strong fit signals**: Where the candidate's experience aligns with what the company values
-- **Potential friction**: Where the candidate's background might raise concerns (domain mismatch, seniority gap, culture clash)
-- **Unknowns**: What you can't determine without more information (flag these — don't guess)
+Use the Role-Fit Assessment Module from `references/cross-cutting.md`. Without a JD, you can assess 3 of 5 dimensions:
+
+1. **Seniority Alignment** — Does the candidate's experience level match what this company typically hires for this type of role? Use public signals (job postings, team composition on LinkedIn, company stage).
+2. **Domain Relevance** — How transferable is the candidate's industry/domain experience? A fintech PM applying to a healthtech startup has a domain gap. Name it, assess how bridgeable it is.
+3. **Trajectory Coherence** — Does this role make sense as the next step in their career? A lateral move to a smaller company for more scope is coherent. A step down in title with no clear rationale raises questions.
+
+**Cannot assess without JD**: Requirement Coverage, Competency Overlap. Flag this: "For a full fit assessment, I'd need the job description."
+
+**Verdict**: Strong Fit / Stretch Fit (investable or long-shot) / Weak Fit — with the specific dimension scores driving the verdict.
+
+**If Weak Fit or Long-Shot Stretch**: Follow the Alternative Suggestions Protocol — name the gaps, suggest what a better-fit version looks like, and respect the candidate's decision if they want to proceed.
 
 ### Output Schema
 
@@ -55,9 +100,13 @@ Cross-reference what you find with the candidate's profile:
 - Confidence: High / Medium / Low
 
 ## Fit Assessment (vs. your profile)
-- Strong alignment: [where your background matches what they value]
-- Potential friction: [where your background might raise questions]
-- Unknowns: [what I'd need to know to give a better assessment]
+- Verdict: [Strong Fit / Investable Stretch / Long-Shot Stretch / Weak Fit]
+- Seniority Alignment: [Strong / Moderate / Weak] — [brief evidence]
+- Domain Relevance: [Strong / Moderate / Weak] — [brief evidence]
+- Trajectory Coherence: [Strong / Moderate / Weak] — [brief evidence]
+- Cannot assess without JD: Requirement Coverage, Competency Overlap
+- Key gaps (if stretch/weak): [specific gaps, not vague]
+- Better-fit alternatives (if weak/long-shot): [what roles would be stronger matches and why]
 
 ## If You Decide to Apply
 - Recommended next steps:
@@ -73,8 +122,10 @@ After research, save a lightweight entry to `coaching_state.md` Interview Loops:
 ```
 ### [Company Name]
 - Status: Researched (not yet applied)
-- Fit assessment: [strong / moderate / weak]
-- Key signals: [1-2 lines]
+- Fit verdict: [Strong / Investable Stretch / Long-Shot Stretch / Weak]
+- Fit confidence: [Limited — no JD]
+- Fit signals: [1-2 lines on what drove the verdict]
+- Structural gaps: [gaps that can't be bridged with narrative, if any]
 - Date researched: [date]
 ```
 

--- a/references/commands/stories.md
+++ b/references/commands/stories.md
@@ -67,10 +67,11 @@ See `references/storybank-guide.md` for the full storybank format, column defini
 
 When the candidate selects "Find gaps," don't just list missing competencies — rank them by how much they matter for this candidate's target roles:
 
-1. Cross-reference the candidate's target roles/companies (from `coaching_state.md`) with the storybank's skill coverage.
-2. For each gap, assess: **Critical** (this competency will definitely be tested and no story exists), **Important** (likely to come up, only weak stories available), **Nice-to-have** (might come up, but won't make or break the interview).
-3. For critical gaps, check: can an existing story be reframed to cover this competency, or does the candidate need to surface a new experience entirely?
+1. Cross-reference the candidate's target roles/companies (from `coaching_state.md`) with the storybank's skill coverage. **Check both Primary and Secondary Skills** — a competency may be covered as a secondary skill in an existing story, which changes the gap from "no story" to "Workable coverage" (see `references/story-mapping-engine.md` for fit scoring).
+2. For each gap, assess: **Critical** (this competency will definitely be tested and no story exists, even as a secondary skill), **Important** (likely to come up, only weak stories or secondary-skill-only coverage available), **Nice-to-have** (might come up, but won't make or break the interview).
+3. For critical gaps, check: can an existing story be reframed to cover this competency (using its secondary skill or an adjacent experience), or does the candidate need to surface a new experience entirely?
 4. Prescribe gap-handling patterns (from the Gap-Handling Module) for any competencies where no real story exists.
+5. **Cross-reference with active prep briefs**: If the candidate has active prep briefs (from `prep`), check predicted questions against gaps. A gap that maps to a predicted question at a current target company is elevated to Critical regardless of general frequency.
 
 A PM interviewing at Stripe with no "influence without authority" story has a critical gap. The same candidate missing a "technical depth" story has a nice-to-have gap. Rank accordingly.
 

--- a/references/cross-cutting.md
+++ b/references/cross-cutting.md
@@ -144,6 +144,68 @@ If scoring reveals patterns consistent with cultural communication differences (
 
 ---
 
+## Role-Fit Assessment Module
+
+Targeting the right roles is as important as performing well in interviews. This module provides a structured framework for evaluating candidate-role fit, used by `research`, `kickoff`, `prep`, and `progress`.
+
+### Five Fit Dimensions
+
+| Dimension | What It Measures | Data Source |
+|---|---|---|
+| **Requirement Coverage** | How many "required" qualifications the candidate meets vs. misses | JD + resume |
+| **Seniority Alignment** | Whether the candidate's experience level matches the role's expectations | JD + resume + career trajectory |
+| **Domain Relevance** | How transferable the candidate's industry/domain experience is | JD + resume + company context |
+| **Competency Overlap** | Overlap between the candidate's demonstrated skills and the role's core competencies | JD + storybank (if available) + resume |
+| **Trajectory Coherence** | Whether this role makes sense as the candidate's next career move — narratively and developmentally | Resume + career history + target role |
+
+Score each dimension: Strong / Moderate / Weak. Not every dimension needs data — flag unknowns explicitly.
+
+### Three-Tier Verdict
+
+**Strong Fit** — Candidate meets most requirements, seniority aligns, domain is relevant or closely adjacent, competencies overlap substantially, and the role is a logical next step. Prep focuses on positioning and differentiation.
+
+**Stretch Fit** — Candidate has meaningful gaps but also clear strengths. Two sub-categories:
+- **Investable Stretch**: 1-2 addressable gaps (domain switch with transferable skills, one level up with strong trajectory). The candidate can make a credible case. Prep focuses on gap-bridging narratives and concern counters.
+- **Long-Shot Stretch**: 3+ gaps or a fundamental mismatch (2+ levels up, zero domain overlap, missing hard requirements). The candidate should understand the odds. Coach helps if they choose to proceed, but names the reality.
+
+**Weak Fit** — Fundamental misalignment across multiple dimensions. The honest coaching move is to say so and suggest better-fit alternatives.
+
+### Confidence by Data Availability
+
+| Data Available | What You Can Assess | What You Can't |
+|---|---|---|
+| Company name only | Seniority Alignment (from public info), Trajectory Coherence | Requirement Coverage, Competency Overlap (no JD) |
+| Company + JD | All 5 dimensions at moderate confidence | Deep domain relevance (may need research) |
+| Company + JD + Resume | All 5 dimensions at high confidence | — |
+| Company + JD + Resume + Storybank | All 5 dimensions at highest confidence (competency overlap is evidence-based, not inferred) | — |
+
+When data is limited, assess what you can and flag what's missing: "I can assess Seniority Alignment and Trajectory Coherence from what I know. For a full fit assessment, I'd need the JD."
+
+### Alternative Suggestions Protocol
+
+When fit is Weak or Long-Shot Stretch, don't just diagnose — help redirect:
+
+1. **Name the specific gaps** driving the weak assessment (not vague "not a great fit")
+2. **Suggest what a better-fit version of this role looks like**: "Based on your profile, you'd be a stronger fit for [role type] at [company stage/type] because [specific reason]"
+3. **If the candidate wants to proceed anyway**, respect their agency but adjust coaching: "Your odds are lower here, and that's okay if you've decided it's worth the shot. Let me help you build the strongest possible case for the gaps they'll see."
+
+### Anti-Patterns
+
+- Don't gatekeep. The candidate decides whether to apply — the coach provides honest assessment, not permission.
+- Don't conflate "stretch" with "impossible." Career growth requires stretch roles. The question is whether the stretch is bridgeable.
+- Don't assess fit based on vibes. Use the 5 dimensions with evidence.
+- Don't over-index on requirement coverage. Many JDs are wish lists. A candidate who meets 60-70% of requirements is often competitive.
+- Don't ignore trajectory coherence. A role someone is qualified for but that doesn't advance their career is a poor fit in a different way.
+
+### Integration
+
+- `kickoff`: Target Reality Check — fires only on clear mismatches (2+ level seniority gap, zero domain experience, function switch without bridge narrative)
+- `research`: Structured Fit Assessment replaces the current vibes-based section — uses the 3 dimensions assessable without a JD
+- `prep`: Full 5-dimension assessment with JD + resume + storybank data. Distinguishes frameable gaps (can counter with narrative) from structural gaps (real limitations)
+- `progress`: Outcome-Based Targeting Insights — when 3+ real interview outcomes exist, analyzes rejection patterns to surface targeting issues
+
+---
+
 ## Cross-Command Dependency Module
 
 Commands produce better output when they have data from other commands. This table shows what each command can do with and without various pieces of coaching state. Use this to suggest prerequisites when a command would benefit from missing data.
@@ -152,7 +214,7 @@ Commands produce better output when they have data from other commands. This tab
 |---|---|---|---|
 | `kickoff` | — | Everything — this is the entry point | — |
 | `research` | Profile from `kickoff` | Profile (gives generic fit assessment) | Company name |
-| `prep` | Storybank, coaching state profile, interviewer links, Interview Intelligence (Company Patterns, Question Bank) | Storybank (can't do story mapping, flags the gap), profile (infers from JD), Interview Intelligence (loses real-question weighting and company pattern data) | Company + Role/seniority + JD |
+| `prep` | Storybank, coaching state profile, interviewer links, Interview Intelligence (Company Patterns, Question Bank), `references/story-mapping-engine.md` (for portfolio-optimized story mapping when storybank exists) | Storybank (can't do story mapping, flags the gap), profile (infers from JD), Interview Intelligence (loses real-question weighting and company pattern data) | Company + Role/seniority + JD |
 | `analyze` | Coaching state (seniority band, storybank for story matching) | Seniority band (asks for it), storybank (skips story mapping) | Transcript |
 | `feedback` | Interview Intelligence (for cross-referencing feedback with existing data), Interview Loops, Score History | All (captures data without cross-referencing) | — |
 | `debrief` | Storybank (for Last Used updates), Interview Loops (for context), Interview Intelligence Question Bank (for past question similarity checks) | All (captures data without cross-referencing) | — |

--- a/references/examples.md
+++ b/references/examples.md
@@ -435,3 +435,100 @@ The pattern here is clear and consistent with what we saw in practice: you skip 
 ```
 
 **Why this example matters**: Shows how signal-reading observations are woven into per-answer analysis, not bolted on as a separate section. The Q2 analysis distinguishes between positive follow-ups (interest) and wrap-up signals (they got enough). The Q4 analysis uses the contrast between the two answers to teach the candidate to read real-time signals — the silence + quick pivot = the answer didn't land. Also demonstrates the coaching move of suggesting a real-time recovery: offering a stronger example mid-interview.
+
+---
+
+## Example 11: System Design Transcript Analysis (Phase-Based Parsing)
+
+**Context**: Senior Engineer, system design round at a growth-stage company. 50-minute collaborative verbal walkthrough. Transcript from Zoom VTT format (auto-detected, normalized to internal representation).
+
+```markdown
+## Interview Delta
+
+## Interview Format
+- Detected format: System design / case study
+- Format source: Coaching state (Round 2 format saved during prep)
+- Scoring weight adjustments: Structure + Substance weighted highest
+- Format-specific dimensions scored: Process Visibility, Scoping Quality, Tradeoff Articulation, Adaptability
+- Coaching scope: I'm coaching how you communicate your thinking — how you scope, narrate decisions, and articulate tradeoffs. I'm not evaluating whether your architecture is technically correct.
+
+## Phase Analysis
+
+### P1: Scoping (4 minutes — 8% of session)
+- Scores: Substance 3 / Structure 4 / Relevance 4 / Credibility 3 / Differentiation 2
+- Format-specific: Process Visibility 4 / Scoping Quality 2
+- What worked: You immediately started asking clarifying questions — "How many concurrent users?" "What's the latency requirement?" Good instinct.
+- Biggest gap: You asked 3 clarifying questions but didn't ask about the most important constraint: data consistency requirements. The interviewer had to introduce this later, which forced a mid-design pivot.
+- Root cause: Scoping checklist is incomplete — you have a mental model for scale questions but not for consistency/reliability questions.
+- Evidence: "Let me start by understanding the scale..." — good opening, but the 3 questions were all scale-related.
+
+### P2: Approach (8 minutes — 16%)
+- Scores: Substance 4 / Structure 4 / Relevance 4 / Credibility 4 / Differentiation 3
+- Format-specific: Process Visibility 5 / Tradeoff Articulation 3
+- What worked: Excellent thinking-out-loud quality. "I'm considering two approaches here — a centralized queue versus a distributed pub/sub model. Let me walk through the tradeoffs..." This is exactly what interviewers want to hear.
+- Biggest gap: You named two approaches but only explored one in detail. The interviewer had to ask "Why not the pub/sub approach?" — you should have addressed it proactively.
+- Root cause: Tradeoff articulation is one-sided — you explain why your preferred approach works, but don't preemptively address why the alternative doesn't.
+
+### P3: Deep-dive (20 minutes — 40%)
+- Scores: Substance 4 / Structure 3 / Relevance 3 / Credibility 4 / Differentiation 3
+- Format-specific: Process Visibility 3 / Adaptability 3
+- What worked: Strong technical depth. When you described the caching layer, the interviewer said "That's a good insight" — clear positive signal.
+- Biggest gap: You spent 20 of 50 minutes here, which squeezed the later phases. Structure dropped because you went deep on the caching layer but then had to rush through the database design. The interviewer's "Let's move on to..." was a time management signal you should have caught earlier.
+- Root cause: Deep-dive rabbit hole — genuine expertise in one area pulls you in, and you lose track of the broader design.
+
+### P4: Adaptation (10 minutes — 20%)
+- Scores: Substance 3 / Structure 3 / Relevance 4 / Credibility 3 / Differentiation 2
+- Format-specific: Process Visibility 3 / Adaptability 4
+- What worked: When the interviewer introduced the data consistency constraint you'd missed in scoping, you pivoted well: "That changes things. I'd need to add a coordination layer..." Good recovery.
+- Biggest gap: The pivot was reactive, not proactive. If you'd asked about consistency in P1, this phase would have been about optimization, not recovery. Also, your narration dropped during the pivot — you went quiet for about 20 seconds while rethinking.
+- Root cause: Silent thinking under pressure. When the design changes, you retreat into your head instead of narrating the rethink.
+
+### P5: Summary (8 minutes — 16%)
+- Scores: Substance 3 / Structure 4 / Relevance 4 / Credibility 3 / Differentiation 3
+- Format-specific: Process Visibility 4 / Tradeoff Articulation 4
+- What worked: Strong summary structure — you walked back through the full design top-to-bottom and named tradeoffs at each layer. "If I had more time, I'd explore..." showed maturity.
+- Biggest gap: Didn't connect the design back to the original requirements. The interviewer asked "Does this meet the latency requirement?" — you should have proactively mapped design decisions to constraints.
+
+## Scorecard
+- Substance: 3.4
+- Structure: 3.6
+- Relevance: 3.8
+- Credibility: 3.4
+- Differentiation: 2.6
+- Process Visibility: 3.8
+- Scoping Quality: 2
+- Tradeoff Articulation: 3.4
+- Adaptability: 3.5
+- Calibration band used: Senior/Lead
+- Hire Signal: Mixed
+
+## Triage Decision
+- Primary bottleneck: Scoping Quality (2) — this is a system design interview, and incomplete scoping cascaded into problems across every subsequent phase.
+- Secondary: Differentiation (2.6) — your design was competent but didn't show a distinctive engineering perspective. Where's your earned secret about system design?
+- Format-aware triage: Process Visibility < 3 would override standard triage, but yours is 3.8 — good. Scoping Quality at 2 is the format-specific priority.
+- Coaching path: Focus on scoping protocol first (systematic checklist for constraints), then tradeoff articulation (preemptively address alternatives).
+
+## Top 3 Gaps To Close
+1. Gap: Incomplete scoping — missed data consistency requirements
+   Why it matters: In system design, scoping errors cascade. Everything after P1 was slightly off because of the missed constraint.
+   Root cause: Scoping mental model covers scale but not consistency/reliability/durability
+   Drill: Build a scoping checklist: scale, consistency, availability, latency, durability, cost. Practice opening 5 different design problems using the full checklist.
+
+2. Gap: One-sided tradeoff articulation
+   Why it matters: Naming two approaches but only exploring one makes it look like you've already decided and the "alternative" was performative.
+   Root cause: Genuine preference for your approach leads you to short-change the comparison
+   Drill: "Steel man the alternative" — for every design decision, spend 30 seconds making the strongest case for the approach you didn't choose before explaining why you prefer yours.
+
+3. Gap: Silent thinking during pivots
+   Why it matters: 20 seconds of silence in a collaborative design interview reads as "stuck." The interviewer can't help you if they don't know what you're thinking.
+   Root cause: Thinking-out-loud habit breaks under pressure when the design needs significant revision
+   Drill: Practice narrating uncertainty: "The consistency requirement changes my approach. Let me think through what needs to change... The caching layer needs a write-through policy instead of write-behind, and I'll need to add a coordination service..."
+
+## Carry Forward
+- Your thinking-out-loud quality in P2 was excellent — "I'm considering two approaches..." is exactly the right way to open a design phase. Make this your default mode, especially during pivots.
+
+## Coaching Scope Note
+I scored the communication quality of your design process — how you scoped, narrated, and articulated tradeoffs. I did not evaluate whether your architecture was technically sound. For technical validation, practice with a senior engineer peer.
+```
+
+**Why this example matters**: Demonstrates phase-based parsing (P1-P5 instead of Q1-Q5), format-specific scoring dimensions alongside the core 5, format-aware triage (Scoping Quality at 2 overrides standard dimension priorities), time allocation analysis (8% in scoping vs. 40% in deep-dive), and the coaching scope boundary note at the end. Shows how system design analysis focuses on the communication process, not the technical solution. Also demonstrates how a missed scoping question cascades through the entire design — making it concrete why scoping is the highest-priority intervention.

--- a/references/rubrics-detailed.md
+++ b/references/rubrics-detailed.md
@@ -146,6 +146,10 @@ Most interview failures trace back to a small number of root causes that manifes
 
 When scoring reveals a pattern, name the root cause explicitly: "This looks like [pattern X] — here's what typically drives it and here's the targeted drill." For cultural/linguistic patterns specifically, always frame as adaptation, not correction.
 
+### Root Cause Persistence Tracking
+
+When the same root cause appears across 2+ consecutive sessions (or across 2+ answers in the same session), it should be escalated from a per-answer observation to an active entry in `coaching_state.md` → Calibration State → Cross-Dimension Root Causes. See `references/calibration-engine.md` Section 3 for the full lifecycle: Detection → Unified Treatment → Progress Tracking → Resolution. The key principle: prescribe ONE intervention targeting the root cause itself, not separate drills for each affected dimension. A root cause affecting Substance and Differentiation (e.g., conflict avoidance) gets tension-mining drills — not separate Substance drills and Differentiation drills.
+
 ---
 
 ## Seniority Calibration

--- a/references/story-mapping-engine.md
+++ b/references/story-mapping-engine.md
@@ -1,0 +1,159 @@
+# Story Mapping Engine
+
+Consolidates story mapping logic into a single protocol. Referenced by `prep` (step 8), `stories` (gap analysis), and `progress` (storybank health).
+
+---
+
+## Section 1: Story-Question Fit Scoring
+
+Replace bare `Q1 -> S###` with a 4-level fit classification:
+
+| Fit Level | Definition |
+|---|---|
+| **Strong Fit** | Primary skill matches the competency being tested. Story strength 4+. Domain aligns with the target company/role. Earned secret is relevant to the question. |
+| **Workable** | Secondary skill matches the competency, OR primary skill matches but story strength is 3, OR domain is adjacent but not direct. Can work with framing guidance. |
+| **Stretch** | No direct skill match but the story can be reframed to address the competency. Story strength 2+. Requires significant bridging in delivery. |
+| **Gap** | No story addresses this competency at any fit level. Trigger gap-handling protocol (see Gap-Handling Module in `references/cross-cutting.md`). |
+
+### Fit Scoring Factor Priority Stack
+
+When evaluating a story-question match, weigh these factors in order:
+
+1. **Competency match** (highest weight) — Primary skill match > Secondary skill match > Reframe match. A story whose primary skill directly addresses the tested competency is always preferred.
+2. **Strength score** (high weight) — Stories rated 4-5 > 3 > 2. A strength-5 story with a secondary skill match may outperform a strength-3 story with a primary skill match.
+3. **Company/role alignment** (medium weight) — Does the story's domain match the target company? Is the earned secret relevant to what this company values? Stories from the same industry or with transferable context get a boost.
+4. **Freshness** (medium weight) — Has this story been used in prior rounds at this company? Has it been used 3+ times in the current job search? Fresh stories signal range.
+5. **Variety** (portfolio constraint) — Applied at the portfolio level, not per-question. Penalizes using the same story twice in one interview prep.
+
+### Mapping Output Format
+
+For each question-story mapping, state:
+- **Fit level**: Strong Fit / Workable / Stretch / Gap
+- **Why**: One line explaining the match (e.g., "Primary skill (leadership) directly matches competency. Strength 4. Domain aligned (B2B SaaS).")
+- **Bridging guidance** (Workable/Stretch only): How to frame the story to better address the competency. (e.g., "Foreground the cross-functional coordination element — it's a secondary skill in this story but it's what the question is testing.")
+
+---
+
+## Section 2: Portfolio Optimization Protocol
+
+7-step process replacing question-by-question mapping:
+
+### Step 1: Generate Candidate Mappings
+For each predicted question, identify ALL stories that could work (Strong Fit, Workable, or Stretch). Build a matrix:
+
+```
+           Q1    Q2    Q3    Q4    Q5    Q6    Q7
+S001       SF    --    W     --    --    St    --
+S002       --    SF    --    W     --    --    --
+S003       W     --    SF    SF    --    --    --
+S004       --    --    --    --    SF    --    W
+S005       --    W     --    --    --    SF    --
+...
+```
+
+SF = Strong Fit, W = Workable, St = Stretch, -- = no viable match.
+
+### Step 2: Detect Conflicts
+Identify questions competing for the same best story. A conflict exists when two or more questions have the same story as their highest-fit option.
+
+### Step 3: Resolve Conflicts
+For each conflict:
+1. Assign the story to the question where it has the highest fit level.
+2. If fit levels are equal, assign to the question where the story's strength matters most (i.e., the harder question or the one with fewer alternative stories).
+3. Cascade to the next-best story for the losing question.
+4. Flag significant downgrades: "Q4 was downgraded from S003 (Strong Fit) to S006 (Workable) due to conflict with Q3. Bridging guidance: [specific framing]."
+
+### Step 4: Apply Variety Constraint
+No story should appear more than once in the final mapping unless no alternative exists. If a story must be reused:
+- Explain why: "S003 is the only story addressing both leadership and prioritization competencies. No alternative exists for Q4."
+- Suggest framing variation: "For Q3, lead with the decision-making angle. For Q4, lead with the stakeholder management angle."
+
+### Step 5: Apply Freshness Constraint
+Check `coaching_state.md` → Interview Loops for stories used in prior rounds at this company.
+- Stories used in a previous round: downgrade by one fit level (Strong Fit → Workable) unless the candidate is asked to go deeper on the same topic.
+- Flag: "S003 was used in Round 1. Using it again in Round 2 signals limited range unless they specifically ask you to elaborate."
+
+### Step 6: Apply Overuse Check
+Flag stories used 3+ times in the current job search (check Use Count in storybank).
+- 3 uses: "S007 has been used in 3 interviews. Consider rotating to a fresher story if alternatives exist."
+- 5+ uses: "S007 is heavily used (5 times). Interviewers in your network may have heard it. Prioritize alternatives."
+
+### Step 7: Output Final Mapping
+Produce the final mapping with annotations (see Output Schema below).
+
+---
+
+## Section 3: Earned-Secret-Aware Selection
+
+### Default Rule
+Between equally ranked stories (same fit level and similar strength), prefer the one with a stronger earned secret. An earned secret makes a story memorable and drives Differentiation scores.
+
+### Conditional Boost
+When company culture signals prize differentiation (e.g., companies known for "bar raiser" rounds, companies whose values emphasize innovation or unique thinking, or when Calibration State shows Differentiation predicts advancement), boost stories with strong earned secrets by treating them as +1 fit level.
+
+Example: S005 (Workable, strong earned secret) competes with S008 (Workable, no earned secret). Under the conditional boost, S005 is treated as Strong Fit equivalent.
+
+### When Calibration Confirms
+If `coaching_state.md` → Calibration State shows that Differentiation correlates with advancement for this candidate, upgrade this from conditional to default: always prefer stories with stronger earned secrets.
+
+---
+
+## Section 4: Secondary Skill Utilization
+
+When no story has the target competency as its Primary Skill:
+1. Check Secondary Skills across the storybank.
+2. A story with the target competency as a Secondary Skill starts at **Workable** fit level.
+3. Provide framing guidance: "This story's primary skill is data-driven decision making, but it also demonstrates influence without authority (secondary). Lead with the influence angle: how you got the engineering team to prioritize without having direct authority over them."
+
+Secondary skill matches are always Workable at best — never Strong Fit — because the competency isn't the centerpiece of the story.
+
+---
+
+## Output Schema
+
+Use this schema in `prep` output to replace the current simple story mapping:
+
+```markdown
+## Story Mapping
+
+### Mapping Matrix
+| Question | Primary Story | Fit | Backup Story | Fit | Notes |
+|----------|--------------|-----|--------------|-----|-------|
+| Q1: [question summary] | S### — [title] | Strong Fit | S### — [title] | Workable | |
+| Q2: [question summary] | S### — [title] | Workable | S### — [title] | Stretch | Bridging: [guidance] |
+| Q3: [question summary] | Gap | — | S### — [title] | Stretch | Gap-handling: Pattern 2 |
+...
+
+### Portfolio Health
+- Unique stories used: [N] of [M] mapped questions
+- Conflicts resolved: [e.g., "Q3 and Q4 competed for S003 — assigned to Q3 (higher fit), Q4 uses S006"]
+- Strength warnings: [stories rated <3 that appear in mapping — specific guidance for each]
+- Freshness warnings: [stories used in prior rounds at this company]
+- Overuse warnings: [stories used 3+ times in current search]
+
+### Gaps
+- [Competency]: best available is [story] ([fit level]). Gap-handling: [Pattern 1-4]. Consider developing a new story for this competency.
+
+### Strength Warnings
+- [Question] -> [Story]: rated strength [N]. [Specific guidance — e.g., "This story needs quantified impact before deployment. Run `stories improve S###` to strengthen it."]
+```
+
+---
+
+## Integration Points
+
+### With Calibration Engine (references/calibration-engine.md)
+- When scoring drift adjusts a dimension, flag stories whose strength ratings were driven by that dimension for re-evaluation.
+- When calibration shows Differentiation predicts advancement, upgrade earned-secret-aware selection from conditional to default.
+- When calibration links a specific dimension to rejections, elevate story mapping gaps in that dimension's competencies to "Calibration-Urgent" priority.
+
+### With Prep (references/commands/prep.md)
+- Prep Step 7 runs a storybank health check before mapping.
+- Prep Step 8 invokes this engine for the full mapping protocol.
+
+### With Stories (references/commands/stories.md)
+- Gap analysis in `stories find gaps` uses the fit scoring system to classify gaps.
+- Secondary skills are checked for coverage before declaring a competency a true gap.
+
+### With Progress (references/commands/progress.md)
+- Storybank health metrics include overuse tracking and freshness risk.

--- a/references/storybank-guide.md
+++ b/references/storybank-guide.md
@@ -111,22 +111,22 @@ Update the storybank:
 
 ## Story Selection Strategy
 
-When matching stories to questions:
+For full portfolio-optimized story mapping, see `references/story-mapping-engine.md`. That engine handles fit scoring (4 levels), conflict resolution, freshness checks, overuse checks, and earned-secret-aware selection. The principles below still apply as the conceptual framework:
 
 ### 1. Competency Match
-Which stories demonstrate the competency being tested?
+Which stories demonstrate the competency being tested? Check both Primary and Secondary Skills.
 
 ### 2. Company Fit
 Which stories align with this company's values and priorities?
 
 ### 3. Freshness
-Have you used this story recently with this company? Avoid repeats.
+Have you used this story recently with this company? Avoid repeats. Stories used in prior rounds at the same company are downgraded.
 
 ### 4. Strength
 Choose 4+ stories when possible. Save 3s for backup.
 
 ### 5. Variety
-Across an interview loop, show range: different projects, skills, outcomes.
+Across an interview loop, show range: different projects, skills, outcomes. No story should appear more than once per interview prep unless no alternative exists.
 
 ---
 
@@ -196,20 +196,26 @@ Then layer in:
 **Healthy storybank:**
 - 8-12 indexed stories
 - At least 5 rated strength 4+
-- All key competencies covered
+- All key competencies covered (check both Primary and Secondary Skills)
 - Mix of domains (not all one type)
 - At least 2 stories with quantified outcomes
 - At least 1 failure/learning story
-- No story used more than 3x in current job search
+- No story used more than 3x in current job search (check Use Count)
+- At least 80% of stories have extracted earned secrets
 
 **Warning signs:**
 - Fewer than 6 stories
 - Most stories rated 3 or below
-- Major competency gaps
+- Major competency gaps (even after checking Secondary Skills)
 - All stories from one job/era
 - No failure stories
 - Relying on 2-3 favorites repeatedly
 - No earned secrets extracted (stories are specific but not distinctive)
+
+**Overuse and freshness tracking:**
+- **Overuse** (Use Count 3+): "S### has been used in [N] interviews. Consider rotating to a fresher story if alternatives exist." At 5+: "S### is heavily used. Interviewers in your network may have heard it. Prioritize alternatives."
+- **Freshness risk**: Stories used in prior rounds at a current company loop should not be reused unless the interviewer explicitly asks for elaboration. Check Interview Loops for stories used per round.
+- **Earned secret coverage**: Stories without earned secrets are incomplete — they may score well on Substance and Structure but will plateau on Differentiation. Track coverage as a percentage.
 
 ---
 

--- a/references/transcript-formats.md
+++ b/references/transcript-formats.md
@@ -1,0 +1,144 @@
+# Transcript Format Detection and Normalization
+
+## Purpose
+
+Step 0.5 in the transcript processing pipeline. Runs before cleaning (Step 1). Detects the source tool/format of a raw transcript and normalizes it to a standard internal representation.
+
+## Format Detection Protocol
+
+- Examine the first 30-50 lines for format signals
+- Check for: VTT headers (`WEBVTT`), timestamp styles (HH:MM:SS vs MM:SS vs inline), speaker label patterns (Name:, Speaker 1:, etc.), topic/chapter headers, paragraph grouping, line numbering, metadata blocks
+- Support 8 formats (detailed below)
+- When detection is uncertain, default to Manual/generic processing and note: "Format not confidently detected — processing as generic transcript. Results may require manual review."
+
+## Supported Formats
+
+### 1. Otter.ai
+
+**Detection signals**: Speaker names on their own line followed by paragraph-grouped text. Timestamps at paragraph level (not per-line). Often includes "Transcribed by Otter" footer.
+
+**Normalization rules**:
+
+- Merge paragraph-grouped text under the same speaker into a single turn
+- Watch for mid-turn misattribution: Otter sometimes reassigns speaker mid-paragraph when background noise triggers speaker detection. If a short (< 10 word) segment attributed to a different speaker appears mid-paragraph, keep it with the surrounding speaker and flag: "[possible misattribution]"
+- Strip paragraph-level timestamps
+- Preserve any summary sections as `[Summary: ...]` markers
+
+### 2. Grain
+
+**Detection signals**: Topic/chapter headers (often bold or with section markers). Speaker labels with timestamps. Structured sections with headings.
+
+**Normalization rules**:
+
+- Preserve topic headers as `[Topic: ...]` markers — these carry valuable structural information for format-aware parsing
+- Don't split Q&A exchanges at topic boundaries — if a question starts in one topic section and the answer continues in the next, keep them together
+- Merge consecutive lines from the same speaker
+
+### 3. Google Meet
+
+**Detection signals**: Per-line speaker labels with timestamps. Very aggressive line splitting — same speaker may have 5-10 consecutive short lines. Format: "Speaker Name HH:MM:SS" or similar.
+
+**Normalization rules**:
+
+- Merge aggressive per-line splitting for the same speaker — consecutive lines from the same speaker become one turn
+- Strip per-line timestamps
+- Reconstruct sentence-level text from fragments
+
+### 4. Zoom VTT (WebVTT format)
+
+**Detection signals**: `WEBVTT` header on first line. Sequential numbered cues. Timestamps in `HH:MM:SS.mmm --> HH:MM:SS.mmm` format. May include positioning metadata (`align:`, `position:`).
+
+**Normalization rules**:
+
+- Strip the WEBVTT header and all metadata lines
+- Strip cue numbering and timestamp lines
+- Extract speaker labels from text content if present (often formatted as "Speaker Name: text" within the cue)
+- Handle positioning metadata by ignoring it entirely
+- Merge consecutive cues from the same speaker
+
+### 5. Granola
+
+**Detection signals**: AI-generated meeting notes format with structured sections (Summary, Key Points, Action Items, Transcript). Speaker labels with timestamps. May include AI-generated summaries above the raw transcript.
+
+**Normalization rules**:
+
+- Locate the raw transcript section (often after AI-generated notes)
+- Strip AI-generated summary/notes sections but note their existence: "[AI notes section detected — using raw transcript below]"
+- Merge same-speaker consecutive lines
+- Preserve action items as `[Action Item: ...]` markers if they appear inline
+
+### 6. Microsoft Teams
+
+**Detection signals**: Speaker labels on separate lines from text content. Timestamps in their own column or line. May include echo artifacts (same text appearing twice). Format often resembles a table or structured block.
+
+**Normalization rules**:
+
+- Combine separate speaker-label lines with their associated text blocks
+- Handle echo artifacts: if the same text appears twice within 2 lines attributed to the same speaker, deduplicate
+- Strip timestamp columns/lines
+- Merge consecutive turns from the same speaker
+
+### 7. Tactiq
+
+**Detection signals**: Line numbers (1, 2, 3...) at the start of lines. Timestamps alongside speaker labels. Clean formatting with consistent structure.
+
+**Normalization rules**:
+
+- Strip line numbers from the start of each line
+- Strip timestamps
+- Merge consecutive same-speaker lines
+
+### 8. Manual/Generic
+
+**Detection signals**: None of the above patterns match, OR the format is ambiguous. Includes manually typed transcripts, notes, or unstructured text.
+
+**Normalization rules**:
+
+- Infer speakers from context clues: Q:/A: labels, quotation marks, paragraph breaks, "Interviewer:"/"Candidate:" labels, indentation patterns
+- If no speaker labels can be inferred, ask the candidate: "I can't identify speaker turns in this transcript. Can you indicate which parts are your answers and which are the interviewer's questions?"
+- Preserve paragraph structure as turn boundaries when no other signals exist
+
+## Disambiguation Rules
+
+When format signals overlap:
+
+- **Otter vs. Google Meet**: Otter groups text into paragraphs under a speaker; Google Meet has one short line per timestamp per speaker. If average line length > 50 words, likely Otter. If < 15 words, likely Google Meet.
+- **Grain vs. Otter**: Grain has explicit topic/chapter headers that structure the transcript. If topic headers exist, treat as Grain. If only speaker labels and paragraphs, treat as Otter.
+- **Teams vs. Otter**: Teams separates speaker labels from text blocks (label on one line, text on the next). Otter puts the speaker label inline or at the top of a paragraph group. If speaker labels are consistently isolated on their own lines, treat as Teams.
+
+## Internal Representation (Normalization Target)
+
+All formats normalize to:
+
+```
+[Speaker Label]: [text of what they said]
+
+[Speaker Label]: [text of what they said]
+```
+
+Rules:
+
+- One speaker turn per block
+- Blank line between turns
+- Timestamps stripped entirely
+- Speaker labels standardized (consistent naming throughout)
+- Topic/chapter headers preserved as `[Topic: ...]` markers between turns
+- Fidelity markers preserved: `[inaudible]`, `[crosstalk]`, `[pause]`, `[laughter]`
+- Duplicate lines and empty turns removed
+- No line breaks within a single turn (flowing text)
+
+## Multi-Speaker Handling
+
+- **2 speakers**: Map to Interviewer/Candidate roles. If names are available, use them but also tag roles: "Sarah Chen (Interviewer): ..."
+- **3+ speakers**: Flag as potential panel interview. Preserve distinct interviewer labels — do NOT merge all interviewers into a single "Interviewer" label. Each person gets their own label. Carry this signal forward to Step 2 for format-aware parsing (panel interview path).
+- **1 speaker detected**: Likely a transcription issue or a monologue section. Flag: "Only one speaker detected — this may be a partial transcript or a transcription error. Proceeding with available data."
+
+## Quality Signals for Step 1.5
+
+After normalization, report these quality signals to the Quality Gate:
+
+- **Speaker label coverage**: What percentage of text blocks have identified speakers? (100% = high, <80% = flag)
+- **Normalization confidence**: How confident is the format detection? (High = clear format match, Medium = some ambiguity, Low = defaulted to generic)
+- **Multi-speaker detection**: Number of distinct speakers detected and whether roles could be assigned
+- **Content preservation**: Estimated percentage of original content preserved through normalization (fidelity markers, topic headers, etc.)
+- **Artifacts detected**: Any echo artifacts, misattributions, or garbled sections identified during normalization

--- a/references/transcript-processing.md
+++ b/references/transcript-processing.md
@@ -4,15 +4,31 @@ This guide covers how to clean, parse, and analyze interview transcripts for max
 
 ---
 
+## Step 0.5: Format Detection and Normalization
+
+**Before cleaning, detect the transcript source format and normalize to a standard representation.** See `references/transcript-formats.md` for the full protocol.
+
+1. Examine the first 30-50 lines for format signals (VTT headers, timestamp styles, speaker label patterns, topic headers).
+2. Identify the source format: Otter.ai, Grain, Google Meet, Zoom VTT, Granola, Microsoft Teams, Tactiq, or Manual/generic.
+3. Apply format-specific normalization rules to produce the internal representation (one speaker turn per block, timestamps stripped, speaker labels standardized).
+4. Detect speaker count: 2 speakers → Interviewer/Candidate. 3+ speakers → flag as potential panel, preserve distinct labels.
+5. Report quality signals: speaker label coverage, normalization confidence, multi-speaker detection, artifacts detected.
+
+If detection is uncertain, default to Manual/generic processing and note the ambiguity.
+
+The normalized transcript is the input to Step 1 (cleaning). Timestamps should already be stripped by normalization — Step 1 focuses on content-level cleaning only.
+
+---
+
 ## Step 1: Clean the Transcript
 
-Raw transcripts from Granola, Otter, Tactiq, or other tools are messy. Clean before analyzing.
+The normalized transcript (from Step 0.5) is cleaner than raw input, but still needs content-level cleaning. Timestamps should already be stripped by normalization.
 
 ### What to Remove
 - Filler words: "um," "uh," "like," "you know," "basically"
 - False starts: "I was going to— actually, let me say—"
-- Duplicated speaker lines (transcription errors)
-- Timestamps (unless needed for specific analysis)
+- Duplicated speaker lines (any remaining after normalization)
+- Any residual timestamps not caught by normalization
 
 ### What to Keep
 - Speaker labels (Interviewer / Candidate)
@@ -51,23 +67,38 @@ After cleaning, assess how much of the transcript is usable before proceeding to
 | **Medium** (60-80% clean) | Some garbled sections, occasional missing speaker labels, most Q&A pairs recoverable | Proceed but flag: "This transcript has gaps. I'll note where my confidence is reduced." Be explicit when claims are based on incomplete data. |
 | **Low** (<60% clean) | Major gaps, missing speaker labels, garbled sections, can't identify all questions | Say so upfront: "This transcript has significant quality issues. I can score [N] of the [M] answers, but my confidence is low overall. Here's what I can and can't assess." Consider asking: "Do you remember any answers that are missing or garbled? Your memory + partial transcript is better than partial transcript alone." |
 
+### Format-Derived Quality Factors
+
+Incorporate these signals from Step 0.5 into the quality assessment:
+- **Speaker label coverage**: If normalization couldn't identify speakers for >20% of text blocks, downgrade quality level by one tier.
+- **Normalization confidence**: Low confidence (defaulted to generic processing) adds uncertainty — note in quality assessment.
+- **Multi-speaker detection**: 3+ speakers detected → flag for panel-aware parsing in Step 2. If speaker roles couldn't be assigned, ask the candidate to clarify who was who.
+- **Artifacts detected**: Echo artifacts, misattributions, or garbled sections identified during normalization should be counted toward the quality assessment.
+
 State the quality level at the start of analysis. Don't pretend bad data is good data.
 
 ---
 
-## Step 2: Parse into Q&A Units
+## Step 2: Format-Aware Parsing
 
-Structure the transcript for systematic analysis.
+Structure the transcript for systematic analysis. The parsing approach depends on the interview format.
 
-### Parsing Prompt
+### Step 2.0: Format Detection
+
+Determine the interview format using this priority chain:
+1. **Coaching state**: Check `coaching_state.md` → Interview Loops → Round formats for this company/round.
+2. **Candidate statement**: The candidate may have told you the format in conversation.
+3. **Transcript inference**: Panel interviews have 3+ speakers. System design transcripts have long candidate monologues with probing follow-ups. Technical+behavioral mix shows distinct mode switches.
+4. **Ask**: If ambiguous, ask: "What type of interview was this — behavioral, system design, panel, or a mix?"
+5. **Default**: If unknown, default to Path A (Behavioral).
+
+### Path A: Behavioral Interview (default)
+
+Used for: behavioral screen, deep behavioral, bar raiser, culture fit, hiring manager 1:1.
 
 ```
-TASK: Parse this transcript into question-answer pairs.
-
-INPUT: [cleaned transcript]
-
-FOR EACH PAIR, CAPTURE:
-- question_number (Q1, Q2, etc.)
+FOR EACH Q&A PAIR, CAPTURE:
+- unit_id: Q1, Q2, etc.
 - question_text (verbatim)
 - answer_text (verbatim, trimmed of filler)
 - topic: behavioral / technical / strategic / situational / cultural
@@ -76,16 +107,108 @@ FOR EACH PAIR, CAPTURE:
 - did_answer_question: Yes / Partial / No
 - follow_up_triggered: Yes / No (did interviewer ask for more?)
 
-OUTPUT FORMAT:
-1. Table with all Q&A pairs and metadata
-2. Summary stats:
-   - Total questions: ___
-   - Fully answered: ___
-   - Partially answered: ___
-   - Not answered: ___
-   - Average answer length: ___ words
-   - Longest answer: ___ words (flag if >300)
-   - Follow-ups triggered: ___
+SUMMARY STATS:
+- Total questions: ___
+- Fully answered: ___
+- Partially answered: ___
+- Not answered: ___
+- Average answer length: ___ words
+- Longest answer: ___ words (flag if >300)
+- Follow-ups triggered: ___
+```
+
+### Path B: Panel Interview
+
+Used when: 3+ distinct speakers detected, or format is known to be panel.
+
+Parse into **exchanges** (not pairs). Each exchange may involve multiple interviewers.
+
+```
+FOR EACH EXCHANGE, CAPTURE:
+- unit_id: E1, E2, etc.
+- lead_interviewer: [name/label of who asked the primary question]
+- question_text (verbatim)
+- answer_text (verbatim)
+- follow_up_chain: [list of follow-ups from ANY interviewer, with interviewer label for each]
+- cross_examiner: [did a different interviewer jump in? who?]
+- competency_tested:
+- word_count:
+
+PANEL ANALYSIS:
+- Interviewer participation map: [who asked how many questions, who followed up most]
+- Cross-interviewer patterns: [did interviewers build on each other's questions? tag-team?]
+- Candidate adaptation: [did the candidate adjust style/depth across different interviewers?]
+- Energy distribution: [even across the panel, or front-loaded/faded?]
+```
+
+### Path C: System Design / Case Study
+
+Used for: system design, technical case study, architectural review, product design.
+
+Parse into **phases** (not pairs). Phase types: scoping, approach, deep-dive, tradeoff, adaptation, summary.
+
+```
+FOR EACH PHASE, CAPTURE:
+- unit_id: P1, P2, etc.
+- phase_type: scoping / approach / deep-dive / tradeoff / adaptation / summary
+- candidate_contributions: [key statements, decisions, reasoning]
+- interviewer_probes: [questions, challenges, redirections within this phase]
+- key_decisions: [decisions the candidate made and rationale]
+- clarification_questions_asked: [by the candidate — critical in system design]
+- thinking_out_loud_quality: High / Medium / Low
+- duration_estimate: [rough time in this phase if inferable]
+
+SUMMARY STATS:
+- Time-in-scoping %: ___ (< 10% is a red flag — candidate skipped scoping)
+- Clarification questions count: ___ (0 is a red flag)
+- Tradeoffs articulated unprompted: ___ vs. when probed: ___
+- Phase progression: [did the candidate manage time across phases?]
+```
+
+### Path D: Technical + Behavioral Mix
+
+Used when: the interview contains distinct behavioral and technical segments.
+
+Segment the transcript by mode, then parse each segment with the appropriate path.
+
+```
+SEGMENTATION:
+- Identify transition points between behavioral and technical modes
+- Label each segment: [behavioral] or [technical]
+- Note transition quality: smooth / abrupt / confused
+
+BEHAVIORAL SEGMENTS: Parse via Path A (Q# units)
+TECHNICAL SEGMENTS: Parse via Path C (P# phases)
+
+MODE-SWITCHING METADATA:
+- Transition points: [where did mode switches happen?]
+- Transition quality: [did the candidate shift cleanly?]
+- Mode balance: [% behavioral vs. % technical]
+- Integration moments: [did the candidate connect technical and behavioral threads?]
+```
+
+### Path E: Case Study (Candidate-Driven)
+
+Used for: consulting-style cases, business cases, product strategy cases where the candidate drives the analysis.
+
+Parse into **stages**: problem definition, framework, analysis, recommendation, Q&A.
+
+```
+FOR EACH STAGE, CAPTURE:
+- unit_id: S1, S2, etc.
+- stage_type: problem-definition / framework / analysis / recommendation / q-and-a
+- information_requests: [what data/clarification did the candidate ask for?]
+- hypothesis_statements: [did the candidate state hypotheses?]
+- pivots: [did the candidate change direction when given new information?]
+- quantitative_rigor: High / Medium / Low / None
+- synthesis_quality: [how well did the candidate tie analysis back to the original problem?]
+
+SUMMARY STATS:
+- Information requests count: ___
+- Hypotheses stated: ___
+- Pivots on new information: ___ (0 may indicate rigidity)
+- Quantitative elements: ___
+- Recommendation clarity: High / Medium / Low
 ```
 
 ---
@@ -114,13 +237,91 @@ Before scoring, scan the transcript against known failure patterns. This provide
 | **Defensive deflection** | When pressed on a weakness, redirects to strengths without acknowledging the gap | Medium | Gap-handling drill |
 | **Rehearsed robotics** | Answer sounds memorized — identical phrasing to previous practice, no adaptation to question nuance | Medium | Variation practice: same story, different framings |
 
-After scanning, include detected anti-patterns in the analysis output. Each detected pattern should reference which Q# triggered it and link to the specific fix.
+After scanning, include detected anti-patterns in the analysis output. Each detected pattern should reference which unit (Q#, E#, P#, S#) triggered it and link to the specific fix.
+
+### Format-Specific Anti-Patterns
+
+In addition to the behavioral anti-patterns above, scan for these format-specific patterns:
+
+**Panel Interview Anti-Patterns:**
+
+| Anti-Pattern | Detection Heuristic | Severity | Fix |
+|---|---|---|---|
+| **Plays to one interviewer** | 70%+ of eye contact cues / engagement directed at one panelist | High | Practice distributing attention. Address follow-ups to the asker, then reconnect with the panel. |
+| **Ignores silent observer** | One panelist asks zero questions and candidate never engages them | Medium | Proactively include quiet panelists: "I'd be curious about your perspective on this." |
+| **Inconsistent depth** | Answers vary wildly in depth across panelists (detailed for senior, thin for junior) | Medium | Calibrate depth to the question, not the questioner's perceived seniority. |
+| **No cross-reference** | Candidate never connects an answer to a previous panelist's question | Low | Build narrative threads: "Building on what [name] asked earlier..." |
+
+**System Design Anti-Patterns:**
+
+| Anti-Pattern | Detection Heuristic | Severity | Fix |
+|---|---|---|---|
+| **Skips scoping** | Candidate jumps to solution within first 2 minutes, no clarification questions | High | Clarification-seeking drill. First 3-5 minutes must be questions. |
+| **Solution fixation** | Commits to one approach without exploring alternatives | High | Tradeoff articulation drill. Name 2+ approaches before committing. |
+| **Silent thinking** | Long pauses (30s+) without narrating thought process | Medium | Thinking-out-loud drill. Narrate even when uncertain. |
+| **Ignores probes** | Interviewer asks a probing question, candidate continues on original track | High | Signal-reading practice. Treat probes as required pivots. |
+| **No time management** | Spends 60%+ of time on one phase, rushes or skips others | Medium | Phase-pacing practice with explicit time targets. |
+| **Bluffs on unknowns** | Claims knowledge of systems/concepts they clearly don't understand | High | Honesty drill: "I'm less familiar with X, but here's how I'd approach learning it..." |
+
+**Technical + Behavioral Mix Anti-Patterns:**
+
+| Anti-Pattern | Detection Heuristic | Severity | Fix |
+|---|---|---|---|
+| **Mode confusion** | Gives behavioral answer to technical question or vice versa | High | Mode-switching drill. Identify the question type before answering. |
+| **One-mode dominance** | 80%+ of interview time spent in one mode despite mixed format | Medium | Balance practice. Deliberately shift modes. |
+| **No integration** | Never connects technical decisions to behavioral context or vice versa | Medium | Integration drill: "The technical choice connects to my leadership approach because..." |
+| **Energy cliff** | Performance visibly drops in the second mode (usually technical → behavioral) | Medium | Stamina practice. Run 45+ minute mixed sessions. |
+
+**Case Study Anti-Patterns:**
+
+| Anti-Pattern | Detection Heuristic | Severity | Fix |
+|---|---|---|---|
+| **Framework forcing** | Applies a named framework (MECE, Porter's 5 Forces) that doesn't fit the problem | High | Problem-first thinking. Understand the problem before reaching for a framework. |
+| **Analysis without hypothesis** | Runs through data/analysis without stating what they expect to find | Medium | Hypothesis-first practice: "I expect to see X because Y. Let me check..." |
+| **Ignores new info** | When given additional data, doesn't update analysis or conclusions | High | Flexibility drill. Practice pivoting when assumptions are challenged. |
+| **No recommendation** | Analyzes thoroughly but never commits to a recommendation | High | "If you had to decide right now" drill. Force a recommendation with rationale. |
+| **Math avoidance** | Skips quantitative analysis when numbers are available | Medium | Quantitative practice. Back-of-envelope calculations build credibility. |
 
 ---
 
 ## Step 3: Multi-Lens Scoring
 
 Run the parsed transcript through evaluative lenses. **Important**: Which lenses you run depends on the Post-Scoring Decision Tree in `references/commands/analyze.md`. If a primary bottleneck is identified after initial scoring, scope the analysis accordingly rather than running all four lenses mechanically. Always follow the evidence sourcing standard from SKILL.md. **For Quick Prep track**: Run only Lens 1 and skip to delta sheet.
+
+### Scoring Weight Adjustments by Format
+
+Reference `references/commands/prep.md`'s Interview Format Taxonomy as the single source of truth for format-specific weight adjustments:
+
+| Format | Primary Dimensions (weighted highest) |
+|---|---|
+| Behavioral screen | Structure, Relevance |
+| Deep behavioral | Substance, Credibility |
+| System design / case study | Structure, Substance |
+| Panel | All dimensions + Adaptability |
+| Technical + behavioral mix | Substance, Structure |
+| Presentation round | Structure, Differentiation |
+| Bar raiser / culture fit | Credibility, Differentiation |
+| Hiring manager 1:1 | Relevance, Differentiation |
+
+### Additional Scoring Dimensions for Non-Behavioral Formats
+
+These supplement the core 5 dimensions — they do not replace them. Score each 1-5 when the format applies:
+
+**System Design / Case Study:**
+- **Process Visibility** (1-5): How clearly the candidate narrated their thinking process. 1 = silent/opaque, 5 = every decision explained in real-time.
+- **Scoping Quality** (1-5): How well the candidate defined the problem before solving it. 1 = jumped to solution, 5 = thorough scoping with clarifying questions.
+- **Tradeoff Articulation** (1-5): How well the candidate named tradeoffs and alternatives. 1 = single approach with no alternatives, 5 = multiple approaches compared with explicit tradeoff reasoning.
+- **Adaptability** (1-5): How well the candidate responded to probes, redirections, and new constraints. 1 = rigid, 5 = graceful pivots.
+
+**Panel:**
+- **Interviewer Adaptation** (1-5): How well the candidate calibrated responses to different panelists. 1 = identical style for everyone, 5 = clearly adapted depth, tone, and focus per interviewer.
+- **Energy Consistency** (1-5): How well the candidate maintained engagement across the full panel session. 1 = visible fatigue/disengagement, 5 = consistent energy throughout.
+- **Cross-Referencing** (1-5): How well the candidate connected threads across different panelists' questions. 1 = treated each question in isolation, 5 = built narrative connections.
+
+**Technical + Behavioral Mix:**
+- **Mode-Switching Fluidity** (1-5): How cleanly the candidate transitioned between technical and behavioral modes. 1 = confused or jarring, 5 = seamless transitions.
+- **Integration Quality** (1-5): How well the candidate connected technical decisions to behavioral context. 1 = no connection, 5 = naturally wove both together.
+- **Energy Trajectory** (1-5): How energy/quality held up across the full mixed session. 1 = significant drop in second half, 5 = maintained or improved.
 
 ### Lens 1: Hiring Manager Perspective
 
@@ -288,6 +489,9 @@ Suggested source: [which experience could fill this]
 CARRY FORWARD:
 [One strong behavior from this interview to maintain]
 
+INTERVIEW FORMAT: [detected format]
+FORMAT-SPECIFIC ANALYSIS: [include if non-behavioral — see below]
+
 REFLECTION PROMPTS:
 - How does this feedback compare to your gut feeling about the interview?
 - Of the growth areas above, which feels most within your control?
@@ -296,8 +500,58 @@ REFLECTION PROMPTS:
 NEXT ACTIONS (co-created with candidate):
 [ ] Update storybank: retire [stories], add [new story]
 [ ] Run drill: [specific exercise for priority growth area]
-[ ] Practice: [weak Q# from this interview] until scores 4+
+[ ] Practice: [weak unit from this interview] until scores 4+
 [ ] Review before next interview: this delta sheet
+```
+
+### Format-Specific Delta Sheet Sections
+
+Include the relevant section below when the interview format is non-behavioral:
+
+**System Design / Case Study:**
+```
+FORMAT-SPECIFIC ANALYSIS: System Design
+
+PROCESS SCORES:
+Process Visibility: ___ | Scoping Quality: ___ | Tradeoff Articulation: ___ | Adaptability: ___
+
+PHASE ANALYSIS:
+- Scoping %: ___% of total time (target: 15-25%)
+- Clarification questions: ___ (0 = red flag)
+- Tradeoff breakdown: ___ unprompted / ___ when probed
+- Phase progression: [managed time well / rushed end / stuck in one phase]
+- Strongest phase: [which phase and why]
+- Weakest phase: [which phase and why]
+```
+
+**Panel:**
+```
+FORMAT-SPECIFIC ANALYSIS: Panel
+
+PANEL SCORES:
+Interviewer Adaptation: ___ | Energy Consistency: ___ | Cross-Referencing: ___
+
+PANEL DYNAMICS:
+- Interviewer engagement: [who was most engaged, who was least]
+- Strongest exchange: E___ — [why it worked]
+- Weakest exchange: E___ — [what went wrong]
+- Cross-interviewer threads: [moments where the candidate connected questions across panelists]
+- Energy arc: [how energy changed across the session]
+```
+
+**Technical + Behavioral Mix:**
+```
+FORMAT-SPECIFIC ANALYSIS: Technical + Behavioral Mix
+
+MIX SCORES:
+Mode-Switching Fluidity: ___ | Integration Quality: ___ | Energy Trajectory: ___
+
+MODE ANALYSIS:
+- Behavioral mode average: Sub ___ / Str ___ / Rel ___ / Cred ___ / Diff ___
+- Technical mode average: Sub ___ / Str ___ / Rel ___ / Cred ___ / Diff ___
+- Stronger mode: [behavioral / technical / balanced]
+- Transition moments: [where mode switches happened and quality of each]
+- Integration highlights: [moments where the candidate connected both modes]
 ```
 
 ---


### PR DESCRIPTION
## Summary

- **Transcript Format Support** — auto-detect and normalize 8 transcript formats (Otter, Grain, Google Meet, Zoom VTT, Granola, Teams, Tactiq, generic) so candidates can paste raw output directly
- **Multi-Format Transcript Analysis** — format-aware parsing for panel (exchanges), system design (phases), case study (stages), and technical+behavioral mix (segmented modes), each with format-specific anti-patterns, additional scoring dimensions, and delta sheet sections
- **Smarter Story Mapping** — portfolio-optimized mapping engine with 4-level fit scoring, 7-step conflict resolution, freshness/overuse tracking, earned-secret-aware selection, and secondary skill utilization
- **Outcome Calibration Loop** — scoring drift detection, cross-dimension root cause tracking with unified treatment, temporal decay for intelligence data, role-drill integration with core dimensions, success pattern capture, and structured unmeasured factor investigation
- **Enhanced Company Intelligence** — 3 research depth levels (Quick Scan, Standard, Deep Dive), structured 7-step search protocol, and claim verification with source tiers
- **Version Roadmap** — VERSIONS.md documenting v1 (shipped), v2 (shipped), v3 (interaction model), and v4 (platform)

4 new files, 17 modified files, +1411/-89 lines.

## Test plan

- [ ] Verify behavioral transcript analysis still follows the exact same path as v1 (backward compatible)
- [ ] Verify all 3 new reference files are complete and internally consistent
- [ ] Verify SKILL.md file routing includes all 3 new files
- [ ] Verify cross-references between calibration-engine.md and story-mapping-engine.md are bidirectional
- [ ] Verify Example 11 demonstrates phase-based parsing with format-specific scoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)