### PR TITLE
Add markdown formatting rules for coaching_state.md writes

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -348,6 +348,15 @@ Write to `coaching_state.md` whenever:
 - Meta-check conversations (record candidate's response and any coaching adjustment to Meta-Check Log)
 - Any session where the candidate reveals coaching-relevant personal context — preferences, emotional patterns, interview anxieties, scheduling preferences, etc. (add to Coaching Notes)
 
+### Markdown Formatting Rules (enforced on every state write)
+
+Every write to `coaching_state.md` must follow these rules to ensure correct rendering on GitHub (CommonMark):
+
+- **Blank line before headings:** Always insert a blank line before any `##` or `###` heading. Without it, the heading renders as inline text.
+- **Blank line after `</details>`:** Always insert a blank line after any `</details>` closing tag. Content immediately after a closing tag may not render correctly.
+- **Table separator rows:** Every markdown table must have a separator row (`|---|---|...`) immediately after the header row. A header row without a separator renders as plain text, not a table.
+- **Nested `<details>` blocks:** When content belongs within a parent `<details>` toggle (e.g., Take-Home Prep within a company's Interview Loop entry), place the nested `<details>` block before the parent's `</details>` tag, not as a sibling.
+
 ---
 
 ## Non-Negotiable Operating Rules


### PR DESCRIPTION
## Summary
- Adds a "Markdown Formatting Rules" section under State Update Triggers in SKILL.md
- Enforces blank lines before headings, blank lines after `</details>`, table separator rows, and proper `<details>` nesting
- Prevents a class of formatting bugs where AI-generated markdown renders correctly in some parsers but breaks on GitHub's strict CommonMark

## Context
Discovered multiple rendering issues in a coaching_state.md file caused by incremental AI writes that omitted blank lines before headings, missed table separator rows, and placed nested `<details>` blocks as siblings instead of children. These rules codify the fix as a mechanism rather than relying on the AI to remember.

## Test plan
- [ ] Verify the new section appears under State Update Triggers in SKILL.md
- [ ] Run a coaching session that writes to coaching_state.md and confirm the output follows the formatting rules
- [ ] Check coaching_state.md renders correctly on GitHub Preview after a session

🤖 Generated with [Claude Code](https://claude.com/claude-code)