### PR TITLE
chore: gitignore .claude/settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ coaching_state.md
 
 # Active skill file (created by copying SKILL.md during setup)
 CLAUDE.md
+
+# Per-user Claude Code permission allowlist (auto-generated as users approve tools)
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

Adds `.claude/settings.local.json` to `.gitignore`. This file is auto-generated per-user by Claude Code as users approve tool permissions during a session. It contains a personal allowlist of specific MCP tool names and Bash command patterns — useful locally, noise in source control.

## Why

Without this gitignore entry, the file appears as untracked in every contributor's worktree, which:
- Creates persistent `git status` noise
- Risks accidental commits of personal allowlist data
- Triggers spurious "uncommitted changes" warnings in tooling

## Fits existing convention

The repo already gitignores per-user state (e.g. `coaching_state.md`). This is the same pattern.

## Test plan

- [x] `git status` no longer shows `.claude/settings.local.json` as untracked
- [x] No other files affected (single-line addition to `.gitignore`)