### PR TITLE
skill: add collapsible toggle format to coaching_state template — readability

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,135 @@
+# interview-coach-skill -- Claude Code Session Context
+
+This file helps Claude Code understand the repo at the start of any session.
+
+---
+
+## What This Repo Is
+
+A Claude skill prompt — not software. The main product is `SKILL.md` (~47K), a comprehensive interview coaching system with 23 commands covering the full interview lifecycle. The skill is used by renaming `SKILL.md` to `CLAUDE.md` in the user's local clone, then running Claude Code.
+
+This repo contains the skill prompt, version history, reference materials, and release snapshots. No code, no dependencies, no build tooling.
+
+---
+
+## Key Files
+
+| File/Folder | Purpose |
+|---|---|
+| `SKILL.md` | The skill prompt (~47K). Main product. Do NOT restructure without explicit direction. |
+| `VERSIONS.md` | Version roadmap: shipped versions (v1-v3), planned versions (v4+), and feature details |
+| `references/` | Supporting reference files loaded by SKILL.md commands (transcript formats, rubrics, examples, etc.) |
+| `releases/` | Tagged release snapshots |
+| `README.md` | Public-facing overview, setup instructions, command reference |
+| `.claude/CLAUDE.md` | This file (session context for repo maintenance — separate from root CLAUDE.md which is the active skill copy) |
+
+---
+
+## Standards
+
+### Commit Format
+
+Every commit must follow: `<type>: <what changed> — <why>`
+
+Types: `skill`, `refs`, `docs`, `chore`, `fix`
+
+Examples:
+```
+skill: add salary command — comp strategy coaching for offer negotiation
+refs: update transcript-formats.md — add Granola format support
+docs: update README command table — reflect v3 additions
+fix: schema migration gap — older coaching_state files now fully upgrade
+chore: update VERSIONS.md — mark v3 as shipped
+```
+
+### PR Creation (mandatory)
+
+After every `git push`, immediately create a PR. Do not stop after push.
+
+**If the session ends without a PR after a push: this is a failure.** If the user says "we're done" or tries to close the session after a push without a PR having been created, flag it immediately before stopping: *"PR not created — do it now or the session is incomplete."*
+
+```bash
+gh pr create \
+  --title "<type>: <concise description>" \
+  --body "$(cat <<'EOF'
+## What
+- <bullet: files changed and what changed in each>
+
+## Why
+<1-3 sentences of context/goal>
+
+## How to verify
+- <concrete confirmation method>
+EOF
+)"
+```
+
+Rules:
+- Title must follow the commit convention above
+- Body must use the What / Why / How to verify format
+- The PR URL printed by `gh pr create` is the only action required from the user — they click Merge, nothing else
+- Do NOT skip this step under any circumstance
+
+### Changelog Rule
+
+Before creating any PR, check if it contains qualifying commits:
+
+1. Run `git log --format="%ad %s" --date=short origin/main..HEAD`
+2. If ANY commit has types `skill:`, `refs:`, `fix:` — draft a changelog entry in `changelog.md`
+3. Include the changelog update in the same PR
+
+Skip only if every commit is: `docs:` / `chore:` / merge
+
+---
+
+## How We Work
+
+1. **Read before creating** — check if a file already exists before writing a new one. Avoid duplication.
+2. **`git mv`, not `cp` + `rm`** — always use `git mv` when moving files. Preserves history.
+3. **No orphaned files** — if content migrates, delete the source. No redirects nobody reads.
+4. **One focused thing per session** — mixing concerns inflates blast radius and muddies git history. Resist scope creep.
+5. **Auto-derive, don't ask** — if data is inferable from context, use it. Ask only when genuinely ambiguous. One question, not several.
+6. **Deferred work needs persistent markers** — verbal instructions to "do it next time" vanish between sessions. Write a flag (TODO, `[deferred]` tag); detect the flag at session start.
+7. **Fix conflicts autonomously** — when merge conflicts, workflow failures, or broken states occur, fix them directly without surfacing the problem to the user. Exception: when resolution requires credentials or out-of-band action the user controls.
+8. **Build mechanisms, not habits** — every recurring action must have: (a) a clear trigger (not manual memory), (b) consistent execution when the trigger fires, (c) a defined expected outcome, (d) retry logic (up to N attempts) when the outcome isn't met, (e) a failure notification if retries are exhausted — never fail silently.
+
+---
+
+## Session Kickoff Protocol
+
+At the start of every session, before doing anything else:
+
+1. Read this file (`CLAUDE.md`)
+2. Read `VERSIONS.md` — check current shipped version and any in-progress work
+3. Run `git log --oneline -10` to see recent changes
+4. State the session goal before touching anything
+
+---
+
+## End of Session
+
+Before closing any session:
+
+1. Summarize what was done
+2. Update `VERSIONS.md` if `SKILL.md` was modified (version bump or roadmap update)
+3. Update `changelog.md` if qualifying changes were made
+4. Verify a PR was created for every push this session
+5. Flag any deferred work with persistent markers (TODO, `[deferred]` tag)
+
+---
+
+## What NOT to Do
+
+- Do not restructure `SKILL.md` without explicit direction — it is 47K and carefully structured across 23 commands with cross-references
+- Do not create software files (no package.json, no .py, no databases)
+- Do not add dependencies or build tooling
+- Do not modify `references/` files without checking which SKILL.md commands depend on them
+- Do not push directly to main without the user's direction
+
+---
+
+## Related Repos
+
+- `christophecapel/myOS` — daily OS, STAR library (`careerOS/star-library/`)
+- `christophecapel/job-hunting` — opportunities, coaching_state.md (symlinked from here), interview prep
+- `christophecapel/portfolio` — PM portfolio case studies

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## What
+<!-- Bullet list: which files changed and what changed in each -->
+-
+
+## Why
+<!-- The context or goal driving this change. 1-3 sentences. -->
+
+## How to verify
+<!-- How to confirm the change is correct. e.g. "grep for X finds no results outside Y" -->
+-

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 # Personal coaching data — contains stories, scores, interview targets, and concerns
 coaching_state.md
 
-# Active skill file (created by copying SKILL.md during setup)
-CLAUDE.md
+# Active skill file at root (created by copying SKILL.md during setup)
+# Scoped to root only — .claude/CLAUDE.md is the repo session context
+/CLAUDE.md

--- a/SKILL.md
+++ b/SKILL.md
@@ -118,16 +118,21 @@ Last updated: [date]
 [rows — compact index. Use Count tracks total times used in real interviews (incremented via debrief). Full column spec in references/storybank-guide.md — the guide adds Impact, Domain, Risk/Stakes, and Notes. Add extra columns as stories are enriched.]
 
 ### Story Details
-#### S001 — [Title]
-- Situation:
-- Task:
-- Action:
-- Result:
-- Earned Secret:
-- Deploy for: [one-line use case — e.g., "leadership under ambiguity questions"]
-- Version history: [date — what changed]
 
-[repeat for each story]
+<details>
+<summary><strong>S001 — [Title]</strong></summary>
+
+- **Situation:**
+- **Task:**
+- **Action:**
+- **Result:**
+- **Earned Secret:**
+- **Deploy for:** [one-line use case — e.g., "leadership under ambiguity questions"]
+- **Version history:** [date — what changed]
+
+</details>
+
+[repeat for each story — each wrapped in its own `<details>` toggle]
 
 ## Score History
 ### Historical Summary (when table exceeds 15 rows, summarize older entries here)
@@ -162,11 +167,16 @@ Last updated: [date]
 [Source: recruiter/interviewer/hiring-manager. Keep verbatim when possible.]
 
 ### Company Patterns (learned from real experience)
-#### [Company Name]
+
+<details>
+<summary><strong>[Company Name]</strong></summary>
+
 - Questions observed: [types and frequency]
 - What seems to matter: [observations from real data]
 - Stories that landed / didn't: [S### IDs]
 - Last updated: [date]
+
+</details>
 
 ### Historical Intelligence Summary
 [Narrated summary when subsections exceed archival thresholds]
@@ -177,7 +187,10 @@ Last updated: [date]
 - Revisit queue: [weaknesses to resurface]
 
 ## Interview Loops (active)
-### [Company Name]
+
+<details>
+<summary><strong>[Company Name]</strong></summary>
+
 - Status: [Decoded / Researched / Applied / Interviewing / Offer / Closed]
 - Rounds completed: [list with dates]
 - Round formats:
@@ -193,6 +206,8 @@ Last updated: [date]
 - Fit signals: [1-2 lines on what drove the verdict]
 - Structural gaps: [gaps that can't be bridged with narrative, if any]
 - Date researched: [date, if `research` was run]
+
+</details>
 
 ## Active Coaching Strategy
 - Primary bottleneck: [dimension]
@@ -319,7 +334,16 @@ Last updated: [date]
 
 ## Coaching Notes
 [Freeform observations that don't fit structured fields — things the coach should remember between sessions]
-- [date]: [observation — e.g., "candidate freezes in panel formats," "gets defensive about short tenure at X," "prefers morning interviews," "mentioned they interview better after coffee"]
+
+<details>
+<summary><strong>[date]</strong> — [short summary of first note]</summary>
+
+- [observation 1]
+- [observation 2]
+
+</details>
+
+[repeat for each date — group same-date notes within a single toggle]
 ```
 
 ### State Update Triggers
@@ -347,6 +371,8 @@ Write to `coaching_state.md` whenever:
 - reflect archives the coaching state (add Status: Archived header)
 - Meta-check conversations (record candidate's response and any coaching adjustment to Meta-Check Log)
 - Any session where the candidate reveals coaching-relevant personal context — preferences, emotional patterns, interview anxieties, scheduling preferences, etc. (add to Coaching Notes)
+
+**Formatting rule for collapsible sections:** When adding new entries to Story Details, Company Patterns, Interview Loops, or Coaching Notes, always wrap each new entry in `<details><summary>...</summary>...</details>`. Bold STAR labels in Story Details (**Situation:**, **Task:**, **Action:**, **Result:**) and key metadata labels (**Earned Secret:**, **Deploy for:**, **Version history:**). For Coaching Notes, group same-date entries within a single toggle; if adding to an existing date's toggle, append inside it.
 
 ---
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to the interview-coach-skill. Anti-chronological.
+
+---
+
+## 2026-03-12
+
+- `docs:` add CLAUDE.md, changelog.md, PR template — standards alignment across all repos
+
+## 2026-03-11
+
+- `skill:` v3 Full Lifecycle — 7 new examples, release notes, cross-command wiring, README update
+
+## 2026-03-10
+
+- `fix:` schema migration gaps — older coaching_state.md files fully upgrade
+- `skill:` audit-driven improvements — 28 enhancements across all 23 commands
+
+## 2026-03-09
+
+- `skill:` add decode, present, and salary commands — JD analysis, presentation coaching, comp strategy
+- `skill:` add pitch and outreach commands — positioning statements, networking outreach coaching
+
+## 2026-03-08
+
+- `skill:` add resume command — holistic resume optimization with ATS, recruiter scan, bullet rewrites
+- `skill:` add linkedin command — profile optimization with recruiter search mechanics
+
+## 2026-03-07
+
+- `skill:` v2 Coaching Depth — challenge protocol, guided flow, bulletproof polish
+- `skill:` add Coaching Depth v2 — transcript formats, story mapping, calibration, company intelligence


### PR DESCRIPTION
## What
- `SKILL.md`: Updated coaching_state.md format template — Story Details, Company Patterns,
  Interview Loops, and Coaching Notes now use HTML `<details>/<summary>` collapsible toggles
- Bolded STAR keywords and key metadata labels in Story Details template
- Added formatting rule to State Update Triggers so all future writes follow the toggle pattern

## Why
coaching_state.md in job-hunting now uses toggles for readability. Without updating the
skill template, any new story/company/loop/note added by the skill would revert to the
old flat format and break the pattern.

## How to verify
- Read the coaching_state.md Format section in SKILL.md — confirm all four sections use toggles
- Confirm STAR labels are bolded in Story Details template
- Confirm State Update Triggers includes the new formatting guidance
