### PR TITLE
feat: add negotiation-protocol — Warwick framework for comp coaching

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ For both options, the coach will ask for your resume, target role, and timeline 
 
 | Command | Purpose | Typical Output |
 |---|---|---|
-| `salary` | Early/mid-process comp coaching (3 depth levels) | Comp research guidance, range construction, stage-specific scripts, total comp education, salary history handling |
+| `salary` | Early/mid-process comp coaching (3 depth levels) | Comp research guidance, range construction, stage-specific scripts, total comp education, salary history handling. Hands off to `negotiate` at Stage 5 (offer received) with Warwick negotiation principles pre-loaded. |
 | `hype` | Pre-interview confidence + psychological warmup. At Level 5: includes a pre-mortem with failure prevention | 60-second reel + 3x3 sheet + focus cue + recovery playbook |
 
 ### Practice and Simulation
@@ -156,7 +156,7 @@ For both options, the coach will ask for your resume, target role, and timeline 
 | `progress` | Trends, self-calibration, outcome tracking, scoring calibration. At Level 5: includes a Hard Truth section | Self-assessment delta + outcome correlation + scoring drift detection + root cause tracking + coaching meta-check |
 | `feedback` | Capture recruiter feedback, outcomes, corrections, context, or coaching meta-feedback. At Level 5: rejections include structured leverage extraction | State updates + next step suggestion |
 | `thankyou` | Post-interview follow-up drafts | Thank-you note + variants |
-| `negotiate` | Post-offer negotiation coaching | Offer analysis + strategy + scripts + specific language |
+| `negotiate` | Post-offer negotiation coaching | Offer analysis, equity evaluation, multi-round negotiation strategy, non-standard terms (4-day weeks, IP carve-outs, performance triggers), comp call transcript scoring, escalation playbook |
 | `reflect` | Post-search retrospective + archive | Journey arc, breakthroughs, transferable skills, archived state |
 | `help` | Show command menu (context-aware) | Full command list + recommended next based on coaching state |
 
@@ -345,6 +345,20 @@ Then provide offer details, competing offers, and ideal outcome. Get:
 - Negotiation strategy with priority ordering
 - Exact scripts for the conversation
 - Fallback language for pushback
+
+### 12) Multi-round comp negotiation
+
+```text
+1. Offer received                       → negotiate (initial strategy + scripts)
+2. First call happens, counterpart
+   pushes back → paste transcript       → analyze (comp-call scoring mode,
+                                          not interview rubric)
+3. Scorecard reveals gaps               → negotiate (multi-round coaching
+                                          for follow-up call)
+4. Repeat until closed
+```
+
+The Warwick framework (see `references/negotiation-protocol.md`) scores comp calls on 5 negotiation-specific dimensions (Anchoring Discipline, Information Gathering, WE Framing, Silence & Pacing, Creative Solutions) rather than the standard interview rubric, and provides multi-round coaching for reframing after pushback, non-standard term pivots (Cap Conversion), and escalation ladders.
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -406,7 +406,8 @@ Execute commands immediately when detected. Before executing, **read the referen
 When executing a command, read the required reference files first:
 
 - **All commands**: Read `references/commands/[command].md` for that command's workflow, and `references/cross-cutting.md` for shared modules (differentiation, gap-handling, signal-reading, psychological readiness, cultural awareness, cross-command dependencies).
-- **`analyze`**: Also read `references/transcript-processing.md`, `references/transcript-formats.md`, `references/rubrics-detailed.md`, `references/examples.md`, `references/calibration-engine.md`, and `references/differentiation.md` (when Differentiation is the bottleneck).
+- **`analyze`**: Also read `references/transcript-processing.md`, `references/transcript-formats.md`, `references/rubrics-detailed.md`, `references/examples.md`, `references/calibration-engine.md`, and `references/differentiation.md` (when Differentiation is the bottleneck). Also read `references/negotiation-protocol.md` Section "Comp Call Transcript Analysis" when the transcript contains 3+ comp discussion markers (see detection logic in `references/commands/analyze.md`).
+- **`negotiate`**: Also read `references/negotiation-protocol.md` for the cross-cutting Warwick framework (per-phase GAINS detail, core principles beyond GAINS, Zombie Number, multi-round coaching, non-standard terms catalog, comp call scoring dimensions, and competence guardrails). If the candidate brings a comp call transcript, also read `references/commands/analyze.md` for the Comp Call Detection step.
 - **`practice`**, **`mock`**: Also read `references/role-drills.md`. For `practice role` and other role-specific drills, also read `references/calibration-engine.md` Section 5 (role-drill score mapping). For `mock`, also read `references/calibration-engine.md` (mock produces scores and benefits from calibration guidance).
 - **`prep`**: Also read `references/story-mapping-engine.md` when storybank exists.
 - **`linkedin`**: Also read `references/differentiation.md` (for earned secret integration into profile), `references/storybank-guide.md` (for storybank data to feed into About/Experience rewrites).
@@ -415,7 +416,7 @@ When executing a command, read the required reference files first:
 - **`outreach`**: Also read `references/differentiation.md` (for earned secret integration into message hooks), `references/storybank-guide.md` (for story selection to build credibility in messages).
 - **`decode`**: Also read `references/cross-cutting.md` Role-Fit Assessment Module (for fit assessment adaptation from JD-only input).
 - **`present`**: Also read `references/storybank-guide.md` (for supporting stories to incorporate into presentations), `references/commands/prep.md` Section "Interview Format Taxonomy" (for format context when presentation is a known interview round format).
-- **`salary`**: Also read `references/commands/negotiate.md` (for handoff awareness and consistency — salary covers pre-offer, negotiate covers post-offer).
+- **`salary`**: Also read `references/commands/negotiate.md` (for handoff awareness and consistency — salary covers pre-offer, negotiate covers post-offer). Also read `references/negotiation-protocol.md` Sections "Core Principles" and "The Zombie Number" when candidate reaches Stage 4 (pre-offer positioning) — the candidate needs negotiation mindset before the offer arrives.
 - **`stories`**: Also read `references/storybank-guide.md` and `references/differentiation.md`.
 - **`progress`**: Also read `references/calibration-engine.md`.
 - **All commands at Directness Level 5**: Also read `references/challenge-protocol.md`.
@@ -511,6 +512,7 @@ Use first match:
 16. Practice intent -> `practice`
 17. Progress/pattern intent -> `progress`
 18. "I got an offer" / offer details present -> `negotiate`
+18b. Comp call transcript present (3+ comp markers detected, see `references/commands/analyze.md` Comp Call Detection) -> `negotiate` + `analyze` (comp-call scoring mode against `references/negotiation-protocol.md`, not the standard interview rubric)
 19. "I'm done" / "accepted" / "wrapping up" -> `reflect`
 20. Otherwise -> ask whether to run `kickoff` or `help`
 
@@ -532,6 +534,7 @@ When a candidate's request implies a sequence of commands, state the plan and ex
 | "I want to optimize my application materials" | `pitch` (if no Positioning Statement) → `resume` → `linkedin` (if not already done) |
 | "I want to start networking" / "How do I reach out to people?" | `pitch` (if no Positioning Statement) → `linkedin` (Quick Audit, if not already done) → `outreach` |
 | "I got rejected from [company]" | `feedback` Type B → `progress` targeting insights (if 3+ outcomes) |
+| "I negotiated but they pushed back" / "follow-up call scheduled" | `negotiate` (multi-round mode — loads `references/negotiation-protocol.md` Multi-Round Negotiation section) |
 
 **Behavior**: When you detect a multi-step intent, briefly state the plan ("I'll walk you through research, then prep, then concerns for [company]"), execute the first step, and at each transition point offer the next step naturally: "That covers the research. Ready to move into full prep?" If the candidate wants to skip or redirect, respect that. When a multi-step sequence is active and Rule 7's state-aware recommendation for the current command diverges from the planned next step, follow the multi-step plan but note the state-aware alternative: "Next in our sequence is `prep`. (Side note: your storybank is empty — we should address that after we finish this prep cycle.)"
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -123,6 +123,32 @@ Three new commands for the artifacts candidates build before they ever interview
 
 ---
 
+## v[N] — Negotiation Protocol (Warwick Framework) — Proposed
+
+**Status:** Proposed (PR pending)
+
+*PR author's note: please slot this entry where it fits your roadmap — proposed as v3.1 or as a v4 prerequisite. It extends (rather than replaces) the condensed GAINS summary added to `negotiate.md` in the Lenny integrations pass.*
+
+### What's New
+
+- **`references/negotiation-protocol.md`** (NEW) — Cross-cutting negotiation framework based on Jacob Warwick's executive negotiation methodology (Lenny's Podcast + Execs and the City Substack). Loaded by `negotiate`, `salary` (Stage 4+), and `analyze` (comp call transcripts). Includes: per-phase GAINS detail (extends the existing summary in `negotiate.md`), 10 core principles with scripts (beyond GAINS), Zombie Number detection, multi-round negotiation guidance, non-standard terms catalog with Golden Cage test and Cap Conversion table, comp call transcript scoring (5 negotiation-specific dimensions), and competence guardrails.
+
+- **`negotiate` extensions** — Five new sections: Multi-Round Negotiation (follow-up call coaching after pushback), Non-Standard Terms (4-day weeks, IP carve-outs, performance triggers, sign-on bonuses, additional leave, title checkpoints), Escalation Playbook (delay card through walk-away), Post-Close Legal Review (register shift for paperwork phase), Comp Call Transcript Analysis (integration with `analyze` for scoring).
+
+- **`analyze` comp call detection** — Auto-detects comp call transcripts (3+ comp markers) and routes to negotiation-specific scoring dimensions instead of the standard interview rubric.
+
+- **`salary` handoff enhancement** — Pre-loads Warwick negotiation principles at Stage 4 so candidates enter the offer stage with the right mindset.
+
+- **Worked example** — Multi-round comp negotiation transcript scored across 2 calls with cross-call pattern analysis.
+
+### Why
+
+The skill had comprehensive interview prep and analysis but limited depth on the most consequential stage: compensation negotiation. The GAINS summary added in the Lenny integrations pass covered the headline moves; this version adds the tactical depth — per-phase GAINS detail, core principles beyond GAINS, multi-round coaching, non-standard term pivots, and comp call scoring dimensions. Cross-references to the existing GAINS summary ensure no duplication.
+
+**Key files**: `references/negotiation-protocol.md` (new), `references/commands/negotiate.md` (5 new sections appended), `references/commands/analyze.md` (Comp Call Detection gate), `references/examples.md` (negotiation scorecard example), `SKILL.md` (Mode Detection 18b, File Routing, Multi-Step Intent), `README.md` (command table + workflow 12)
+
+---
+
 ## v4: Interaction Model (planned)
 
 **Thesis**: Now that the coaching brain is strong and comprehensive, change *how* candidates interact with it.

--- a/references/commands/analyze.md
+++ b/references/commands/analyze.md
@@ -11,6 +11,40 @@ If a candidate drops a transcript without having run `kickoff` first, don't refu
 3. **Proceed with analysis.** Use inferred or stated seniority band for calibration. Skip story-mapping sections (no storybank exists). Skip cross-referencing with prep data.
 4. **After the analysis, suggest kickoff**: "I've scored this transcript, but I'm working without your full context — no storybank, no coaching history, no target company profile. If you want to get the most from this system, run `kickoff` to set up your coaching profile. Your analysis scores will carry forward."
 
+### Comp Call Detection
+
+Before running the standard transcript analysis below, scan for compensation discussion markers. Comp calls are structurally different from interviews and should not be scored on the interview rubric.
+
+#### Detection Logic
+
+Count occurrences of these markers in the transcript (case-insensitive):
+
+`salary`, `base`, `equity`, `bonus`, `offer`, `package`, `counter`, `negotiate`, `compensation`, `vesting`, `sign-on`, `stock`, `RSU`, `pro-rate`, `band`, `range`, `budget`
+
+**If 3+ distinct markers found:** route to negotiation-specific analysis.
+- Load `references/negotiation-protocol.md`
+- Score against the 5 Negotiation Performance Dimensions (not the standard 5-dimension interview rubric)
+- Output the Negotiation Performance Scorecard
+- Write results to `Comp Strategy` section of `coaching_state.md` (not Score History)
+
+**If fewer than 3 markers:** proceed with the standard Step Sequence below.
+
+#### Why This Matters
+
+Comp calls are structurally different from interviews:
+- Success is measured by package outcome, not answer quality
+- The "interviewer" is a counterpart, not an evaluator
+- Silence, timing, and information control matter more than substance/structure
+- The standard rubric (Substance, Structure, Relevance, Credibility, Differentiation) doesn't map to negotiation performance
+
+Scoring a comp call on the interview rubric would give meaningless results. The negotiation dimensions (Anchoring Discipline, Information Gathering, WE Framing, Silence & Pacing, Creative Solutions) measure what actually matters.
+
+#### Edge Cases
+
+- **Mixed transcript (interview + comp discussion in same call):** If the transcript contains both interview questions AND comp markers, score the interview portion with the standard rubric and the comp portion with negotiation dimensions. Note both in the output.
+- **Recruiter screen with salary question:** If the transcript is a recruiter screen where salary came up briefly (1-2 markers, not 3+), score as a standard interview but add a note: "Salary handling: [assessment of how the candidate handled the comp question]."
+- **Post-offer call that's purely admin (start date, paperwork):** Low marker count, no negotiation. Standard analysis won't apply either. Flag as "administrative call — no analysis applicable."
+
 ### Step Sequence
 
 1. **Check for existing debrief data.** If `coaching_state.md` has a `debrief` entry for this interview (same company/round), pull it in as context — the candidate's emotional read, interviewer signals they noticed, stories they used, and their same-day self-assessment. This is valuable because debrief captures impressions while fresh, before memory reconstruction smooths things over. Note any discrepancies between debrief impressions and what the transcript actually shows — these deltas are coaching gold.

--- a/references/commands/negotiate.md
+++ b/references/commands/negotiate.md
@@ -122,6 +122,180 @@ When the candidate has more than one offer:
 - **Decision framework**: Help the candidate weight factors beyond comp — growth trajectory, learning potential, manager quality, work-life balance, company stability. As Dragova notes: "Getting paid more up-front doesn't always mean you'll make the most overall. Plan carefully." Consider how promotions work, manager influence, product/team visibility, and company brand value to the candidate's future earnings trajectory. The highest-paying offer isn't always the best offer.
 - **Negotiation order**: Dragova's sequence — start with overall total compensation (single number), then equity adjustments in a follow-up round, then signing bonus last.
 
+---
+
+*The sections below extend Jacob Warwick's executive negotiation framework (via Lenny's Podcast + Execs and the City Substack), building on the GAINS summary above. Full cross-cutting protocol in `references/negotiation-protocol.md`.*
+
+### Multi-Round Negotiation
+
+When the initial ask doesn't close and a follow-up call is scheduled.
+
+#### When This Applies
+
+The candidate has made their ask (comp, equity, non-standard terms), the counterpart hasn't said yes, and a follow-up conversation is scheduled. This is structurally different from the initial negotiation:
+- The counterpart has had time to think and consult others
+- Their position may have hardened OR softened
+- The candidate's framing from the first call is already on record
+- Power dynamics have shifted based on who deferred to whom
+
+#### Coaching Sequence
+
+1. **Debrief the first call.** Before coaching the follow-up, analyze what happened: What was asked? What was the response? What objections were raised? What language did the counterpart use? Score against the Negotiation Performance Dimensions in `references/negotiation-protocol.md` if a transcript is available.
+
+2. **Diagnose the counterpart's position.** Map their response to one of:
+   - **Deferral to authority** ("I need to check with my co-founder/board") — they may be on your side but can't approve alone. Coach: make them your advocate. "Would you be willing to take this framing to [authority]?"
+   - **Principled objection** ("we value flexibility/trust/outcomes over rigidity") — they're using values language to avoid commitment. Coach: name the asymmetric risk. Use "can you help me understand?"
+   - **Stacked objections** (3+ concerns that all lead to the same conclusion) — underlying concern is preserving unilateral discretion. Coach: name the pattern. "Is there a single thing that would unlock this?"
+   - **Hard no** ("this is a fairly clear position for us") — genuine boundary. Coach: accept gracefully OR walk, depending on candidate's floor.
+
+3. **Reframe, don't repeat.** If the first call's framing didn't land, don't say "that was the wrong framing." Say "Let me be clearer on this." Reframe without self-blame. See `references/negotiation-protocol.md` (Multi-Round Negotiation → Reframing after pushback) for a library of common framing misfires and their repairs.
+
+4. **Structure the follow-up as: opener (signal deal is done) → acknowledge their position → make your adjusted ask → close.** The follow-up should feel like a continuation, not a restart.
+
+5. **Listen-first structure.** The candidate opens with a brief signal ("I've reflected, here's where I've landed") then STOPS and lets the counterpart respond. The counterpart's opening words reveal which scenario the candidate is in. Match the response to the scenario, don't deliver a pre-planned pitch.
+
+#### Coaching the Opener
+
+The follow-up opener must accomplish three things in under 30 seconds:
+- Signal the deal is happening (reduce counterpart anxiety)
+- Acknowledge their position from last time (validate without conceding)
+- Set expectations for what's coming (small items, not a re-negotiation)
+
+Example framework: "Thanks for the patience. I've reflected on what we discussed. I heard you on [their position]. I've got [a proposal / a couple of things] I think you'll be aligned with, and then we can finalize. How does that sound?"
+
+#### Key Coaching Points
+
+- **Know when to stop.** If the counterpart comes back having advocated harder than expected (unsolicited improvements, above-ask concessions, named "good faith"), the correct move is to accept with gratitude and close. Pushing after they over-delivered signals you'll never be satisfied. The coach should assess: did they advocate or merely respond? If advocate: close warm. If merely respond: probe further. Full principle in `references/negotiation-protocol.md` (Core Principle #10).
+- **The counterpart's words from the previous call are ammunition.** If they offered something (a schedule structure, a development budget, a way of working), reference THEIR words back to them. "You mentioned you'd support X. I'd love to build on that."
+- **"Walk me through what that looks like from your side"** is the strongest follow-up play for informal commitments. The counterpart describes the arrangement in their own words, then the candidate mirrors back and asks for documentation.
+- **Every informal commitment needs a documentation mechanism.** Ranked from strongest to weakest: contract clause > offer letter reference > email confirmation > verbal alignment. Coach the candidate to push for the highest they can get without reopening a closed debate.
+
+### Non-Standard Terms
+
+Senior hires often negotiate beyond base/equity/bonus. The coach should proactively surface these when traditional levers are capped.
+
+#### When to Surface
+
+- Candidate says "base is at their ceiling" or "equity is constrained"
+- Company is bootstrapped, early-stage, or PE-backed with rigid bands
+- Candidate has lifestyle/work-structure requirements beyond comp
+- Counterpart has signaled flexibility ("we're a startup, we can be creative")
+
+#### Term Catalog
+
+| Term | When to raise | How to frame | Common pushback | Counter |
+|---|---|---|---|---|
+| **Reduced schedule (4-day week, 9-day fortnight)** | After base/equity directionally aligned | "This is how I stay at the level that delivers the outcomes you hired me for" | "We've never done this" / "What about the team?" | "Not unusual for senior leadership. The output speaks for itself." If fully declined, a fallback is asking for one protected focus day per week (lighter lift, less precedent). |
+| **Professional development budget** | When counterpart offers it, or as part of package rebalancing | "Annual, discretionary, referenced in the offer letter" | "We don't have a formal program" / low anchor | Counter-anchor with rationale: "Categories like tooling, training, and conferences move fast enough to justify a recurring budget line" |
+| **IP / moonlighting carve-out** | Contract stage, not negotiation call | "Standard for senior hires — protects both sides" | "Our standard contract covers this" | Check the contract's IP assignment clause; push for pre-existing work schedule if needed |
+| **Performance-based equity triggers** | When initial equity is capped | "If I deliver X outcome, what does that unlock?" | "We don't have a mechanism yet" | "Can we build one? Even informal milestones tied to equity top-ups." |
+| **Sign-on bonus** | When base is capped and candidate has a gap to bridge | One-time payment; amortize over expected tenure | "We don't do sign-on bonuses" | "Even a small one bridges the gap between offer and market. It's one-time, not ongoing." |
+| **Additional leave** | When work-life balance matters, OR when base is capped and leave is an easier ask for the company (often true at startups — see Cap Conversion in `references/negotiation-protocol.md`) | "Leaders who don't burn out stay longer" OR as convertible leverage if the leave ask can't land | "Everyone gets X weeks" | "This is a leadership-level term, not a company-wide policy change. If leave can't move, can we look at the base or a sign-on instead?" |
+| **Title / scope review at checkpoints** | When starting below expected level | Lock the checkpoint dates and criteria, not just the intent | "We'll revisit when it makes sense" | "Can we agree on month 4 and month 8 as explicit review points?" |
+
+#### The Golden Cage Test
+
+When a counterpart offers a compromise that looks like what the candidate asked for but strips the substance, coach the candidate to name it:
+
+**Test:** "If I accepted this, would I actually get what I need? Or would I get the label without the substance?"
+
+See the Golden Cage Test pattern library in `references/negotiation-protocol.md` for the full 5-variant example set (prof dev, customer access, title checkpoint, equity cliff, performance triggers) and the naming-the-distinction script.
+
+Coach the candidate to name the distinction clearly without being confrontational: "I appreciate the offer. Those are different things for me. Here's why..."
+
+### Escalation Playbook
+
+When standard negotiation reaches an impasse.
+
+#### Escalation Ladder
+
+| Step | When | How | Risk level |
+|---|---|---|---|
+| **1. Delay card** | Counterpart expects an answer you're not ready to give | "I need to think about this. Can I come back to you tomorrow?" | Low. Buys time, preserves leverage. |
+| **2. Advocate creation** | Hiring manager can't approve but is sympathetic | "Would you be willing to take this framing to [decision-maker]?" | Low. Makes them your champion. |
+| **3. Direct to decision-maker** | Hiring manager is blocked; someone higher controls the P&L | Ask hiring manager first: "Would it be okay if I had a brief chat with [name] directly on this one point?" | Medium. Must go through, not around, the hiring manager. |
+| **4. Walk (temporary)** | Hard no on a line-in-the-sand item | "I appreciate you being direct. I need to think about what that means." | High. Only credible if you can actually walk. |
+| **5. Walk (permanent)** | Candidate's floor is genuinely below the offer | "This isn't the right fit on these terms. I respect your position. If circumstances change, I'm open." | High. Burns the bridge for this cycle. |
+
+#### Coaching the Walk
+
+- **Never walk on the call.** Always take 24-48 hours. Decisions made in the moment are emotional, not strategic.
+- **Walking is only credible if the candidate has alternatives.** Coach them to build BATNA (competing offers, fractional options, financial runway) before declaring a line in the sand.
+- **Walking IS negotiation.** When a candidate walks from a position of genuine conviction (not bluff), the investment the company has made (6 rounds, references checked, team excited) creates pull. The counterpart often comes back.
+- **If walking, leave warm.** "I genuinely appreciate how you've handled this process. If circumstances change on either side, I'm open." This preserves the relationship for re-engagement.
+
+#### When the Counterpart Uses an Absent Decision-Maker
+
+A common pattern: "I need to check with my co-founder / board / [name]." This can be genuine or a shield.
+
+**Coach the candidate to probe:** "Which pieces is [authority] flexible on, and which are firm?" Forces the counterpart to reveal what's real vs negotiating position.
+
+**If everything is blocked by the absent authority:** "It sounds like we need [authority] in the conversation." But NEVER suggest a group call with multiple decision-makers against the candidate alone (2v1 disadvantage). Either get the hiring manager to advocate, or go 1-on-1 with the authority.
+
+### Post-Close Legal Review
+
+*Full principle in `references/negotiation-protocol.md` (Core Principle #11). This section covers `negotiate` coaching during the paperwork phase, after commercial terms are closed.*
+
+#### When This Applies
+
+After the candidate has accepted an offer verbally and is awaiting or reviewing the contract and related legal documents. Commercial terms (base, equity, PD budget, leave, title) are closed. The outstanding items are legal/logistical: IP assignment, non-compete, notice period, probation, annexures for any informal commitments.
+
+#### The Register Shift
+
+The primary coaching move is recognizing that the paperwork phase requires a different register from the negotiation phase. Candidates who succeeded in the negotiation by being assertive, specific, and commercial often carry that register into the paperwork phase and accidentally re-open tension.
+
+**Coaching signal:** candidate's draft paperwork-review email uses words like "redline," "annexure," "clause," "pursuant to." Or numbered sections. Or a formal opener. All signals that the candidate has unconsciously adopted their lawyer's register for counterpart correspondence.
+
+**Coaching prompt:** "Read your draft aloud. Does it sound like YOU, or like your LAWYER? If it sounds like your lawyer, rewrite in the register of your last warm call with the counterpart."
+
+#### Coaching Sequence
+
+1. **Audit the draft email for register.** Identify any legal jargon, formal structure, or re-thanking patterns.
+2. **Flag anything that re-opens closed items.** Any re-listing of the commercial package, any re-thanking for wins, any re-anchoring on specific numbers.
+3. **Confirm informal commitments are framed as counterpart's own words.** Any verbal agreements (a schedule arrangement, a development commitment, a remote/flexibility pattern) should be referenced using language the counterpart used, not candidate-side language.
+4. **Test against the "lawyer-to-counterpart mix" failure mode.** Ensure legal questions go through lawyers; logistics questions go counterpart-to-counterpart in plain language.
+5. **Rewrite in warm register.** Short, warm, logistics-framed, specific timeline commitment, no ceremony.
+
+#### Separate Channels Rule
+
+- **Lawyer-to-lawyer:** legal register, full redline, numbered items, formal sign-off. Goes through the candidate's lawyer to the counterpart's lawyer.
+- **Counterpart-to-counterpart:** warm register, category previews not clause-level detail, timeline confirmation, logistics framing. Goes candidate-to-counterpart directly.
+
+If the candidate doesn't have a lawyer, the candidate IS the lawyer — but still separates the registers by subject line and email. Legal clarifications to the counterpart's lawyer in one thread; logistics and informal-commitment asks to the counterpart in another.
+
+#### Coaching the Annexure Ask
+
+When an informal commitment (a schedule arrangement, a development commitment, a remote/flexibility pattern) was verbally agreed but not in the offer letter, the candidate may want it captured in writing. This is legitimate and expected. The coaching move:
+
+- **Reference the counterpart's own description.** "A short annexure capturing [the informal arrangement]."
+- **Offer format flexibility.** "Happy to use a different format if you'd prefer — a signed side letter, an email exchange, whatever works for you."
+- **Frame as buttoning up, not re-negotiating.** "One thing I'd love to include..." (not "I also want to add...").
+- **Low-stakes register.** One paragraph. Not a legal memo.
+
+#### Failure Mode to Flag
+
+If the candidate reports that the counterpart has become cold or slow to respond during the paperwork phase, check the register of recent candidate-to-counterpart correspondence. Legal-register emails from the candidate are the most common cause of post-close chill. Diagnosis: re-read the last 2-3 emails aloud and ask "does this sound like the same person who was on the warm call last week?" If no, warmth has leaked out; send a short human message to re-establish.
+
+### Comp Call Transcript Analysis
+
+*Note: Full scoring dimensions and rubric are in `references/negotiation-protocol.md`. This section covers how `negotiate` integrates with `analyze` for comp calls.*
+
+When a candidate brings a comp call transcript for review as part of the `negotiate` workflow:
+
+1. **Route to negotiation-specific analysis.** Use the 5 Negotiation Performance Dimensions from `references/negotiation-protocol.md` instead of the standard interview rubric.
+2. **Score and identify the primary gap.** The priority improvement feeds directly into the coaching for the follow-up call.
+3. **Map counterpart language to scenarios.** What the counterpart said reveals their actual position (deferral, principled objection, stacked objections, hard no). This diagnosis shapes the follow-up strategy.
+4. **Write results to Comp Strategy** in `coaching_state.md`, not to Score History (comp calls are not interviews).
+
+#### Output Integration
+
+After scoring a comp call transcript, the negotiate workflow should produce:
+- The standard Negotiation Assessment output (offer analysis, leverage, strategy, scripts)
+- PLUS the Negotiation Performance Scorecard from `negotiation-protocol.md`
+- PLUS specific coaching adjustments for the follow-up call based on what the transcript revealed
+
+This creates a feedback loop: score the last call → coach the next call → score that call → iterate.
+
 ### Output Schema
 
 ```markdown

--- a/references/examples.md
+++ b/references/examples.md
@@ -904,3 +904,80 @@ You haven't researched yet, so do these tonight:
 ```
 
 **Why this example matters**: Demonstrates the Quick Script depth — what a candidate needs when the recruiter screen is tomorrow and they haven't prepared. Shows the deflection-first strategy with a fallback range, the critical "don't disclose current comp" coaching, and the research homework assignment. The coach doesn't fabricate salary data — it guides the candidate to research sources and helps construct a defensible range. Also handles the remote/location comp complexity that trips up many candidates.
+
+---
+
+## Example: Negotiation Performance Scorecard (Post-Offer Comp Call)
+
+**Context:** Senior product leader candidate received a Chief Product Officer offer at an early-stage SaaS company (post-Series A, approximately $4-6M ARR range). Offer: $245K base + $25K bonus + 0.05% equity. Candidate negotiated across two calls over 3 days.
+
+**Call 1 transcript scored:**
+
+### Negotiation Performance Scorecard — Call 1
+
+| Dimension | Score | Evidence |
+|---|---|---|
+| Anchoring Discipline | 5 | Never named a number. When asked "do you have something in mind?" responded: "I don't want to throw a number out. What does the right package look like?" Counterpart proposed $270K+$15K. |
+| Information Gathering | 3 | Asked about business exposure and customer access (good intel). Didn't probe equity constraints before accepting the bootstrap frame. Missed opportunity to ask "what's the range on equity?" |
+| WE Framing | 2 | Pitched professional development as "I need this for my wellbeing." Mentioned personal tools and learning projects outside work. Counterpart latched onto "outside commitments on company salary." |
+| Silence & Pacing | 3 | Used silence effectively after base ask (counterpart proposed higher). Filled silence with justification during non-standard term ask (7+ examples given, each creating pushback surface). |
+| Creative Solutions | 2 | Focused entirely on contract clause for schedule structure. Didn't explore: performance triggers, sign-on bonus, additional leave, title review at checkpoints, advisory role. |
+
+**Overall: 3.0 / 5**
+
+**Strongest dimension:** Anchoring Discipline — textbook execution. Never named first, counterpart moved $20-40K above target.
+
+**Priority improvement:** WE Framing — every ask was ME-framed ("I need," "for my development," "for my wellbeing"). Reframe: "Here's what this looks like for [company] — a leader who stays ahead of the curve every week, bringing back frameworks the team uses daily."
+
+### Negotiation Performance Scorecard — Call 2 (follow-up after counterpart consulted decision-maker)
+
+| Dimension | Score | Evidence |
+|---|---|---|
+| Anchoring Discipline | 4 | Maintained position on equity without naming a new number first. Used "what's the chance we could look at this?" (soft ask). Lost half-point: didn't deploy prepared ROI framing when counterpart pushed back. |
+| Information Gathering | 4 | Asked counterpart to describe the professional development arrangement: "Can you walk me through what that looks like practically from your side?" Got detailed description of expectations. Asked twice for specifics on the counterpart's hard-no scope. |
+| WE Framing | 4 | Reframed from "outside commitments" to "professional development." Used "I'm aligned with what you suggested." Referenced counterpart's own words from previous call. Mirrored back their description before asking for documentation. |
+| Silence & Pacing | 3 | Bought 5 days between calls (strong). On the call, listened well during counterpart's multi-minute position statement. But filled pause after equity deferral instead of holding silence. |
+| Creative Solutions | 3 | Pivoted from contract clause to offer letter reference (lighter mechanism). Introduced professional development budget as a separate formalized commitment. But didn't explore performance-based equity triggers when equity was deferred. |
+
+**Overall: 3.6 / 5 (+0.6 from Call 1)**
+
+**Strongest dimension:** Information Gathering — "walk me through what that looks like" play worked perfectly. Counterpart described the arrangement in their own words, candidate mirrored back, asked for documentation.
+
+**Priority improvement:** Creative Solutions — when equity was deferred to the executive team, the candidate accepted the deferral without exploring alternatives (performance triggers, milestone-based top-ups, equity review at scope expansion checkpoints). These were available but not deployed.
+
+### Cross-Call Pattern Analysis
+
+| Dimension | Call 1 | Call 2 | Trend | Coaching note |
+|---|---|---|---|---|
+| Anchoring | 5 | 4 | Stable-high | Core strength. Now reflex across multiple conversations. |
+| Info Gathering | 3 | 4 | Improving | "Walk me through" play is the breakthrough. Standardize. |
+| WE Framing | 2 | 4 | Strong improvement | The reframe from personal-benefit language to "professional development" + referencing counterpart's own words was the key fix. |
+| Silence & Pacing | 3 | 3 | Flat | Silence after asks remains the growth edge. Candidate fills pauses with justification under pressure. Needs deliberate practice. |
+| Creative Solutions | 2 | 3 | Improving | Pivoted from contract to offer letter (lighter mechanism). But still defaulting to the single-lever approach when multiple creative options exist. |
+
+**Primary coaching adjustment:** Build a "creative comp menu" the candidate can scan during calls. When one lever is blocked, immediately surface the next: equity blocked → performance triggers → sign-on → additional leave → title review. The menu prevents the common failure of accepting a single "no" as final when three other doors are open.
+
+### State Writes
+
+After scoring, write to `coaching_state.md`:
+
+**Comp Strategy section update:**
+```markdown
+## Comp Strategy
+- Date: [date]
+- Depth: Deep Strategy (multi-round)
+- Target range: $285-300K base, 0.18-0.20% equity
+- Range basis: Previous role comp and published benchmarks for role tier
+- Research completeness: thorough
+- Stage coached: Post-offer (multi-round, 2 calls)
+- Scripts provided: opener, equity ask, professional development formalization, trust handler
+- Key principle: When the primary ask is declined, explore parallel levers (equity tier, development budget, leave). Let the counterpart describe their constraints, then reframe the request as addressing their stated concern.
+- Negotiation Performance: Call 1 = 3.0/5, Call 2 = 3.6/5 (improvement driven by WE framing fix + info gathering via "walk me through")
+```
+
+**Coaching Notes addition:**
+```markdown
+- [date]: Comp negotiation across 2 calls. Anchoring discipline is now reflex (stable 4-5). WE framing improved dramatically between calls (2→4) after coaching on "professional development" reframe. Silence under pressure remains the primary growth edge. Creative solutions menu needed for future negotiations.
+```
+
+**Why this example matters**: Demonstrates how `analyze` in comp-call mode scores two successive negotiation conversations and extracts a cross-call pattern. Shows the WE-framing fix in action (the candidate's Call 1 ME-framed asks became Call 2 WE-framed asks after coaching). Shows how dimension-level scoring surfaces the exact growth edge (Silence & Pacing remained flat while three other dimensions improved). Demonstrates the state-write pattern that feeds future sessions.

--- a/references/negotiation-protocol.md
+++ b/references/negotiation-protocol.md
@@ -1,0 +1,346 @@
+# Negotiation Protocol (Cross-Cutting Reference)
+
+A cross-cutting negotiation framework that deepens comp coaching rigor. Loaded by `negotiate` (post-offer) and `salary` (pre-offer, Stage 4+). Also loaded by `analyze` when a comp call transcript is detected. Not a standalone command.
+
+**Source:** Jacob Warwick's executive negotiation framework (Lenny's Podcast + Execs and the City Substack).
+
+**Relationship to existing content:** `references/commands/negotiate.md` already contains a condensed GAINS summary and Warwick attribution. This protocol **extends** that summary with per-phase detail, additional core principles beyond GAINS, a non-standard term catalog (Golden Cage + Cap Conversion), multi-round coaching, an escalation playbook, and 5-dimension comp call transcript scoring. Cross-references back to `negotiate.md` are used wherever upstream already covers a principle — this file does not duplicate the GAINS-A "sell the vacation" move or the "haste equals risk" strategic-patience principle.
+
+---
+
+## When This Protocol Applies
+
+| Trigger | Command | What loads |
+|---|---|---|
+| Candidate has received a formal offer | `negotiate` | Full protocol |
+| Candidate is at Stage 4 (pre-offer positioning) | `salary` | Principles + scripts only |
+| Transcript contains comp discussion markers | `analyze` | Comp Call Scoring section |
+
+**Comp call detection markers** (3+ of these in a transcript triggers comp-call mode): salary, base, equity, bonus, offer, package, counter, negotiate, compensation, vesting, sign-on, stock, RSU, pro-rate.
+
+---
+
+## GAINS Model — Per-Phase Detail
+
+The condensed 5-principle summary lives in `references/commands/negotiate.md` under "Negotiation Strategy Framework (GAINS)." The detail below expands each phase with the tactical moves that ladder up to it.
+
+**1. Gather Intelligence**
+
+Research beyond surface data. Understand WHO decides (P&L owner, not recruiter), WHAT they care about (revenue gaps, talent retention), WHY this role exists now (backfill, growth, new function). The deeper your understanding of their pain, the stronger your position.
+
+**2. Align with Advocates**
+
+Move from "selling credentials" to "solving problems." Build internal champions through the interview process — people who will advocate for you when you're not in the room. Every interview interaction is positioning for the negotiation that comes later. The "sell the vacation" move (paint a vivid post-hire picture) is covered in `negotiate.md`'s GAINS-A step.
+
+**3. Influence Momentum**
+
+Add genuine value through the process. Each interaction makes you stickier. The more people invested in you, the harder it is to let you go over comp. Control timing and scarcity: specific time slots, not "I'm flexible."
+
+**4. Navigate Complexity**
+
+Master timing and relationship dynamics. Slow down — haste equals risk (see `negotiate.md`'s strategic-patience treatment). Control when conversations happen, who you talk to, and the environment. Phone or video minimum; in-person is best. Walking meetings are ideal (side by side = collaborative, not confrontational).
+
+**5. Secure Value**
+
+Finalize agreements with specificity. Lock terms in writing. Every verbal commitment that isn't documented is a commitment that may not survive a leadership change, a busy quarter, or a reorg. Deliver early wins to validate the investment.
+
+---
+
+## Core Principles (Beyond GAINS)
+
+These principles are distilled from Jacob Warwick's executive negotiation work (via Lenny's Podcast + Execs and the City Substack), extending the condensed GAINS summary in `negotiate.md` with tactical depth.
+
+### 1. Don't Say a Number First
+
+Let them anchor. The company negotiates thousands of times; you negotiate 4-5 times in your career. They have information asymmetry. Don't help them by anchoring yourself.
+
+**Script:** "I don't want to throw a number out. You know the role — what does the right package look like?"
+
+**If pushed:** "What did you have in mind?" They reveal their range; you respond from information, not vulnerability.
+
+**If they persist:** "I want to thank you for being an advocate for me and for respecting that I won't share compensation figures right now." (Reputation hack: they either agree or look disrespectful.)
+
+---
+
+### 2. Make It WE Not ME
+
+Every ask must be framed as a company win, not a personal need. "Given that we've had challenges with talent retention, wouldn't it make sense to proactively offer protections that show the team they're valued?" The candidate who frames their ask as a company benefit gets further than the one who frames it as a personal requirement.
+
+**Anti-pattern:** "I need this for my wellbeing / my development / my family."
+**Reframe:** "Here's what this looks like for [company] — a leader who [specific benefit], bringing back [specific value]."
+
+---
+
+### 3. They Have Margin (20-40%)
+
+Companies always have room above posted bands. The number they offer first is not their best number. Studies show anchoring egregiously high wins 75% more than "just being reasonable."
+
+**Coaching application:** When a candidate says "the offer is at the top of their range," probe: "How do you know? Did they tell you, or did you derive it from the JD?" Posted ranges are starting positions, not ceilings.
+
+---
+
+### 4. Buying Time on the Offer
+
+`negotiate.md`'s Anxiety Coaching covers the broader "haste equals risk" principle. This subsection adds the specific post-offer script for the 2-3 day review window.
+
+**Script (post-offer):** "I appreciate you making me an offer. I'm excited to work with you. I want to review this over the next couple of days, talk to my advisor. I'll get back to you. I imagine we start working together in a couple weeks."
+
+Signals: deal will get done (reduces their anxiety), but you're not rushing (preserves your leverage).
+
+---
+
+### 5. Never Split the Difference
+
+Don't meet in the middle. If they offer X and you asked for Y, don't settle at (X+Y)/2 — that's lazy negotiating. Probe instead.
+
+**Script:** "Can you help me understand your thinking on that?" or "Was that a mistake?"
+
+Often reveals they can go higher. Splitting the difference means neither side found the real ceiling.
+
+---
+
+### 6. Control the Messaging
+
+Every written communication is a negotiation move. Emails, texts, LinkedIn messages — all positioning. Don't telegraph negotiation intent in writing before the call. Don't signal eagerness. Let the call be the call.
+
+**Rules:**
+- Never negotiate over email (can't control tone)
+- Never negotiate through recruiters (game of telephone — go to the decision maker)
+- Short messages signal confidence ("the more confident you get, the shorter your communication gets")
+- When counterpart opens warm, match warmth — short + confident, not short + cold
+
+---
+
+### 7. Go to the Decision Maker
+
+"Go to the one who has skin in the game. Who controls the P&L? That's who you want to talk to." If the recruiter or hiring manager can't approve, go around them — respectfully.
+
+**Script (text to decision maker):** "We're almost across the line. Open to chat?"
+
+Short = confident. Two sentences max.
+
+---
+
+### 8. Emotional Connection > Logic
+
+"Too many executives lean on credibility and logic because we're trained to do that. The emotional side is where a lot of deals get unfair." You'll always lose the logical argument against a company (they have more data). Lead with what's personal, authentic, unreplicable.
+
+**Coaching application:** Help candidates identify their personal connection to the company/role that no other candidate has. Mission alignment, personal experience with the problem space, specific people they want to work with.
+
+---
+
+### 9. Creative Comp Solutions
+
+When traditional comp is capped, find value outside salary bands. Performance-based triggers, sign-on bonuses, additional leave, advisory roles, professional development budgets, equity restructuring, IP carve-outs.
+
+**Model (performance-based triggers):** "If the company grows to $X ARR and I contributed to it, what would that outcome look like? Would that be another tranche of stock or cash?"
+
+**Principle:** "Those who push for performance-based comp tend to have more skin in the game. Those are the types of people I want working for me."
+
+---
+
+### 10. Know When to Stop
+
+Not every moment is a moment to push. When the counterpart has advocated for you — gone to their decision-maker, pushed past their own comfort zone, come back with MORE than you asked for — the correct move is to acknowledge, accept, and close with grace. Pushing for one more thing after they over-delivered destroys the goodwill you just earned and makes you look ungrateful.
+
+**The test:** "Did they come back with more than I expected?" If yes, stop. Close warm. The relationship capital going into day 1 is worth more than the incremental dollars.
+
+**This is NOT the same as caving under relief.** Caving = accepting a weak counter without deploying any objection handlers (e.g., accepting the first equity number without testing the floor, taking a bonus-for-base swap without probing the cap, or saying yes to a title without getting the scope review date written in). Knowing when to stop = recognizing when the counterpart has genuinely stretched, acknowledging it, and preserving the relationship for the long game.
+
+**Coaching application:** When a candidate gets a strong counter-offer and asks "should I push for more?", the coach should assess: did the counterpart advocate or merely respond? If they advocated (went to bat with their decision-maker, gave unsolicited improvements, named it as "good faith"), the answer is usually "close with gratitude." If they merely responded (split the difference, gave the minimum), the answer is "probe further."
+
+**Script (when stopping is right):** "That's great. I really appreciate you pushing on this. Let's do it." Short. Warm. Done. Don't add "but one more thing."
+
+---
+
+### 11. Post-Close Legal Review Tone
+
+Once commercial terms are closed and the contract is in hand, the negotiation ends and the paperwork phase begins. The paperwork phase is a shared logistics problem between candidate and counterpart, not another round of negotiation. Legal register belongs lawyer-to-lawyer; counterpart-to-counterpart stays warm and human.
+
+**The failure mode:** treating paperwork review as another negotiation round. A formal "redline pack" email with numbered sections, legal terminology ("annexure," "clause," "redline"), and exhaustive previews re-opens tension already resolved. It reads as adversarial when the relationship is closed. Counterparts notice the tone shift and brace for another fight.
+
+**Three rules:**
+1. **Warmth preserved.** Counterpart register matches the last warm call, not the lawyer's brief.
+2. **Paperwork framed as logistics, not negotiation.** "Standard senior-hire stuff. Nothing unusual." Pre-empts counterpart anxiety that commercial terms are being re-opened.
+3. **Separate channels.** Lawyer-to-lawyer correspondence can use legal register. Counterpart-to-counterpart does not. Never mix.
+
+**Coaching application:** When a candidate is about to draft a post-offer paperwork-review email, the coach should ask: "Read it aloud. Does it sound like YOU talking to your counterpart, or like your LAWYER talking to their lawyer?" If the second, rewrite in plain language with warmth preserved.
+
+**What NOT to include in counterpart emails during legal review:**
+- Re-thanks for commercial wins already closed (reads as needy).
+- Re-listing the commercial package (re-anchors, invites re-negotiation).
+- Exhaustive redline preview (scope inflation; makes 4 items feel like 14).
+- Asking for deadlines the candidate can set themselves.
+
+**What to include:**
+- Short timeline commitment ("feedback tomorrow, signed by Friday").
+- References to any informal commitments framed as counterpart's own words ("the [arrangement] you described on [date]").
+- One-line previews of paperwork categories, not clauses ("IP scope, non-compete, notice, a handful of smaller items").
+- Offer flexibility on form, not substance ("happy to use a different format if you'd prefer").
+
+**Script (counterpart email during legal review):**
+> "Thanks for [the chat / yesterday]. A few quick things: [timeline], [informal commitments as their words], [paperwork as logistics], [any logistics flags]. Best, [name]."
+
+---
+
+## The Zombie Number
+
+A candidate's previous compensation that continues to haunt future negotiations. Recruiters pass this information between databases, and employers use it as an anchor (+15%) instead of determining fair pay based on role scope.
+
+**Detection:** Coach should ask: "Have you shared your current or past compensation with anyone in this process?" If yes, the zombie is active.
+
+**Redirect script:** "I'd rather focus on the scope of this role and what a fair package looks like for the outcomes you need. What range are you working with?"
+
+**Prevention:** Never share comp history with recruiters early. If pressed: "I don't discuss compensation until we're ready to make an offer. I'd love the opportunity to learn more about the team first."
+
+---
+
+## Multi-Round Negotiation
+
+When the first call doesn't close, the follow-up requires a different approach.
+
+**Key shift:** The counterpart has had time to think and may have consulted others. Their position may have hardened OR softened. You need to read which before deploying strategy.
+
+**Structure:**
+1. Open with genuine curiosity, not a pitch: "Where did things land?"
+2. Listen completely before responding. Every word is intel.
+3. If their position has shifted, match your response to the NEW position (not your prepared reframe of the old one)
+4. Address objections one at a time. Don't stack responses.
+5. Steer toward the proposal only after clearing the current objection.
+
+**Reframing after pushback:** If a previous framing didn't land, acknowledge it without self-blame: "Let me be clearer on this — [reframe]." Not "that was the wrong framing" (unnecessary concession). Common framing misfires to diagnose and repair:
+- "Reduced schedule" heard as "less commitment" → reframe as "focused schedule for senior output."
+- "Professional development day" heard as "day off" → reframe as "investment in craft that compounds back into the role."
+- "Portfolio work" heard as "side gig" → reframe as "skills practice that keeps my edge sharp for your outcomes."
+- "Remote flexibility" heard as "avoidance" → reframe as "output pattern I've validated over the last N years."
+- "Scope review at 6 months" heard as "wanting a promotion already" → reframe as "mutual checkpoint so we both know this is working."
+
+**When the counterpart stacks objections:** Multiple principle-based objections (trust, outcomes, flexibility, team, precedent, fairness to others) often all ladder to one underlying concern: preserving unilateral discretion. Name the pattern: "I hear several concerns, and I want to address each. But help me understand — is there a single thing that would unlock this?"
+
+---
+
+## Non-Standard Terms
+
+Not every negotiation is about base salary. Senior hires often negotiate:
+
+| Term | When to raise | How to frame |
+|---|---|---|
+| **Reduced schedule (4-day week, 9-day fortnight)** | After base/equity are directionally aligned | "This is how I stay at the level that delivers the outcomes you hired me for" |
+| **IP / moonlighting carve-out** | Contract stage, not negotiation call | "Standard for senior hires — employment lawyer reviews to protect both sides" |
+| **Professional development budget** | When they offer it as alternative | Accept as additive, not substitute for structural terms |
+| **Performance-based triggers** | When salary bands are capped | "If I deliver X outcome, what does that unlock in terms of comp?" |
+| **Sign-on bonus** | When base is capped | One-time payment to bridge the gap between offer and market |
+| **Additional leave** | When work-life balance matters, OR when base is capped and leave is an easier ask for the company (often true at startups where cash is tight but leave is cheap) | Frame as retention ("leaders who don't burn out stay longer") OR as convertible leverage — if the leave ask can't land, it often converts into base or equity instead |
+| **Title / scope review at checkpoints** | When starting below expected level | Lock the checkpoint dates and criteria, not just the intent |
+
+**Golden cage test:** If a proposed compromise looks like what you asked for but strips the substance, name it. Same vocabulary, different substance is the signature of a golden cage. Common variants:
+
+- **Asked:** dedicated professional development day. **Offered:** a day with fewer meetings on the calendar. **Different because:** one is investment in your craft, the other is just a calendar change.
+- **Asked:** unfettered customer access. **Offered:** summary reports from customer success. **Different because:** one gives you live signal, the other gives you a filtered view owned by someone else.
+- **Asked:** title with scope review at 6 and 12 months, criteria written down. **Offered:** title with a vague "we'll revisit." **Different because:** one has a forcing function, the other depends on goodwill.
+- **Asked:** equity with a 1-year cliff. **Offered:** equity with a 2-year cliff. **Different because:** one aligns risk to your ramp, the other is a retention lock.
+- **Asked:** performance-based trigger with named outcomes. **Offered:** "discretionary review at end of year." **Different because:** one is contractual, the other is mood-based.
+
+**Script:** "I want to make sure we're on the same page. What you're offering is X. What I'm asking for is Y. Those are different things because [substance]. Can we get to Y?"
+
+### Cap Conversion: When One Dimension Is Locked
+
+When the counterpart says a specific dimension is capped (salary band, equity pool, leave policy, title seniority), the correct move is NOT to accept the cap and lose the value. It's to pivot the unmet value to a different dimension. Companies usually have flexibility somewhere — the question is where.
+
+**Common cap conversions:**
+
+| Ask that hit a cap | Common pivot | Why the pivot works |
+|---|---|---|
+| Leave (extra week) | Base bump | Companies resist leave precedents (visible to others); base is private and flexible |
+| Base | Equity grant, sign-on bonus, or title checkpoint | Cash flow is often the real constraint, not package value |
+| Equity | Performance-based triggers, shorter cliff, accelerated vesting | Equity pools are capped, but vesting terms are negotiable |
+| Title | Scope review at 3/6/12 months with written criteria | Title is politically sensitive; trajectory usually is not |
+| Remote days | Outcomes-based agreement + review checkpoint | Counterpart wants the right to reverse; pivot gives them an exit |
+
+**The underlying principle:** if a commitment isn't in the contract, assume it could be removed later, and negotiate as if it weren't there at all. Informal arrangements ("everyone gets the holiday period off," "we're flexible on remote days," "we'll revisit title next year") can be revoked without notice; contractual terms cannot.
+
+**Coaching application:** When the counterpart defends a cap with "we already give you X informally," treat this as a signal to formalize, not to accept the informal benefit as sufficient.
+
+**Script:**
+> "That's generous, and I appreciate it. Can we write it into the contract? If that's not possible, I'm still asking for the original thing — because if the informal benefit changes later, I lose both."
+
+---
+
+## Comp Call Transcript Analysis
+
+When `analyze` detects a comp call transcript, score against these 5 dimensions instead of the standard interview rubric.
+
+### Negotiation Performance Dimensions
+
+| Dimension | What it measures | 1 (Poor) | 3 (Adequate) | 5 (Exceptional) |
+|---|---|---|---|---|
+| **Anchoring Discipline** | Did the candidate avoid naming a number first? | Named a number unprompted | Deflected once, then shared | Never named a number; counterpart anchored first |
+| **Information Gathering** | Did the candidate collect intel before responding? | Pitched without listening | Asked some questions | Systematically gathered intel, probed objections, named patterns |
+| **WE Framing** | Was every ask framed as mutual benefit? | All asks were ME-framed ("I need") | Mixed framing | Every ask led with company benefit; counterpart felt like they were solving a shared problem |
+| **Silence & Pacing** | Did the candidate use silence and control timing? | Filled every silence, rushed to respond | Some pauses, mostly reactive | Strategic silence after asks; controlled meeting timing; took 2-3 days on offers |
+| **Creative Solutions** | Did the candidate explore beyond base salary? | Only discussed base | Mentioned equity/bonus | Proposed creative mechanisms (triggers, IP carve-outs, development budgets, schedule structures) |
+
+### Scoring Output
+
+```markdown
+## Negotiation Performance Scorecard
+
+| Dimension | Score | Evidence |
+|---|---|---|
+| Anchoring Discipline | [1-5] | [specific moment from transcript] |
+| Information Gathering | [1-5] | [specific moment from transcript] |
+| WE Framing | [1-5] | [specific moment from transcript] |
+| Silence & Pacing | [1-5] | [specific moment from transcript] |
+| Creative Solutions | [1-5] | [specific moment from transcript] |
+
+**Overall:** [average] / 5
+**Strongest dimension:** [name] — [why]
+**Priority improvement:** [name] — [specific adjustment for next round]
+```
+
+---
+
+## Competence Guardrails
+
+The coach provides negotiation STRATEGY, not professional advice in these domains:
+
+| Domain | Coach can | Coach cannot | Redirect to |
+|---|---|---|---|
+| **Tax implications** | Flag that equity has tax consequences | Calculate tax liability or recommend tax strategies | "Consult a tax professional before making equity decisions" |
+| **Legal review** | Recommend having a lawyer review the contract | Interpret contract clauses or assess enforceability | "Have an employment lawyer review this — standard for senior hires" |
+| **Equity valuation** | Help compare equity offers directionally (%, vesting, cliff) | Determine fair market value or predict future valuation | "An equity advisor or the company's 409A valuation can help here" |
+| **Jurisdiction-specific law** | Note that rules vary by jurisdiction | Advise on specific employment law requirements | "Check your jurisdiction's rules on [topic] — they vary significantly" |
+
+When a candidate asks something in a guardrailed domain, don't guess. Say: "That's outside what I can reliably coach on. Here's who can help: [specific professional type]."
+
+See also `negotiate.md`'s "Competence Guardrails" section for the general post-offer guardrails (AMT calculations, ISOs, equity structures).
+
+---
+
+## Command-Specific Invocations
+
+### `negotiate` — Full Protocol
+
+Load this entire protocol when `negotiate` is invoked. The protocol supplements (does not replace) the existing `negotiate.md` workflow. Key integration points:
+
+- **Offer analysis:** Apply Principle #3 (They Have Margin) when evaluating whether the offer is competitive
+- **Strategy:** Apply the per-phase GAINS detail above to structure the negotiation approach (the condensed summary in `negotiate.md` covers the headline moves; this file covers the tactical depth)
+- **Scripts:** Provide the Core Principles scripts alongside existing `negotiate.md` scripts
+- **Scoring:** If candidate brings a comp call transcript for review, use the Negotiation Performance Dimensions instead of standard rubric
+- **Multi-round:** Apply Multi-Round Negotiation section when candidate reports pushback after initial ask
+- **Non-standard:** Apply Non-Standard Terms section when traditional comp levers are capped
+- **Guardrails:** Apply Competence Guardrails for tax/legal/equity/jurisdiction questions
+
+### `salary` — Principles + Scripts Only
+
+Load Core Principles and Zombie Number sections when `salary` reaches Stage 4 (pre-offer positioning). The candidate needs negotiation mindset before the offer arrives, not the full tactical framework.
+
+Key integration: when salary coaching transitions to negotiate coaching (offer received), the handoff should reference principles already established: "We talked about not anchoring to a number. That principle is now live — here's how to apply it to the actual offer."
+
+### `analyze` — Comp Call Scoring
+
+Load Comp Call Transcript Analysis section when transcript contains 3+ comp discussion markers. Score against the 5 negotiation dimensions instead of standard interview rubric. Output the Negotiation Performance Scorecard.
+
+**Detection logic:** Before standard transcript processing, scan for comp markers. If 3+ markers found, route to negotiation-specific analysis. If fewer than 3, proceed with standard interview analysis.
+
+**State writes:** After scoring, write results to `Comp Strategy` section of `coaching_state.md` (not Score History — comp calls are not interviews).


### PR DESCRIPTION
## Summary

- **New reference file `references/negotiation-protocol.md`** (344 lines) — cross-cutting negotiation framework based on Jacob Warwick's executive negotiation methodology (Lenny's Podcast + Execs and the City Substack). Loaded by `negotiate` (full protocol), `salary` (Stage 4+ principles & scripts), and `analyze` (comp call transcripts).
- **Extends (does not replace) the existing GAINS summary** added to `negotiate.md` in the Lenny integrations pass (`4dcc2e6` + `a109da6`). The new file adds per-phase GAINS detail, 10 core principles beyond GAINS, and tactical depth. Cross-references back to `negotiate.md` wherever a principle is already covered — "Sell the Vacation" and "Haste equals risk" appear only as pointers to your existing treatment, not duplicated.
- **5 new `negotiate.md` sections** appended after "Multiple Concurrent Offers": Multi-Round Negotiation (follow-up call coaching after pushback), Non-Standard Terms (4-day weeks, IP carve-outs, performance triggers, sign-on, additional leave, title checkpoints), Escalation Playbook (delay card → walk), Post-Close Legal Review (register shift for paperwork phase), Comp Call Transcript Analysis (integration with `analyze`).
- **`analyze.md` comp call detection gate** — auto-detects transcripts with 3+ comp discussion markers and routes to 5-dimension negotiation scoring (Anchoring Discipline, Information Gathering, WE Framing, Silence & Pacing, Creative Solutions) instead of the standard interview rubric.
- **`examples.md` worked example** — multi-round comp negotiation transcript scored across 2 calls with cross-call pattern analysis and state-write pattern.
- **Wiring** — `SKILL.md` Mode Detection (item 18b), File Routing (new `negotiate` entry, updated `analyze` + `salary`), Multi-Step Intent Detection row; `README.md` command table + workflow 12; `VERSIONS.md` new proposed version entry (heading left as `v[N]` with a note asking you to slot it — proposed as v3.1 or a v4 prerequisite).

## Rationale

The GAINS summary you added covers the headline moves. This PR adds the tactical depth that was outside its scope: per-phase detail, additional core principles (Don't Say a Number First, Make It WE Not ME, They Have Margin, Never Split the Difference, Control the Messaging, Go to the Decision Maker, Emotional > Logic, Creative Comp Solutions, Know When to Stop, Post-Close Legal Review Tone), Zombie Number detection, multi-round coaching for follow-up calls, the Cap Conversion table for when one dimension is locked, and negotiation-specific scoring for comp call transcripts. Competence Guardrails mirror your existing `negotiate.md` guardrails section for tax/legal/equity/jurisdiction questions.

## Test plan

- [ ] Load a `coaching_state.md` and invoke `negotiate` with a comp call transcript that includes 3+ comp markers — verify routing to Comp Call Scoring (5 negotiation dimensions) instead of the interview rubric
- [ ] Verify `analyze.md` Comp Call Detection gate fires BEFORE the standard Step Sequence
- [ ] Verify `salary` at Stage 4 pre-loads Core Principles + Zombie Number from `negotiation-protocol.md`
- [ ] Verify no duplication with existing GAINS summary in `negotiate.md` — "Sell the Vacation", "Haste equals risk", $20M stock-payout anecdote should appear only as cross-references
- [ ] Verify Mode Detection item 18b routes comp call transcripts correctly (distinct from item 18 "offer details present" → `negotiate`)
- [ ] Verify the Multi-Round Negotiation row in Multi-Step Intent Detection ("I negotiated but they pushed back" / "follow-up call scheduled")
- [ ] Confirm `VERSIONS.md` `v[N]` placeholder is where you'd like it — happy to rebase into whatever version number fits your roadmap

## Attribution

Jacob Warwick's executive negotiation framework from Lenny's Podcast and Execs and the City Substack. Sources already credited in the existing GAINS section of `negotiate.md` remain the primary attribution; this PR deepens that integration.
