### PR TITLE
Add linkedin command: profile optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Say `kickoff`, share your resume, and you're being coached in under 2 minutes.
 
 **Guided flow** — The coach recommends a specific next step after every command based on your coaching state — not a generic menu. When you say something like "prepare me for my interview at Google," it detects the multi-step intent and walks you through the full sequence (research, prep, concerns, hype) with natural transitions. Session start greetings include a prescriptive recommendation for the highest-leverage move right now.
 
+**LinkedIn profile optimization** — Section-by-section audit of your LinkedIn profile against how the platform actually works: recruiter boolean search mechanics, algorithm distribution, and section-specific impact. Three depth levels from quick audit to deep optimization with content strategy. Not a resume-to-LinkedIn copy — a platform-native optimization that treats LinkedIn as its own game.
+
 **Differentiation** — Earned secrets and spiky POVs are a first-class dimension, not an afterthought. The system pushes you past "competent" toward "memorable."
 
 **Self-awareness** — Tracks the gap between your self-assessment and actual coach scores. Knows if you're an over-rater or under-rater, and adjusts coaching accordingly.
@@ -83,6 +85,7 @@ The coach will ask for your resume, target role, and timeline — then build you
 | `stories` | Build/manage storybank + rapid-retrieval drill. At Level 5: stories get red-teamed with 5 challenge lenses | Story table + earned secrets + gap analysis + retrieval drill |
 | `concerns` | Anticipate interviewer concerns | Concern-counter-evidence map |
 | `questions` | Generate interviewer questions | 5 tailored, non-generic questions |
+| `linkedin` | LinkedIn profile optimization (3 depth levels) | Section-by-section audit, rewritten sections, content strategy |
 | `hype` | Pre-interview confidence + psychological warmup. At Level 5: includes a pre-mortem with failure prevention | 60-second reel + 3x3 sheet + focus cue + recovery playbook |
 | `thankyou` | Post-interview follow-up drafts | Thank-you note + variants |
 | `progress` | Trends, self-calibration, outcome tracking, scoring calibration. At Level 5: includes a Hard Truth section | Self-assessment delta + outcome correlation + scoring drift detection + root cause tracking + coaching meta-check |
@@ -290,6 +293,7 @@ interview-coach-skill/
     │   ├── stories.md
     │   ├── concerns.md
     │   ├── questions.md
+    │   ├── linkedin.md
     │   ├── hype.md
     │   ├── thankyou.md
     │   ├── progress.md

--- a/SKILL.md
+++ b/SKILL.md
@@ -61,6 +61,7 @@ After reading `coaching_state.md`, check whether it contains all sections and co
 - **Missing `Secondary Skill` column in Storybank**: Add the column to the table header. Leave existing rows blank for Secondary Skill. Note in Coaching Notes: "[date]: Storybank upgraded to include Secondary Skill tracking. Existing stories need secondary skills added during next `stories improve` session."
 - **Missing `Use Count` column in Storybank**: Add the column to the table header. Initialize all existing rows to 0. The count will begin tracking from this point forward.
 - **Missing `Calibration State` section**: Add the full section using the schema defined below (after Active Coaching Strategy). Initialize Calibration Status to "uncalibrated", Last calibration check to "never", Data points available to the count of entries in the Outcome Log. All tables start empty.
+- **Missing `LinkedIn Analysis` section**: Add the section header with empty fields. Note in Coaching Notes: "[date]: LinkedIn Analysis section added. Run `linkedin` to populate."
 
 Run this migration silently — do not announce schema changes to the candidate unless they affect immediate coaching recommendations. After migration, the coaching state is fully compatible with the current skill version.
 
@@ -201,6 +202,16 @@ Last updated: [date]
 ### Unmeasured Factor Investigations
 | Date | Trigger | Hypothesis | Investigation | Finding | Action |
 
+## LinkedIn Analysis
+- Date: [date]
+- Depth: [Quick Audit / Standard / Deep Optimization]
+- Overall: [Strong / Needs Work / Weak]
+- Recruiter discoverability: [Strong / Moderate / Weak]
+- Credibility on visit: [Strong / Moderate / Weak]
+- Differentiation: [Strong / Moderate / Weak]
+- Top fixes pending: [1-3 line items]
+- Positioning gaps: [resume ↔ LinkedIn inconsistencies, if assessed]
+
 ## Meta-Check Log
 | Session | Candidate Feedback | Adjustment Made |
 |---------|-------------------|-----------------|
@@ -233,6 +244,7 @@ Write to `coaching_state.md` whenever:
 - feedback captures ad-hoc input: recruiter feedback (add to Recruiter/Interviewer Feedback — also check for drift signals when feedback contradicts coach scoring), outcomes (update Outcome Log + Question Bank Outcome column — trigger calibration check when 3-outcome threshold is crossed), corrections (evaluate and adjust if warranted — may update Score History or Storybank ratings, record in Coaching Notes), post-session memories (route to Question Bank, Storybank, Interview Loops, or Company Patterns as appropriate), and meta-feedback (record in Meta-Check Log)
 - progress reviews trends (update Active Coaching Strategy, check Score History archival, check Interview Intelligence archival thresholds). Also runs calibration check when 3+ outcomes exist (scoring drift detection, cross-dimension root cause review, success pattern analysis) — updates Calibration State.
 - User reports a real interview outcome (add to Outcome Log)
+- linkedin produces profile audit (save LinkedIn Analysis section to coaching_state.md — date, depth, overall score, dimension scores, top fixes pending, positioning gaps)
 - prep starts a new company loop or updates interviewer intel, round formats, fit verdict, fit confidence, and structural gaps (add to Interview Loops)
 - negotiate receives an offer (add to Outcome Log with Result: offer)
 - reflect archives the coaching state (add Status: Archived header)
@@ -277,6 +289,7 @@ Execute commands immediately when detected. Before executing, **read the referen
 | `stories` | Build/manage storybank |
 | `concerns` | Generate likely concerns + counters |
 | `questions` | Generate tailored interviewer questions |
+| `linkedin` | LinkedIn profile optimization |
 | `hype` | Pre-interview confidence and 3x3 plan |
 | `thankyou` | Thank-you note / follow-up drafts |
 | `progress` | Trend review, self-calibration, outcomes |
@@ -293,6 +306,7 @@ When executing a command, read the required reference files first:
 - **`analyze`**: Also read `references/transcript-processing.md`, `references/transcript-formats.md`, `references/rubrics-detailed.md`, `references/examples.md`, `references/calibration-engine.md`, and `references/differentiation.md` (when Differentiation is the bottleneck).
 - **`practice`**, **`mock`**: Also read `references/role-drills.md`. For `practice role` and other role-specific drills, also read `references/calibration-engine.md` Section 5 (role-drill score mapping). For `mock`, also read `references/calibration-engine.md` (mock produces scores and benefits from calibration guidance).
 - **`prep`**: Also read `references/story-mapping-engine.md` when storybank exists.
+- **`linkedin`**: Also read `references/differentiation.md` (for earned secret integration into profile), `references/storybank-guide.md` (for storybank data to feed into About/Experience rewrites).
 - **`stories`**: Also read `references/storybank-guide.md` and `references/differentiation.md`.
 - **`progress`**: Also read `references/calibration-engine.md`.
 - **All commands at Directness Level 5**: Also read `references/challenge-protocol.md`.
@@ -376,13 +390,14 @@ Use first match:
 4. "Just had an interview" / "just finished" / post-interview context -> `debrief`
 5. Company + JD context -> `prep`
 6. Company name only (no JD, no interview scheduled) -> `research`
-7. Story-building / storybank intent -> `stories`
-8. System design / case study / technical interview practice intent -> `practice technical` (sub-command of `practice`)
-9. Practice intent -> `practice`
-10. Progress/pattern intent -> `progress`
-11. "I got an offer" / offer details present -> `negotiate`
-12. "I'm done" / "accepted" / "wrapping up" -> `reflect`
-13. Otherwise -> ask whether to run `kickoff` or `help`
+7. LinkedIn profile/optimization intent -> `linkedin`
+8. Story-building / storybank intent -> `stories`
+9. System design / case study / technical interview practice intent -> `practice technical` (sub-command of `practice`)
+10. Practice intent -> `practice`
+11. Progress/pattern intent -> `progress`
+12. "I got an offer" / offer details present -> `negotiate`
+13. "I'm done" / "accepted" / "wrapping up" -> `reflect`
+14. Otherwise -> ask whether to run `kickoff` or `help`
 
 ### Multi-Step Intent Detection
 
@@ -394,6 +409,7 @@ When a candidate's request implies a sequence of commands, state the plan and ex
 | "I just finished my interview at [company]" | `debrief` → (later) `analyze` if transcript available |
 | "Help me get ready for tomorrow" | `hype` (+ `prep` if none exists for the company) |
 | "I want to work on my stories" | `stories add`/`improve` cycle |
+| "I'm starting my job search" | `kickoff` → `stories` → `linkedin` (Quick Audit) |
 | "I got rejected from [company]" | `feedback` Type B → `progress` targeting insights (if 3+ outcomes) |
 
 **Behavior**: When you detect a multi-step intent, briefly state the plan ("I'll walk you through research, then prep, then concerns for [company]"), execute the first step, and at each transition point offer the next step naturally: "That covers the research. Ready to move into full prep?" If the candidate wants to skip or redirect, respect that. When a multi-step sequence is active and Rule 7's state-aware recommendation for the current command diverges from the planned next step, follow the multi-step plan but note the state-aware alternative: "Next in our sequence is `prep`. (Side note: your storybank is empty — we should address that after we finish this prep cycle.)"

--- a/references/commands/help.md
+++ b/references/commands/help.md
@@ -15,6 +15,8 @@ When the user types `help`, generate a context-aware command guide — not just 
    - If 3+ scored sessions exist: highlight `progress`
    - If an offer was received: highlight `negotiate`
    - If drill progression shows the candidate hasn't completed Stage 1: highlight `practice ladder`
+   - If LinkedIn Analysis doesn't exist and storybank has 3+ stories: highlight `linkedin`
+   - If LinkedIn Analysis exists and overall is "Weak" or "Needs Work": highlight `linkedin` (mention pending fixes)
    - If the candidate mentions recruiter feedback or an outcome in conversation but hasn't used `feedback`: highlight `feedback`
 4. **Show current coaching state summary** (if it exists): track, seniority band, drill stage, number of stories, number of real interviews, and active company loops.
 5. **End with a prompt**: "What would you like to work on?"
@@ -36,6 +38,7 @@ When the user types `help`, generate a context-aware command guide — not just 
 | `prep [company]` | Full prep brief — role-fit assessment (5 dimensions — identifies frameable vs. structural gaps), format guidance, culture read, interviewer intelligence (from LinkedIn URLs), predicted questions (weighted by real questions from past interviews when available), story mapping, and a day-of cheat sheet |
 | `concerns` | Anticipate likely interviewer concerns about your profile + counter-evidence strategies |
 | `questions` | Generate 5 tailored, non-generic questions to ask your interviewer |
+| `linkedin` | LinkedIn profile optimization — section-by-section audit, recruiter search optimization, content strategy. Three depth levels: Quick Audit, Standard, Deep Optimization. At Level 5 Deep: Challenge Protocol applied to your profile. |
 | `hype` | Pre-interview boost — 60-second hype reel, 3x3 sheet (concerns + counters + questions), warmup routine, and mid-interview recovery playbook |
 
 ### Practice and Simulation
@@ -94,6 +97,7 @@ When the user types `help`, generate a context-aware command guide — not just 
 - For high-priority targets, ask for a deep dive research — `research [company]` and mention you want comprehensive intelligence
 - Paste raw transcripts from any tool (Otter, Zoom, Grain, etc.) — the system auto-detects the format and cleans it up
 - The coach will recommend a specific next step after every command — just follow the flow if you're not sure what to do next
+- Your LinkedIn profile is a search engine, not a resume. Run `linkedin` to optimize for how recruiters actually find candidates.
 - Everything saves automatically to `coaching_state.md` — pick up where you left off, even weeks later
 
 What would you like to work on?

--- a/references/commands/linkedin.md
+++ b/references/commands/linkedin.md
@@ -1,0 +1,276 @@
+# linkedin — LinkedIn Profile Optimization
+
+Optimize the candidate's LinkedIn profile as a search-discoverable, credibility-building, job-landing surface. LinkedIn is its own platform with its own rules — not a resume mirror. The profile needs to be optimized for how LinkedIn actually works: recruiter boolean search, algorithm distribution, section-specific mechanics, and content strategy.
+
+Also read `references/differentiation.md` (for earned secret integration into profile) and `references/storybank-guide.md` (for storybank data to feed into About/Experience rewrites).
+
+---
+
+## How LinkedIn Actually Works
+
+**Recruiter Search**: LinkedIn Recruiter uses boolean search across profile fields. Headline has the highest keyword weight, followed by current title, skills, experience descriptions, and about. Recruiter Lite matches on title + headline + skills. Full Recruiter also searches experience descriptions and about. Skills are filterable (checkbox filters in Recruiter search). Open to Work increases visibility in recruiter results.
+
+**Algorithm (for content/engagement)**: Posts go through 3-phase distribution: quality filter → test audience → broader network. Comments are ~15x more valuable than likes for reach. PDF carousels get 3-6x engagement vs text. External links reduce reach ~60%. Engagement in first 60-90 min determines distribution.
+
+**Section Impact Ranking** (for recruiter discovery + profile visits):
+1. Headline (highest search weight, first thing seen)
+2. Current title (second-highest search weight)
+3. Skills (filterable in recruiter search — the only filterable field)
+4. Experience descriptions (searched in full Recruiter)
+5. About section (searched, but lower weight)
+6. Photo + banner (affects click-through rate from search results)
+7. Open to Work signal (increases recruiter visibility)
+8. Featured section (credibility when they visit your profile)
+9. Recommendations (social proof, low search weight)
+10. Custom URL + completeness signals
+
+---
+
+## Priority Check
+
+Before running the full audit, check coaching state:
+- If no `kickoff` has been run: "I can audit your LinkedIn profile, but without your target role context I'll be giving generic advice instead of optimizing for how recruiters in your target space actually search. Want to run `kickoff` first so I can target the audit, or proceed with a general review?"
+- If the candidate has an interview within 48 hours: "You have an interview in [X] hours. LinkedIn optimization can wait — let's focus on `hype` / `prep` first. Come back to this after."
+
+---
+
+## Required Inputs
+
+- LinkedIn profile URL or full profile text (pasted sections)
+- Target role context (from coaching_state.md Profile, or ask)
+
+## Optional Inputs
+
+- Depth level: Quick Audit / Standard / Deep Optimization (default: Standard)
+- Specific sections to focus on (e.g., "just headline and about")
+
+---
+
+## Depth Levels
+
+| Level | When to Use | What It Covers |
+|---|---|---|
+| **Quick Audit** | Fast check, building a target list, or just wants the biggest wins | Headline + title + skills + about. Top 3 fixes only. |
+| **Standard** | Default. Full profile review. | All 9 sections. Section-by-section audit + content strategy overview. |
+| **Deep Optimization** | High-priority job search, major profile overhaul | All 9 sections + detailed content strategy + positioning consistency check (resume vs. LinkedIn vs. interview narrative) + Challenge Protocol (Level 5). |
+
+---
+
+## Logic / Sequence
+
+### Step 1: Profile Intake
+
+Ask for LinkedIn profile URL or pasted text. If URL provided, ask candidate to paste the relevant sections (the coach can't browse LinkedIn). Accept whatever format they provide — be flexible.
+
+### Step 2: Context Assembly
+
+Pull from coaching_state.md:
+- Target role(s) and seniority band
+- Resume Analysis (positioning strengths, concerns, story seeds)
+- Storybank (for earned secrets that should surface in About/Experience)
+- Active Coaching Strategy (bottleneck — if Differentiation is the gap, emphasize that in LinkedIn too)
+
+### Step 3: Section-by-Section Audit (9 sections)
+
+For each section, evaluate against its specific purpose:
+
+**1. Headline** (search + first impression)
+- Does it contain keywords recruiters search for in the target role?
+- Is it specific enough to differentiate (not "Passionate Leader" — concrete skills/domain)?
+- Does it signal seniority appropriately?
+- Character limit: 220 chars. Every word must earn its place.
+- Provide a rewritten headline with rationale.
+
+**2. Current Title + Company** (search weight)
+- Does the title match what recruiters search for?
+- If current title is non-standard ("Ninja", "Rockstar"), suggest the searchable equivalent.
+- Note: Can't change company-assigned title, but can adjust in headline.
+
+**3. Skills Section** (filterable search)
+- Are the right skills listed? (Skills are the ONLY filterable field in recruiter search.)
+- Are the top 3 pinned skills aligned with target role?
+- Are skills ordered by relevance to target, not alphabetically?
+- Provide a recommended skill list (top 10) with ordering rationale.
+
+**4. About Section** (search + credibility + differentiation)
+- First 3 lines visible before "see more" — do they hook?
+- Does it contain target keywords naturally (not keyword-stuffed)?
+- Does it tell a narrative, or is it a bullet list of skills? (Narrative wins.)
+- Does it surface earned secrets or a spiky POV from the storybank?
+- Is there a clear "what I do + what makes me different + what I'm looking for" structure?
+- Provide a rewritten About with rationale.
+
+**5. Experience Descriptions** (search + depth)
+- Are descriptions accomplishment-oriented (not responsibility-oriented)?
+- Do they contain searchable keywords?
+- Do they quantify impact where possible?
+- Are the most recent 2-3 roles fully fleshed out? (Older roles can be brief.)
+- For the most recent role: provide a rewritten description.
+
+**6. Photo + Banner** (click-through rate)
+- Photo: Professional, approachable, recent? (Can't see it, but provide guidance.)
+- Banner: Custom or default? Custom banners with a value prop or domain signal increase profile visit conversions.
+- Provide guidance on what a strong banner communicates.
+
+**7. Featured Section** (credibility when they visit)
+- Is it being used? Most candidates leave it empty.
+- What should go here: published work, key projects, media mentions, portfolio pieces, talks.
+- Provide 2-3 specific recommendations based on their resume/storybank.
+
+**8. Recommendations** (social proof)
+- How many? (3+ is baseline credibility.)
+- Are they from relevant people (managers, cross-functional partners, clients)?
+- Provide guidance on who to ask and how to make the ask.
+
+**9. URL + Completeness** (signals)
+- Custom URL set?
+- Profile completeness: all sections filled, education, certifications, volunteer?
+- Open to Work: on or off? When to use each setting.
+
+### Step 4: Positioning Consistency Check (Deep Optimization only)
+
+Cross-reference LinkedIn profile against:
+- Resume (from kickoff): Are the same positioning strengths leading? Are titles/descriptions consistent? Inconsistencies create doubt.
+- Interview narrative (from storybank + coaching strategy): Does the LinkedIn profile tell the same story the candidate tells in interviews?
+- Flag gaps: "Your resume leads with [X] but your LinkedIn leads with [Y]. A recruiter who reads both will notice."
+
+### Step 5: Content Strategy Overview (Standard + Deep)
+
+Not just the profile — how to use LinkedIn as a platform:
+- **Posting cadence**: 2-3 posts/week during active search. Consistency > volume.
+- **Content types that work**: Industry takes with personal angle, "here's what I learned" posts from real experience, PDF carousels with frameworks, commentary on industry news.
+- **Content types that don't work**: "Excited to announce" posts (low engagement), reposting without commentary, posting external links (kills reach).
+- **Engagement strategy**: Comment thoughtfully on posts by people at target companies and in target roles. This is higher-leverage than posting for getting noticed.
+- **What NOT to post**: Anything that signals desperation ("Looking for my next opportunity! Please help!"), anything controversial that could screen you out, anything that contradicts your positioning.
+
+Provide 3 specific post ideas based on their storybank and earned secrets.
+
+### Step 6: Challenge Protocol (Deep Optimization, Level 5 only)
+
+Run Challenge Protocol lenses against the LinkedIn profile:
+- **Assumption Audit**: What must be true for this profile to work? (e.g., "Assumes recruiters in your target space search for [keyword]. Do they?")
+- **Blind Spot Scan**: What can't you see about your own profile? (e.g., "You think your About section tells a story. From the outside, it reads as a list of capabilities.")
+- **Devil's Advocate**: If a recruiter was looking for reasons to skip your profile... (e.g., "Generic headline, no Featured section, 2 recommendations — this profile says 'I didn't try.'")
+- **Strengthening Path**: The single highest-leverage fix.
+
+---
+
+## Output Schema — Quick Audit
+
+```markdown
+## LinkedIn Quick Audit
+
+## Top 3 Fixes (in priority order)
+1. **[Section]**: [What's wrong] → [Specific fix with rewrite]
+2. **[Section]**: [What's wrong] → [Specific fix with rewrite]
+3. **[Section]**: [What's wrong] → [Specific fix with rewrite]
+
+## Quick Wins
+- [1-2 things that take <5 minutes and improve discoverability]
+
+**Recommended next**: `linkedin` (Standard) — get the full audit. **Alternatives**: `stories`, `prep [company]`
+```
+
+## Output Schema — Standard
+
+```markdown
+## LinkedIn Profile Audit: [Name]
+
+## Profile Score
+- Recruiter discoverability: [Strong / Moderate / Weak] — [1-line evidence]
+- Credibility on visit: [Strong / Moderate / Weak] — [1-line evidence]
+- Differentiation: [Strong / Moderate / Weak] — [1-line evidence]
+- Overall: [Strong / Needs Work / Weak]
+
+## Section-by-Section
+
+### Headline
+- Current: [quoted]
+- Assessment: [what works, what doesn't, search implications]
+- Recommended: [rewritten headline]
+- Why: [rationale — keyword targeting, differentiation, seniority signal]
+
+### About
+- Assessment: [hook strength, keyword presence, narrative vs. list, differentiation]
+- Recommended: [full rewritten About section]
+- Why: [rationale]
+
+### Skills
+- Assessment: [alignment with target role, top 3 pinned, missing keywords]
+- Recommended top 10: [ordered list with rationale]
+
+### Experience (most recent role)
+- Assessment: [accomplishment vs. responsibility oriented, keywords, quantification]
+- Recommended rewrite: [rewritten description]
+
+### [Other sections — briefer assessments + specific fixes]
+
+## Content Strategy Overview
+- Posting approach: [2-3 sentences]
+- 3 post ideas based on your background:
+  1. [specific idea with hook]
+  2. [specific idea with hook]
+  3. [specific idea with hook]
+
+## Priority Moves (ordered)
+1. [highest-impact fix — do this first]
+2. [second-highest]
+3. [third]
+
+**Recommended next**: `stories` — make sure your storybank feeds your LinkedIn narrative. **Alternatives**: `prep [company]`, `linkedin` (Deep Optimization)
+```
+
+## Output Schema — Deep Optimization
+
+```markdown
+## LinkedIn Deep Optimization: [Name]
+
+## Profile Score
+[same as Standard]
+
+## Section-by-Section
+[same as Standard, but all 9 sections get full treatment — not just headline/about/skills/experience]
+
+## Positioning Consistency
+- Resume ↔ LinkedIn: [aligned / gaps — specific gaps listed]
+- Interview narrative ↔ LinkedIn: [aligned / gaps — specific gaps listed]
+- Inconsistencies to resolve: [specific items]
+
+## Content Strategy
+[same as Standard, but expanded]
+- Engagement targets: [specific people/companies to engage with based on target roles]
+- Content calendar: [week 1-4 suggested cadence]
+
+## Challenge (Level 5 only)
+- Assumptions this profile rests on: [2-3]
+- Blind spots: [what you can't see about your own profile]
+- Devil's advocate: [strongest case for a recruiter to skip you]
+- Highest-leverage fix: [the one thing that changes everything]
+
+## Priority Moves (ordered)
+1. [highest-impact fix]
+2. [second]
+3. [third]
+4. [fourth]
+5. [fifth]
+
+**Recommended next**: `stories` — earned secrets from your storybank should surface in your About and Experience. **Alternatives**: `prep [company]`, `practice`
+```
+
+---
+
+## Coaching State Integration
+
+After running `linkedin`, save to coaching_state.md:
+
+```markdown
+## LinkedIn Analysis
+- Date: [date]
+- Depth: [Quick Audit / Standard / Deep Optimization]
+- Overall: [Strong / Needs Work / Weak]
+- Recruiter discoverability: [Strong / Moderate / Weak]
+- Credibility on visit: [Strong / Moderate / Weak]
+- Differentiation: [Strong / Moderate / Weak]
+- Top fixes pending: [1-3 line items]
+- Positioning gaps: [resume ↔ LinkedIn inconsistencies, if assessed]
+```

--- a/references/cross-cutting.md
+++ b/references/cross-cutting.md
@@ -219,6 +219,7 @@ At Level 5, the Challenge Protocol (`references/challenge-protocol.md`) activate
 - `progress` → Hard Truth (the single hardest thing the coach needs to say)
 - `hype` → Pre-Mortem (2-3 failure modes with prevention cues)
 - `feedback` Type B rejection → Rejection Leverage (retrospective lenses 1-3)
+- `linkedin` Deep Optimization → Profile Challenge (lenses 1, 2, 4, 5: Assumption Audit, Blind Spot Scan, Devil's Advocate, Strengthening Path — Pre-Mortem omitted as it doesn't apply to a static profile)
 
 **Avoidance Confrontation**: At Level 5, when avoidance patterns are detected (3+ instances of the same pattern — skipping competencies, choosing safe drills, changing subjects on weaknesses), name it directly: "I've noticed you've steered away from [topic] three times now. That's usually a signal that this is exactly where we need to go." At Levels 1-4, note in Coaching Notes and raise gently during meta-checks.
 
@@ -249,6 +250,7 @@ Commands produce better output when they have data from other commands. This tab
 | `thankyou` | Debrief data, Interview Loops, interviewer intel | All (asks candidate for callbacks) | — |
 | `progress` | 3+ scored sessions, outcome data, Interview Intelligence (Question Bank, Feedback, Patterns) | Works with 1-2 sessions (reduced — see minimum data thresholds), Interview Intelligence (loses question-type performance and accumulated pattern analysis) | At least 1 scored session |
 | `negotiate` | Interview Loops, outcome log | Both (collects offer details fresh) | Offer details |
+| `linkedin` | Profile from `kickoff`, storybank, Resume Analysis, Active Coaching Strategy | Profile (gives generic audit without target role context), storybank (can't surface earned secrets, flags the gap) | LinkedIn profile text (pasted or described) |
 | `reflect` | Full coaching state with score history and outcomes | Score history (narrates from limited data) | — |
 
 **How to use this**: When running a command that would benefit from missing data, mention the gap briefly and offer to fill it — don't refuse to run. Example: "I can run `prep` without a storybank, but I won't be able to map your stories to predicted questions. Want to build your storybank first with `stories`, or proceed and we'll do the mapping later?"


### PR DESCRIPTION
## Summary
- New `linkedin` command for LinkedIn profile optimization — treats LinkedIn as its own platform (recruiter boolean search, algorithm distribution, section-specific impact) rather than a resume mirror
- Three depth levels: Quick Audit (top 3 fixes), Standard (9-section audit + content strategy), Deep Optimization (+ positioning consistency + Challenge Protocol at Level 5)
- Full SKILL.md integration: command registry, file routing, mode detection, multi-step intent, state triggers, coaching_state schema with migration, and Challenge Protocol registration in cross-cutting.md

## Test plan
- [ ] Verify `linkedin.md` loads correctly when command is detected
- [ ] Verify Mode Detection item 7 (LinkedIn intent) routes correctly
- [ ] Verify Multi-Step Intent "I'm starting my job search" triggers kickoff → stories → linkedin sequence
- [ ] Verify Schema Migration Check adds LinkedIn Analysis section to existing coaching_state.md files
- [ ] Verify `help` command shows linkedin in Interview Prep section with correct highlights
- [ ] Verify Challenge Protocol fires only at Deep Optimization + Level 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)