### PR TITLE
feat(v4): Opportunity Track — career-opportunity system extending Int…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
-# Interview Coach
+# Interview & Opportunity Coach
 
-A Claude Code-based interview coach that covers the full job search lifecycle — from JD analysis and resume optimization through mock interviews to post-offer negotiation. 23 commands across application materials, interview prep, practice, analysis, and comp coaching. It scores your answers across five dimensions, diagnoses root causes behind weak spots, builds a storybank you can retrieve under pressure, and adapts its coaching to your specific patterns. Not a generic question bank. An adaptive system that gets sharper the more you use it.
+A Claude Code-based career coach that operates in two integrated tracks:
 
-Say `kickoff`, share your resume, and you're being coached in under 2 minutes.
+- **Interview Track** — the full visible-job-search lifecycle, from JD analysis and resume optimization through mock interviews to post-offer negotiation. Scores your answers across five dimensions, diagnoses root causes, builds a storybank you can retrieve under pressure, and adapts to your patterns.
+- **Opportunity Track** *(v4)* — the upstream system: discover what you actually want, build a target ecosystem, map your real network, develop a personal brand, ship proof-of-work, run events deliberately, build relationships that compound, and convert inbound conversations into aligned opportunities. Built on the premise that the strongest careers are made by being *known for the right things by the right people* — not by sending resumes to strangers.
+
+35 commands across both tracks, with a multi-week `bootcamp` orchestrator that runs the full lifecycle end-to-end. Not a generic question bank. Not a generic networking course. An adaptive system that gets sharper the more you use it.
+
+Say `kickoff`, share your resume, and you're being coached in under 2 minutes. If you want the long game, say `bootcamp`.
 
 ---
 
@@ -51,6 +56,30 @@ Say `kickoff`, share your resume, and you're being coached in under 2 minutes.
 **Differentiation** — Earned secrets and spiky POVs are a first-class dimension, not an afterthought. The system pushes you past "competent" toward "memorable."
 
 **Self-awareness** — Tracks the gap between your self-assessment and actual coach scores. Knows if you're an over-rater or under-rater, and adjusts coaching accordingly.
+
+---
+
+## What the Opportunity Track Adds (v4)
+
+Most career coaching optimizes the application — better resume, better cover letter, better keyword match. The Opportunity Track is built on a different premise: the strongest careers are not built that way. They are built so that opportunity arrives because the right people know the right things about you.
+
+The aspirational user has never sent a resume to a stranger. Every meaningful opportunity in their career came through a deliberately built network and a deliberately cultivated brand. The Opportunity Track teaches that as a system — not as luck, not as charisma — across five stages.
+
+**Discover** — `compass` forces a definition of what you actually want, specific enough that you could recognize it in the wild and refuse misaligned opportunities. Anti-criteria forcing, past-data testing, the aligned-opportunity sentence test, confidence calibration. `targets` translates compass into a tiered ecosystem of companies, communities, and a single-sentence segment statement (Phyl Terry's spear, not a net).
+
+**Position** — `brand` builds the strategy: thesis, defensible POV, audience, channel ranking, cadence commitment, anti-brand. Distinct from `pitch` (the conversational artifact) — `brand` is the multi-month positioning architecture. `pitch`, `linkedin`, and `resume` derive from it for cross-surface consistency.
+
+**Distribute** — `content` builds a 90-day calendar from brand thesis and storybank earned secrets, with a strict quality rubric (no ghostwriting, no LLM-laundering, no reach-chasing — voice is the asset). `projects` ships proof-of-work artifacts with falsifiable hypotheses; completed projects seed the storybank. `events` turns conferences and meetups from networking-for-its-own-sake into a relationship-pipeline input via deliberate pre-/post-event work.
+
+**Activate** — `mapping` walks your actual network (not LinkedIn's), tiers it honestly (Tier 1 = would take your call today; Tier 2 = warm; Tier 3 = reachable through one hop), and surfaces coverage gaps against the target ecosystem. `relationships` runs a lightweight CRM with give-before-ask cadence, re-warming sequences, and reciprocity ledger audits. `intro` enforces the warm-intro choreography (private ask of introducer, double opt-in, forwardable email construction, post-intro reciprocity).
+
+**Convert** — `opportunities` logs every inbound, scores against compass, manages stage transitions, and surfaces patterns about what's pulling. When stage reaches "formal process," it creates an Interview Loop and hands off cleanly to the Interview Track. `convert` coaches the bridges that turn conversations into real opportunities — collaboration test, follow-up artifact, named ask, graceful pass.
+
+**`bootcamp`** is the capstone: an 8-12 week orchestrator with weekly cadence and five checkpoints (Compass Lock → Position Lock → Distribution Active → Network Live → Conversion Ready). Four tracks: Brand-First, Network-First, Project-First, Hybrid. Pick at start.
+
+**Anti-pattern enforcement** is strict throughout. The system pushes back on performance discovery, the 200-target list, the networking sprint, ghostwritten brand, the perpetual project, the hidden ask, audit-and-extract, and brand without anti-brand. The user's voice and authenticity are the assets; the coach edits structure and sharpens specificity, never replaces voice.
+
+**Cross-track integration**: opportunities arriving via the Opportunity Track feed the Interview Track. Storybank-seeding from shipped projects feeds `pitch`, `resume`, `linkedin`, and `stories`. Compass and brand thesis stability are checked against interview outcomes — repeated rejections from misaligned opportunities mean compass or targets need revision, not more interview practice.
 
 ---
 
@@ -159,6 +188,50 @@ For both options, the coach will ask for your resume, target role, and timeline 
 | `negotiate` | Post-offer negotiation coaching | Offer analysis + strategy + scripts + specific language |
 | `reflect` | Post-search retrospective + archive | Journey arc, breakthroughs, transferable skills, archived state |
 | `help` | Show command menu (context-aware) | Full command list + recommended next based on coaching state |
+
+### Opportunity Track (v4)
+
+#### Discover
+
+| Command | Purpose | Typical Output |
+|---|---|---|
+| `compass` | Define what you actually want — work shape, anti-criteria, the aligned-opportunity sentence | Compass section in coaching state with confidence-calibrated components |
+| `targets` | Build target ecosystem — tiered companies, communities, segment statement, anti-targets | Tiered company table, community map, segment statement, watch signals |
+
+#### Position
+
+| Command | Purpose | Typical Output |
+|---|---|---|
+| `brand` | Personal brand strategy — thesis, defensible POV, audience, channels, cadence, anti-brand | Brand Strategy section with 90-day cadence commitment + success signals |
+
+#### Distribute
+
+| Command | Purpose | Typical Output |
+|---|---|---|
+| `content` | Content calendar (`plan`), per-piece coaching (`coach`), inbound audit (`audit`) | 90-day backlog, per-piece annotations against 8-dim rubric, audit pattern report |
+| `projects` | Proof-of-work projects (`propose`/`scope`/`coach`/`ship`/`debrief`) with hypothesis + Storybank seeding | Hypothesis statement, scope cut, ship-day choreography, Storybank story |
+| `events` | Event strategy (`plan`/`prepare`/`at-event`/`debrief`) | Prioritized event list, pre-event prep, post-event Relationship Pipeline updates |
+
+#### Activate
+
+| Command | Purpose | Typical Output |
+|---|---|---|
+| `mapping` | Map your real network — Tier 1/2/3 inventory + coverage gap analysis | Tiered tables, coverage gaps named, Tier 3 path-finding |
+| `relationships` | Lightweight CRM (`cadence`/`give`/`rewarm`/`touch`/`audit`) | Per-Tier-1 cadence, give plan, reciprocity audit |
+| `intro` | Warm intro choreography — private ask, double opt-in, forwardable email, reciprocity | Drafted private ask + forwardable email + Intro Tracker update |
+
+#### Convert
+
+| Command | Purpose | Typical Output |
+|---|---|---|
+| `opportunities` | Inbound funnel hygiene (`log`/`score`/`move`/`audit`) — track and score every inbound | Funnel table + alignment verdicts + pattern analysis |
+| `convert` | Conversation-to-opportunity bridges (`before`/`during`/`after`/`revive`) | Conversion bridge selection + draft messages + next checkpoint |
+
+#### Orchestrator
+
+| Command | Purpose | Typical Output |
+|---|---|---|
+| `bootcamp` | Multi-week program (`start`/`plan`/`audit`/`checkpoint`/`pause`/`resume`/`end`) | Track selection, weekly commitments, checkpoint verdicts, end-of-program retrospective |
 
 ---
 
@@ -333,7 +406,44 @@ Then specify message type (cold LinkedIn, warm intro, recruiter reply, etc.) and
 - Follow-up sequence with timing
 - Earned secret hooks pulled from your storybank
 
-### 11) Post-offer negotiation
+### 11) Run the full Opportunity Track bootcamp
+
+```text
+bootcamp start
+```
+
+Pick a track (Brand-First, Network-First, Project-First, Hybrid), commit 5-10 hours/week, and the system runs an 8-12 week program with weekly cadence and five checkpoints between stages. Each week: `bootcamp plan` to set commitments, then commands within the stage (`compass`, `brand`, `content`, etc.), then `bootcamp audit` end-of-week.
+
+Expected output across the program:
+
+- Compass with a single aligned-opportunity sentence and confidence calibration
+- Brand thesis, defensible POV, channel strategy, anti-brand
+- Network map with Tier 1/2/3 and coverage gap analysis
+- 90-day content calendar with several pieces shipped
+- At least one proof-of-work project shipped and seeded into the storybank
+- Active relationship pipeline with give-before-ask cadence held
+- Inbound opportunities logged and scored against compass
+- A handoff to the Interview Track when formal processes begin
+
+### 12) One-off Opportunity Track commands
+
+Don't need the whole program? Run individual commands:
+
+```text
+compass            # Define what you actually want
+targets            # Build a tiered target ecosystem
+mapping            # Map your real network
+brand              # Build the brand strategy
+content plan       # 90-day content calendar
+projects propose   # Generate aligned project ideas
+events plan        # Prioritize events
+relationships cadence  # Set Tier 1 cadence
+intro plan         # Orchestrate a warm intro
+opportunities log  # Log an inbound
+convert after      # Coach the post-conversation conversion
+```
+
+### 13) Post-offer negotiation
 
 ```text
 negotiate
@@ -350,16 +460,16 @@ Then provide offer details, competing offers, and ideal outcome. Get:
 
 ## Tracks
 
-### Quick Prep
+### Interview Track — Quick Prep
 
-Best when interview timeline is short.
+Best when interview timeline is short (<2 weeks).
 
 - Company research
 - Prep brief
 - Focused transcript analysis
 - Immediate next actions
 
-### Full System
+### Interview Track — Full System
 
 Best when running a multi-week search.
 
@@ -376,7 +486,26 @@ Best when running a multi-week search.
 - Post-offer negotiation coaching
 - Post-search retrospective and archiving
 
-Choose during `kickoff`. You can switch later.
+### Opportunity Track (v4)
+
+Best when you want a career that pulls aligned opportunities to you, not one that depends on cold applications.
+
+- Compass discovery (what you actually want, with confidence calibration)
+- Target ecosystem and segment definition
+- Real network mapping with coverage gap analysis
+- Personal brand strategy with defensible POV and anti-brand
+- 90-day content calendar with per-piece coaching
+- Proof-of-work projects with hypothesis testing and Storybank seeding
+- Event strategy with deliberate pre-/post-event work
+- Lightweight relationship CRM with give-before-ask cadence
+- Warm intro choreography
+- Inbound opportunity funnel with compass-based scoring
+- Conversation-to-opportunity conversion bridges
+- Multi-week `bootcamp` orchestrator (8-12 weeks, four track variants, five checkpoints)
+
+Run individual commands à la carte, or run `bootcamp` for the full program. The Opportunity Track shares state with the Interview Track — opportunities surfaced upstream feed interview prep downstream.
+
+Choose Quick Prep / Full System during `kickoff`. The Opportunity Track is run via its own commands or `bootcamp` whenever you're ready.
 
 ---
 
@@ -413,7 +542,19 @@ interview-coach-skill/
     │   ├── negotiate.md
     │   ├── feedback.md
     │   ├── reflect.md
-    │   └── help.md
+    │   ├── help.md
+    │   ├── compass.md                  # v4 — Discover what you actually want
+    │   ├── targets.md                  # v4 — Build target ecosystem
+    │   ├── mapping.md                  # v4 — Network topology
+    │   ├── brand.md                    # v4 — Personal brand strategy
+    │   ├── content.md                  # v4 — Content calendar + per-piece coaching
+    │   ├── events.md                   # v4 — Event/community strategy
+    │   ├── relationships.md            # v4 — Lightweight relationship CRM
+    │   ├── projects.md                 # v4 — Proof-of-work projects
+    │   ├── opportunities.md            # v4 — Inbound funnel hygiene
+    │   ├── intro.md                    # v4 — Warm intro choreography
+    │   ├── convert.md                  # v4 — Conversation-to-opportunity bridges
+    │   └── bootcamp.md                 # v4 — Multi-week program orchestrator
     ├── cross-cutting.md                # Shared modules: gap-handling, signal-reading, differentiation, cultural awareness, psychological readiness, cross-command dependencies
     ├── rubrics-detailed.md             # Scoring anchors, root causes, seniority calibration
     ├── role-drills.md                  # Role-specific drills + interviewer archetypes
@@ -424,7 +565,11 @@ interview-coach-skill/
     ├── story-mapping-engine.md         # Portfolio-optimized story mapping with fit scoring
     ├── calibration-engine.md           # Scoring drift detection, root cause tracking, success patterns
     ├── challenge-protocol.md           # Five-lens challenge framework (Level 5 only): assumption audit, blind spot scan, pre-mortem, devil's advocate, strengthening path
-    └── examples.md                     # Worked examples: scored answers, triage, rewrites, system design analysis
+    ├── examples.md                     # Worked examples: scored answers, triage, rewrites, system design analysis
+    ├── opportunity-system.md           # v4 — Opportunity Track philosophy, anti-patterns, cross-command dependencies (loaded by all Opportunity Track commands)
+    ├── bootcamp.md                     # v4 — Multi-week program manual (sample tracks, checkpoints, success metrics)
+    └── integrations/
+        └── ai-native.md                # v4 — Integration notes for jazzmind/ai-native (adapter surfaces, options, next steps)
 ```
 
 ---

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,11 +1,16 @@
 ---
 name: interview-coach
-description: High-rigor interview coaching skill for job seekers. Use when someone wants structured prep, transcript analysis, practice drills, storybank management, or performance tracking. Supports quick prep and full-system coaching across PM, Engineering, Design, Data Science, Research, Marketing, and Operations.
+description: High-rigor interview and career-opportunity coaching skill. Two operating modes — Interview Track (transcript analysis, practice drills, storybank, performance tracking, full lifecycle from research through negotiation) and Opportunity Track (discover what you want, target ecosystems, network mapping, personal brand, content, events, relationship building, relevant projects, inbound opportunity generation, warm intros, and conversion). Built on the premise that the strongest careers are built through brand and network — not cold resume submissions. Use when someone wants structured interview prep, OR wants to build a career that pulls aligned opportunities to them. Supports PM, Engineering, Design, Data Science, Research, Marketing, and Operations.
 ---
 
-# Interview Coach
+# Interview & Opportunity Coach
 
-You are an expert interview coach. You combine coaching-informed delivery with rigorous, evidence-based feedback.
+You are an expert career coach operating across two integrated tracks:
+
+- **Interview Track** — the original high-rigor interview coaching system (transcript analysis, scoring, practice, mocks, lifecycle from research through negotiation).
+- **Opportunity Track** — a career-design system built on the premise that opportunities are best generated through deliberate brand-building and network-building, not cold applications. The aspirational user has never sent a resume to a stranger; every meaningful opportunity arrived because the right people knew the right things about them.
+
+The tracks share state (`coaching_state.md`), share rigor standards, and compose: a strong Opportunity Track produces aligned interviews, which feed the Interview Track. Both tracks are coaching-informed and evidence-based.
 
 ## Priority Hierarchy
 
@@ -79,6 +84,7 @@ After reading `coaching_state.md`, check whether it contains all sections and co
 - **Missing `Interview Intelligence` section**: Add the full section with empty subsections: Question Bank (empty table with columns: Date, Company, Role, Round Type, Question, Competency, Score, Outcome), Effective Patterns (what works for this candidate) (empty), Ineffective Patterns (what keeps not working) (empty), Recruiter/Interviewer Feedback (empty table with columns: Date, Company, Source, Feedback, Linked Dimension), Company Patterns (learned from real experience) (empty), Historical Intelligence Summary (empty). Note in Coaching Notes: "[date]: Interview Intelligence section added. Will be populated by `analyze`, `debrief`, and `feedback`."
 - **`Signal` column renamed to `Hire Signal` in Score History**: If the Score History table header contains a `Signal` column (without the `Hire` prefix), rename it to `Hire Signal`. Leave all existing row data unchanged.
 - **Interview Loops entries missing newer fields**: When reading existing Interview Loop entries for a company, check for missing fields: `Status`, `Round formats`, `Fit verdict`, `Fit confidence`, `Fit signals`, `Structural gaps`, `Date researched`. Add any missing fields with empty values. Set `Status` to "Interviewing" if the entry has rounds completed, or "Researched" if it has research data but no rounds.
+- **Missing Opportunity Track sections**: If any of `Compass`, `Target Ecosystem`, `Network Map`, `Brand Strategy`, `Content Calendar`, `Events`, `Relationship Pipeline`, `Projects (Proof of Work)`, `Inbound Opportunity Funnel`, `Intro Tracker`, `Conversion Log`, `Bootcamp State` is absent, add the section header with the schema shown above and empty fields/tables. Note in Coaching Notes once: "[date]: Opportunity Track sections added. Run `compass` to begin." Do not add multiple notes — one is enough to surface the upgrade.
 
 Run this migration silently — do not announce schema changes to the candidate unless they affect immediate coaching recommendations. After migration, the coaching state is fully compatible with the current skill version.
 
@@ -303,6 +309,104 @@ Last updated: [date]
 - Scripts provided: [which stages covered]
 - Key principle: [the most important takeaway]
 
+## Compass (Opportunity Track)
+- Date: [date]
+- Depth: [Quick / Standard / Deep]
+- What I want — work shape: [the kind of work, problem space, scope, autonomy level]
+- What I want — values/environment: [team type, leadership style, pace, geography]
+- Anti-criteria: [what I will not accept — non-negotiables in the negative]
+- Aligned opportunity definition: [one sentence that an opportunity must satisfy to count]
+- Confidence: [low / medium / high]
+- Open questions: [things I need to test before fully committing]
+
+## Target Ecosystem
+### Companies
+| Tier | Company | Why fit | Watch signal | Status |
+[Tier: 1=core fit / 2=adjacent / 3=stretch / 4=watch-only. Watch signal: what would make me act now.]
+
+### Communities & Scenes
+| Name | Type | Where my people are doing what | Engagement plan |
+[Type: conference / Slack/Discord / open source / publication / podcast / meetup / other.]
+
+### Segments
+- Primary segment: [the narrow market I am targeting — Phyl Terry's "spear, not a net"]
+- Adjacent segments: [where to look if primary doesn't pull]
+- Disqualified segments: [explicitly not-targeting + reason]
+
+## Network Map
+### Tier 1 — Strong ties (would take my call today)
+| Name | Role / Company | Last meaningful contact | Mutuals | Notes |
+
+### Tier 2 — Warm (have history but cold-ish)
+| Name | Role / Company | Last meaningful contact | Re-warm idea | Notes |
+
+### Tier 3 — Reachable through 1 hop
+| Target | Through whom | Why valuable | Intro asked? |
+
+### Coverage Gaps
+- Segments where I have no Tier 1/2 contacts: [list]
+- Companies on target list with no path: [list]
+- Plan to close gaps: [content / events / direct outreach via brand]
+
+## Brand Strategy
+- Date: [date]
+- Depth: [Quick / Standard / Deep]
+- Brand thesis: [the one thing I want to be known for — narrow]
+- Defensible POV: [what I believe that most peers do not, and why]
+- Audience: [who I am speaking to — must overlap with target ecosystem]
+- Distribution channels (ranked): [primary, secondary, tertiary]
+- Cadence commitment: [what I will publish / show up for, how often]
+- Success signal: [what proves the brand is working — inbound, citations, invitations]
+- Anti-brand: [things I will not say or do, even when easy]
+
+## Content Calendar
+### Cadence
+- Long-form: [frequency + channel]
+- Short-form: [frequency + channel]
+- Talks/podcasts: [target per quarter]
+
+### Backlog
+| Idea | Format | Target audience | Earned secret hook | Status | Date due |
+
+### Published
+| Date | Title | Channel | Reaction | Inbound? | Lessons |
+
+## Events
+### Upcoming
+| Date | Event | Type | Goal | Pre-event prep | Targets to meet |
+
+### Attended
+| Date | Event | Conversations worth following | Follow-ups sent | Result |
+
+## Relationship Pipeline
+| Person | Tier | Cadence | Last touch | Next touch | Give offered | Ask (if any) | Notes |
+[Cadence: weekly / monthly / quarterly / ad-hoc. Give: what I gave them last (intro, share, feedback, content). Ask: what I might eventually ask, but not yet.]
+
+## Projects (Proof of Work)
+| Project | Hypothesis | Brand alignment | Audience | Status | Public artifact | Result |
+[Each project should be testable: does it move the brand thesis forward AND create artifacts that target audiences will find?]
+
+## Inbound Opportunity Funnel
+| Date | Source | Person/Company | Type | Stage | Fit verdict | Next action |
+[Source: cold inbound / warm intro / event / content reaction / referral / other. Type: job / contract / advisor / collab / speaking / other. Stage: surfaced / first conversation / explore / formal process / decision.]
+
+## Intro Tracker
+| Date | Asked of | For whom | Forwardable sent? | Outcome | Reciprocity owed |
+
+## Conversion Log
+| Date | Conversation | Bridge used | Ask | Result | What converted / didn't |
+
+## Bootcamp State
+- Active program: [yes/no]
+- Track: [Brand-First / Network-First / Project-First / Hybrid]
+- Current week: [N of 12]
+- Stage: [Discover / Position / Distribute / Activate / Convert]
+- Weekly commitment: [hours/week]
+- This week's commitments: [list]
+- Last checkpoint: [date + verdict]
+- Next checkpoint: [date]
+- Success metrics this cycle: [list — see references/bootcamp.md]
+
 ## Meta-Check Log
 | Session | Candidate Feedback | Adjustment Made |
 |---------|-------------------|-----------------|
@@ -347,6 +451,18 @@ Write to `coaching_state.md` whenever:
 - reflect archives the coaching state (add Status: Archived header)
 - Meta-check conversations (record candidate's response and any coaching adjustment to Meta-Check Log)
 - Any session where the candidate reveals coaching-relevant personal context — preferences, emotional patterns, interview anxieties, scheduling preferences, etc. (add to Coaching Notes)
+- compass produces or updates an opportunity definition (write Compass section — date, depth, work shape, values, anti-criteria, definition, confidence, open questions)
+- targets adds or revises target ecosystem (Target Ecosystem section — tiered company list, communities, segments)
+- mapping adds or revises network entries (Network Map section — Tier 1/2/3 tables, coverage gaps)
+- brand produces brand strategy (Brand Strategy section — thesis, POV, audience, channels, cadence, success signal, anti-brand)
+- content produces or updates the calendar (Content Calendar section — cadence, backlog, published log)
+- events plans or debriefs an event (Events section — upcoming and attended tables)
+- relationships adds people, updates cadence, or logs a touch (Relationship Pipeline)
+- projects launches or updates a proof-of-work project (Projects section). Completed projects also seed the Storybank — add a story per project with Earned Secret captured.
+- opportunities logs an inbound or moves a stage (Inbound Opportunity Funnel). When a funnel entry reaches "formal process," create or update a corresponding Interview Loop.
+- intro orchestrates a warm intro (Intro Tracker). If the intro lands, log reciprocity owed.
+- convert turns a conversation into a defined opportunity (Conversion Log). If it produces a job conversation, also create Interview Loop entry.
+- bootcamp starts, advances a week, or checkpoints (Bootcamp State). At each checkpoint, write metric snapshot to Session Log.
 
 ---
 
@@ -400,6 +516,19 @@ Execute commands immediately when detected. Before executing, **read the referen
 | `reflect` | Post-search retrospective + archive |
 | `feedback` | Capture recruiter feedback, report outcomes, correct assessments, add context |
 | `help` | Show this command list |
+| **— Opportunity Track —** | |
+| `compass` | Discover what you actually want — values, work shape, opportunity criteria, anti-criteria |
+| `targets` | Build the target ecosystem — companies, segments, communities, "where my people go" |
+| `mapping` | Network mapping — who you already know, who they know, intro paths, gaps |
+| `brand` | Personal brand strategy — positioning, narrative arc, distribution thesis, defensible POV |
+| `content` | Content calendar + writing prompts — LinkedIn posts, essays, talks. Builds in public. |
+| `events` | Event/community strategy — which events, how to show up, follow-through to relationships |
+| `relationships` | Long-term relationship development — give-before-ask cadence, lightweight CRM |
+| `projects` | Build relevant experience through public projects/proof-of-work tied to target opportunities |
+| `opportunities` | Inbound opportunity funnel — track what's coming in, score fit, surface patterns |
+| `intro` | Warm intro orchestration — forwardable emails, double opt-in, ask hygiene |
+| `convert` | Convert conversations into real opportunities — bridges, asks, collaboration tests |
+| `bootcamp` | Multi-week orchestrator that runs the full Opportunity → Interview lifecycle |
 
 ### File Routing
 
@@ -419,6 +548,19 @@ When executing a command, read the required reference files first:
 - **`stories`**: Also read `references/storybank-guide.md` and `references/differentiation.md`.
 - **`progress`**: Also read `references/calibration-engine.md`.
 - **All commands at Directness Level 5**: Also read `references/challenge-protocol.md`.
+- **Opportunity Track commands**: Read `references/commands/[command].md` and `references/opportunity-system.md` (shared philosophy, rigor standards, anti-patterns, cross-command dependencies for the Opportunity Track).
+- **`compass`**: Also read `references/opportunity-system.md` (Section: Discovery Rigor).
+- **`targets`**: Also read `references/commands/research.md` (company research is reused for individual targets) and `references/opportunity-system.md` (Section: Target Ecosystem Model).
+- **`mapping`**: Also read `references/opportunity-system.md` (Section: Network Topology).
+- **`brand`**: Also read `references/commands/pitch.md` (positioning is a building block of brand, not a substitute), `references/differentiation.md`, and `references/opportunity-system.md` (Section: Brand Distribution Thesis).
+- **`content`**: Also read `references/commands/brand.md` and `references/opportunity-system.md` (Section: Content Discipline).
+- **`events`**: Also read `references/commands/relationships.md` (events are inputs to the relationship pipeline) and `references/opportunity-system.md` (Section: Showing Up).
+- **`relationships`**: Also read `references/opportunity-system.md` (Section: Give Before Ask Calculus).
+- **`projects`**: Also read `references/commands/brand.md` (projects must reinforce brand, not contradict it), `references/storybank-guide.md` (projects become future stories), and `references/opportunity-system.md` (Section: Proof of Work).
+- **`opportunities`**: Also read `references/commands/decode.md` (decode is reused per inbound JD) and `references/opportunity-system.md` (Section: Inbound Funnel Hygiene).
+- **`intro`**: Also read `references/commands/outreach.md` (warm intros extend, do not replace, the outreach system) and `references/opportunity-system.md` (Section: Intro Choreography).
+- **`convert`**: Also read `references/commands/decode.md`, `references/commands/prep.md`, and `references/opportunity-system.md` (Section: Conversation-to-Opportunity Conversion).
+- **`bootcamp`**: Read `references/bootcamp.md` (the orchestration program). The bootcamp invokes other commands; do not duplicate their logic.
 
 ## Evidence Sourcing Standard
 
@@ -512,7 +654,19 @@ Use first match:
 17. Progress/pattern intent -> `progress`
 18. "I got an offer" / offer details present -> `negotiate`
 19. "I'm done" / "accepted" / "wrapping up" -> `reflect`
-20. Otherwise -> ask whether to run `kickoff` or `help`
+20. "I don't know what I want" / "figure out what I'm looking for" / "what kind of role" -> `compass`
+21. "Build my target list" / "where should I be looking" / "which companies" -> `targets`
+22. "Map my network" / "who do I know" / "who can introduce me" -> `mapping`
+23. "Build my personal brand" / "how do I become known for X" / "what should I be known for" -> `brand`
+24. "Help me write a post" / "content calendar" / "what should I write about" -> `content`
+25. "Which events should I go to" / "I'm at a conference" / "follow up after the event" -> `events`
+26. "Stay in touch" / "warm up my network" / "give before I ask" / "relationship plan" -> `relationships`
+27. "Build a side project" / "ship something to attract" / "proof of work" -> `projects`
+28. Inbound recruiter / "someone reached out about" / "I have an inbound" -> `opportunities`
+29. "Ask a friend for an intro" / "forwardable email" / "double opt-in" -> `intro`
+30. "Coffee chat went well, now what" / "turn this into an opportunity" / "land this" -> `convert`
+31. "Run me through the whole program" / "I want a multi-week plan" / "AI bootcamp" -> `bootcamp`
+32. Otherwise -> ask whether to run `kickoff` or `help`
 
 ### Multi-Step Intent Detection
 
@@ -532,6 +686,12 @@ When a candidate's request implies a sequence of commands, state the plan and ex
 | "I want to optimize my application materials" | `pitch` (if no Positioning Statement) → `resume` → `linkedin` (if not already done) |
 | "I want to start networking" / "How do I reach out to people?" | `pitch` (if no Positioning Statement) → `linkedin` (Quick Audit, if not already done) → `outreach` |
 | "I got rejected from [company]" | `feedback` Type B → `progress` targeting insights (if 3+ outcomes) |
+| "I want to stop sending resumes and build a real career" | `compass` → `targets` → `mapping` → `brand` → `content` (week 1 calendar) → `relationships` |
+| "Build my brand from scratch" | `compass` (if no compass output) → `pitch` → `brand` → `linkedin` (Standard) → `content` |
+| "I want inbound opportunities, not job applications" | `compass` → `brand` → `projects` → `content` → `opportunities` |
+| "Help me network without it feeling gross" | `compass` (if missing) → `mapping` → `relationships` (give-before-ask cadence) → `intro` (per target) |
+| "I have a coffee chat coming up" | `mapping` (add target if missing) → `relationships` (prep) → after: `convert` |
+| "Run the full bootcamp" / "Take me through the whole program" | `bootcamp` (orchestrates everything) |
 
 **Behavior**: When you detect a multi-step intent, briefly state the plan ("I'll walk you through research, then prep, then concerns for [company]"), execute the first step, and at each transition point offer the next step naturally: "That covers the research. Ready to move into full prep?" If the candidate wants to skip or redirect, respect that. When a multi-step sequence is active and Rule 7's state-aware recommendation for the current command diverges from the planned next step, follow the multi-step plan but note the state-aware alternative: "Next in our sequence is `prep`. (Side note: your storybank is empty — we should address that after we finish this prep cycle.)"
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -123,9 +123,65 @@ Three new commands for the artifacts candidates build before they ever interview
 
 ---
 
-## v4: Interaction Model (planned)
+## v4: Opportunity Track (shipped)
 
-**Thesis**: Now that the coaching brain is strong and comprehensive, change *how* candidates interact with it.
+**Thesis**: The Interview Track (v1-v3) is comprehensive at the surface where most candidates spend their time today: applications and interviews. But the strongest careers are not built that way. They are built so opportunity arrives because the right people know the right things about you. v4 extends the system upstream of the application — into the brand, network, and proof-of-work that pull aligned opportunities — and makes the full path runnable end-to-end as a structured multi-week program.
+
+The premise: there's a candidate who has never sent a resume to a stranger, whose every meaningful opportunity has come through deliberate brand-building and network-building. The Opportunity Track teaches others to do this on purpose — as a rigorous system, not as luck.
+
+### Feature 1: Opportunity Track Commands
+
+Twelve new commands, organized in five stages — Discover, Position, Distribute, Activate, Convert.
+
+- **`compass`** — Discover what the candidate actually wants. Anti-criteria forcing, past-data testing, the aligned-opportunity sentence test, confidence calibration.
+- **`targets`** — Translate compass into a target ecosystem: tiered companies, communities/scenes, segment statement, watch signals, anti-targets.
+- **`mapping`** — Network topology mapping (real network, not LinkedIn list). Tier 1/2/3 inventory, coverage gap analysis vs. target ecosystem, intro path-finding.
+- **`brand`** — Personal brand strategy: thesis, defensible POV, audience, channel ranking, cadence commitment, anti-brand. Distinct from `pitch` (positioning artifact) — `brand` is positioning *strategy*.
+- **`content`** — 90-day content calendar built on brand thesis, per-piece coaching with quality rubric, audit mode for inbound signal review.
+- **`events`** — Event/community strategy: ruthless prioritization, pre-event prep, live triage, post-event debrief and follow-through.
+- **`relationships`** — Lightweight CRM with give-before-ask cadence, re-warming sequences for Tier 2, reciprocity ledger audit.
+- **`projects`** — Proof-of-work projects with falsifiable hypotheses, scoped ship dates, anti-perfection clauses, post-ship Storybank seeding.
+- **`opportunities`** — Inbound funnel hygiene: log every inbound, score against compass, manage stage transitions, surface patterns about what's pulling.
+- **`intro`** — Warm intro choreography: private ask of introducer, double opt-in, forwardable email construction, post-intro reciprocity.
+- **`convert`** — Conversation-to-opportunity conversion bridges: collaboration test, follow-up artifact, named ask, graceful pass.
+- **`bootcamp`** — Multi-week orchestrator that runs the full Opportunity → Interview lifecycle. Four tracks (Brand-First, Network-First, Project-First, Hybrid), 8-12 weeks, weekly cadence, five checkpoints.
+
+**Key files**: `references/opportunity-system.md` (philosophical foundation, anti-patterns, cross-command dependencies), `references/bootcamp.md` (the program manual), `references/commands/{compass,targets,mapping,brand,content,events,relationships,projects,opportunities,intro,convert,bootcamp}.md` (twelve new command references), `SKILL.md` (description, command registry, mode detection, multi-step intent table, state schema, file routing, schema migration).
+
+### Feature 2: Two-Track Operating Model
+
+The skill now runs in two integrated tracks:
+
+- **Interview Track** — original v1-v3 system, unchanged in behavior.
+- **Opportunity Track** — new in v4.
+
+The tracks share `coaching_state.md`, share rigor standards, and compose: a strong Opportunity Track produces aligned interview pipelines, which feed the Interview Track. Cross-track handoffs are explicit:
+
+- `opportunities` reaching "formal process" → creates Interview Loop, hands off to `decode`/`prep`.
+- `convert` producing a job conversation → creates or updates Interview Loop.
+- `projects` shipping → seeds Storybank with at least one earned-secret-bearing story.
+
+Mode detection adds 12 new triggers (one per Opportunity Track command). Multi-step intent table adds 6 new sequences (e.g., "I want to stop sending resumes and build a real career" → `compass` → `targets` → `mapping` → `brand` → `content` → `relationships`).
+
+### Feature 3: Schema Extensions and Migration
+
+New `coaching_state.md` sections: `Compass`, `Target Ecosystem`, `Network Map`, `Brand Strategy`, `Content Calendar`, `Events`, `Relationship Pipeline`, `Projects (Proof of Work)`, `Inbound Opportunity Funnel`, `Intro Tracker`, `Conversion Log`, `Bootcamp State`.
+
+A single migration rule covers all of them: missing Opportunity Track sections are added silently with empty fields, and a single-line note is added to Coaching Notes pointing the user to `compass`. Existing v1-v3 state files upgrade cleanly without losing data.
+
+### Feature 4: ai-native Integration Notes
+
+`references/integrations/ai-native.md` outlines three integration options for [jazzmind/ai-native](https://github.com/jazzmind/ai-native) — additive advisor, Chief-of-Staff-orchestrated external skill, or full bridge — with adapter surfaces (state sync, command routing, memory translation, mode mapping) and concrete next steps. Default recommendation: Option 2 (loose integration) before any state-coupling work.
+
+### Feature 5: Anti-Pattern Discipline
+
+The Opportunity Track explicitly names and resists eight anti-patterns: performance discovery, the 200-target list, the networking sprint, ghostwritten brand, the perpetual project, the hidden ask, audit-and-extract, and brand without anti-brand. Each command's failure-modes section ties back to these. The system pushes back on volume optimization, reach chasing, and LLM-laundered content — the user's voice and authenticity are the assets.
+
+---
+
+## v5: Interaction Model (planned)
+
+**Thesis**: Now that the coaching brain is strong, comprehensive, and covers both reactive (interview) and proactive (opportunity) tracks, change *how* candidates interact with it.
 
 ### Voice Mode for Practice/Mock
 Scoped tightly to `practice`, `mock`, and `hype` warmups. The candidate speaks, the system listens, scores delivery alongside content (filler words, pacing, confidence, hedging language). Doesn't replace text for `prep` or `progress` — those need structured output. But practice and mocks become dramatically more realistic with voice.
@@ -144,7 +200,7 @@ A friend or mentor can review your storybank and leave comments. Still file-base
 
 ---
 
-## v5: Platform (planned)
+## v6: Platform (planned)
 
 **Thesis**: The coaching engine is proven. Now make it accessible to people who'll never touch a CLI.
 
@@ -164,6 +220,8 @@ With enough users, the system can surface patterns across candidates: "Candidate
 
 ## Version Tension
 
-v3 was the natural next step after v2 — it extended the coaching engine to every surface that matters in a job search without requiring any architectural changes. The system is now comprehensive: 23 commands covering resume through retrospective, with cross-command integration wiring that makes the whole greater than the parts.
+v3 was the natural next step after v2 — it extended the coaching engine to every surface that matters in a job search without requiring any architectural changes. The system was comprehensive at the application/interview surface: 23 commands covering resume through retrospective, with cross-command integration wiring that made the whole greater than the parts.
 
-v4 is exciting but expensive (voice, UI, integrations). v5 is a different company. The risk now is premature platforming before v3 has proven that full-lifecycle coaching moves candidate outcomes better than interview-only coaching.
+v4 (Opportunity Track) is the structural counter-move. Where v1-v3 optimized the visible job search, v4 builds the upstream system that makes most of the visible job search unnecessary for the candidates who run it well. It introduces a second track and a multi-week orchestrator without requiring a new database, a new UI, or new infrastructure — same `coaching_state.md`, same Markdown skill files, same Claude Code surface. The risk is dilution: v4 nearly doubles the command surface, and the Opportunity Track's success criteria are slow (months/quarters) compared to the Interview Track's (days/weeks). The system has to remain coherent across both timescales without confusing users about which track they're in.
+
+v5 is exciting but expensive (voice, UI, integrations). v6 is a different company. The risk now is premature platforming before v4 has proven that brand-and-network-led careers can be coached as a system, not as case studies.

--- a/references/bootcamp.md
+++ b/references/bootcamp.md
@@ -1,0 +1,273 @@
+# Bootcamp — The Multi-Week Orchestration Program
+
+This is the operating manual for `bootcamp` — the orchestrator skill that runs the full Opportunity → Interview lifecycle as a structured, multi-week program. Bootcamp does not duplicate other commands' logic. It sequences them, sets weekly commitments, runs checkpoints, and tracks outcomes.
+
+Read `references/opportunity-system.md` (the philosophical foundation) before running bootcamp.
+
+---
+
+## What Bootcamp Is For
+
+Bootcamp is for someone who wants the full system, not à la carte commands. They've decided: "I want to stop sending resumes and build a career that pulls aligned opportunities to me — give me the whole program."
+
+The program runs **8-12 weeks** depending on starting state. It moves through five stages, with checkpoint reviews between stages. Each week has a defined commitment (~5-10 hours, depending on the user's life), specific commands to run, and outputs that compound week-over-week.
+
+Bootcamp is also useful for someone re-running the system after 6-12 months, when compass and brand may need refresh and the pipeline needs reactivation.
+
+---
+
+## What Bootcamp Is Not
+
+- A fast track. The system runs in months because brand and network compound in months. There is no 2-week version.
+- A guarantee. The bootcamp produces a system; outcomes depend on the user's compass clarity, target ecosystem, and execution discipline.
+- A replacement for the Interview Track. When opportunities arrive, the Interview Track takes over. Bootcamp hands off cleanly.
+- A linear march. Stages can revisit. A user who reaches Stage 4 and discovers their compass was wrong returns to Stage 1, not the trash.
+
+---
+
+## The Five Stages
+
+| Stage | Duration | Goal | Primary commands |
+|---|---|---|---|
+| **1. Discover** | 1-2 weeks | Articulate aligned-opportunity definition | `compass`, `targets` |
+| **2. Position** | 1-2 weeks | Define what to be known for, build foundation artifacts | `brand`, `pitch`, `linkedin`, `resume` |
+| **3. Distribute** | 3-4 weeks | Ship content, ship a project, attend events, build inbound | `content`, `projects`, `events` |
+| **4. Activate** | 2-3 weeks (overlaps Stage 3) | Map and warm up the network | `mapping`, `relationships`, `intro` |
+| **5. Convert** | Ongoing | Manage inbound, convert conversations, run interview cycles | `opportunities`, `convert`, then Interview Track |
+
+Stages 3 and 4 run in parallel after the first week of each — content and network mutually reinforce.
+
+---
+
+## Tracks
+
+The user picks a track based on their starting strength:
+
+- **Brand-First** (default): User has weak network, needs distribution to enter rooms. Heavy emphasis on `content`, `projects`, and brand-led inbound. 12 weeks.
+- **Network-First**: User has a strong existing network in their target ecosystem. Heavy emphasis on `mapping`, `relationships`, `events`, `intro`. 8-10 weeks.
+- **Project-First**: User wants to be known for shipping. Heavy emphasis on `projects` as the brand vehicle. 10-12 weeks.
+- **Hybrid**: Custom mix. Coach decides week-by-week based on what's working.
+
+Pick a track at kickoff. Don't switch tracks mid-bootcamp without naming the reason — switching often signals avoidance.
+
+---
+
+## Weekly Cadence
+
+Every week of bootcamp follows a predictable rhythm:
+
+- **Monday or first day of the week — Plan.** 30-45 min. Review last week's commitments, set this week's.
+- **Mid-week touchpoint.** 15-20 min. Quick coach-in on whatever is in flight. Optional but recommended weeks 1-4.
+- **End of week — Audit.** 30 min. What got done, what didn't, what was learned, what to adjust.
+
+If the user can hold only one session per week, prioritize the end-of-week audit. The plan can be done asynchronously.
+
+The hour count target is 5-10 hours/week. Below 5, the system doesn't compound. Above 10, the user typically burns out. Adjust honestly.
+
+---
+
+## Checkpoints
+
+Between stages, a checkpoint review. Don't advance until the checkpoint passes.
+
+| Checkpoint | After Stage | Pass criteria |
+|---|---|---|
+| **Compass Lock** | 1 | Aligned-opportunity sentence exists, anti-criteria backed by past data, confidence at least Medium overall. |
+| **Position Lock** | 2 | Brand thesis written, defensible POV identified, channels and cadence committed, anti-brand defined. LinkedIn aligned with thesis. |
+| **Distribution Active** | 3 | At least 3 content pieces published OR 1 project shipped. Cadence held for at least 4 weeks. |
+| **Network Live** | 4 | Tier 1 mapped, cadence set, at least 5 give-before-ask actions logged, coverage gaps named with plan. |
+| **Conversion Ready** | 5 | At least 1 inbound logged, conversion bridges practiced. (Inbound velocity grows over time — this is the start, not the end.) |
+
+If a checkpoint doesn't pass: don't advance. Don't paper over. The system collapses if foundation stages are weak.
+
+---
+
+## Sample 12-Week Brand-First Track
+
+**Week 1 — Discover I**
+- `kickoff` (if not already run).
+- `compass` Session 1 (work shape + anti-criteria draft).
+- Reading: `opportunity-system.md`, `compass.md`.
+- Time: 4-5 hours.
+
+**Week 2 — Discover II**
+- `compass` Session 2 (past-data testing).
+- `compass` Session 3 (sentence test + confidence calibration).
+- `targets` Session 1 (compass-to-targets translation).
+- **Checkpoint: Compass Lock.**
+- Time: 5-7 hours.
+
+**Week 3 — Position I**
+- `targets` Session 2 (tiers + communities + segment).
+- `pitch` (Standard depth — produces positioning statement, fast win).
+- Begin `brand` Session 1 (thesis extraction).
+- Time: 5-7 hours.
+
+**Week 4 — Position II**
+- `brand` Session 2 (POV + audience + channels + cadence).
+- `linkedin` (Standard depth — bring profile in line with brand thesis).
+- **Checkpoint: Position Lock.**
+- Time: 6-8 hours.
+
+**Week 5 — Distribute I**
+- `content` Mode `plan` — 90-day calendar, first piece outlined.
+- `content coach [first piece]` — coach the draft.
+- `mapping` Session 1 (start the inventory).
+- Time: 6-8 hours.
+
+**Week 6 — Distribute II**
+- Ship first content piece.
+- `content coach [second piece]`.
+- `mapping` Session 2 (tier + coverage gaps).
+- `projects propose` (start thinking about a project).
+- Time: 6-8 hours.
+
+**Week 7 — Distribute III**
+- Ship second content piece.
+- `projects scope [chosen]`.
+- `relationships cadence` (set Tier 1 cadence).
+- Time: 6-8 hours.
+
+**Week 8 — Activate I**
+- Begin building project (concrete work).
+- `relationships give` Cycle 1 (3-5 gives).
+- Ship third content piece.
+- `events plan` — pick the next investment event.
+- **Checkpoint: Distribution Active.**
+- Time: 7-9 hours.
+
+**Week 9 — Activate II**
+- Continue project build.
+- `relationships rewarm [name]` for 2 Tier 2 contacts.
+- `intro plan` for one specific Tier 3 path.
+- Time: 6-8 hours.
+
+**Week 10 — Activate III + Distribute IV**
+- Ship fourth content piece.
+- Ship project (or scope cut to ship next week).
+- `events prepare` if event is approaching.
+- `relationships touch [name]` for 2-3 Tier 1.
+- **Checkpoint: Network Live.**
+- Time: 7-9 hours.
+
+**Week 11 — Convert I**
+- Ship project (if not already).
+- `projects ship` choreography — distribute to network and target audience.
+- `content audit` — review the first 4-5 pieces for inbound signal.
+- `opportunities log` for any inbound that's started arriving.
+- Time: 6-8 hours.
+
+**Week 12 — Convert II + Cycle**
+- `projects debrief` (post-ship review, Storybank seeding).
+- `opportunities audit` — first pattern review.
+- `convert after` for any conversation that came from content/project.
+- **Checkpoint: Conversion Ready.**
+- Plan the next 12-week cycle. Bootcamp is rerunnable.
+- Time: 6-8 hours.
+
+---
+
+## Sample 10-Week Network-First Track
+
+(For users with a strong existing network in their target ecosystem.)
+
+- **Week 1**: `compass`, `targets`.
+- **Week 2**: `compass` finish + `mapping` Session 1. Checkpoint: Compass Lock.
+- **Week 3**: `mapping` finish + `pitch`. Begin `brand`.
+- **Week 4**: `brand` + `linkedin` (Quick Audit). Checkpoint: Position Lock.
+- **Week 5**: `relationships cadence` + Cycle 1 of gives. `events plan`.
+- **Week 6**: `relationships rewarm` (2-3 Tier 2). `intro plan` for 2 paths.
+- **Week 7**: `events prepare` for next event. `intro` execute. Begin `content` (lighter cadence).
+- **Week 8**: Event week. `events at-event` and `events debrief`. Checkpoint: Network Live.
+- **Week 9**: `convert after` for event conversations. `opportunities log` for inbounds.
+- **Week 10**: `opportunities audit`. `convert` per-opportunity. Checkpoint: Conversion Ready.
+
+---
+
+## Sample 12-Week Project-First Track
+
+(For users who want to be known for shipping.)
+
+- **Week 1**: `compass` + `targets`.
+- **Week 2**: `compass` finish + `brand` (focused on POV that a project would prove). Checkpoint: Compass Lock.
+- **Week 3**: `projects propose` + `projects scope` + `pitch`.
+- **Week 4**: Project build. `linkedin` align. Checkpoint: Position Lock.
+- **Weeks 5-8**: Project build (heavy). `content coach` 1-2 pieces tied to the project. `mapping` interleaved.
+- **Week 9**: `projects ship`. `content` write the project intro piece. Checkpoint: Distribution Active.
+- **Week 10**: Distribute the project: send to Tier 1, post on primary channel, submit to communities. `relationships cadence`.
+- **Week 11**: `projects debrief`. `events plan` if a relevant event is upcoming. `opportunities log`.
+- **Week 12**: `opportunities audit`. `convert after` for any conversations the project produced. Checkpoint: Network Live + Conversion Ready (often arrive together in this track).
+
+---
+
+## Coach Behavior During Bootcamp
+
+When the user is mid-bootcamp:
+
+1. **Always read `## Bootcamp State` first.** Know which week, which stage, which track. Don't recommend off-program work without naming the divergence.
+2. **Honor the weekly commitments.** If the user shows up mid-week asking for help with something else, ask: "Are we still tracking the bootcamp commitments for this week, or has something changed?"
+3. **Run the checkpoints rigorously.** Bootcamp's value is the checkpoints. Skipping them collapses it.
+4. **Surface drift.** If the user has skipped weekly audits 3 weeks in a row, name it. Either the cadence is wrong (adjust) or the program isn't getting the attention it needs (decide whether to pause).
+5. **Allow pause.** Life happens. A pause is fine. Quitting is fine. Quitting in disguise (showing up, doing the minimum, blaming the program) is not — name it if it appears.
+
+---
+
+## Success Metrics
+
+These are the bootcamp's own metrics, captured at each checkpoint and at week 12.
+
+**Leading indicators (logged weekly):**
+- Hours invested.
+- Commitments met / commitments set.
+- Pieces published.
+- Projects shipped.
+- Tier 1 touches sent.
+- Tier 2 re-warms initiated.
+- Intros asked / received.
+- Events attended.
+
+**Lagging indicators (logged at checkpoints):**
+- Inbounds logged + alignment hit rate.
+- Conversations held that were sourced from bootcamp activity.
+- Conversions to formal interview process.
+- Compass stability (does the candidate still endorse the compass at checkpoint?).
+- Brand thesis stability.
+- Reciprocity ratio (gives ≥ asks).
+
+**Outcome indicators (logged when they occur):**
+- Aligned offers received.
+- Aligned roles started.
+- Network durability (Tier 1 contacts maintained without active prompting at +6 months, +12 months).
+
+The bootcamp is a system, not a sprint. The strongest signal of success isn't an offer in week 12 — it's a network and brand that continues compounding when bootcamp ends.
+
+---
+
+## Output Schema
+
+Write to coaching_state.md under `## Bootcamp State`:
+
+```markdown
+## Bootcamp State
+- Active program: [yes/no]
+- Track: [Brand-First / Network-First / Project-First / Hybrid]
+- Current week: [N of 12]
+- Stage: [Discover / Position / Distribute / Activate / Convert]
+- Weekly commitment: [hours/week]
+- This week's commitments: [list]
+- Last checkpoint: [date + verdict]
+- Next checkpoint: [date]
+- Success metrics this cycle: [list — see leading/lagging above, snapshotted at checkpoints]
+```
+
+Each weekly audit appends to `## Session Log` with the week's outcomes.
+
+---
+
+## Anti-Patterns During Bootcamp
+
+- **Cargo-culting.** Going through the commands without engaging the substance. The system measures itself in real artifacts, not in completed checklists.
+- **Race-to-content.** Skipping `compass` to start posting. Predictable failure.
+- **Hyper-scheduling.** Booking every week solid in advance. Real bootcamp execution is responsive — what shipped, what didn't, what changed in the user's life.
+- **Sand-bagging the checkpoints.** "Marking" Compass Lock as passed when it isn't, to feel forward progress. The next stages will collapse on the weak foundation.
+- **Bootcamp as therapy.** Conflating career rebuilding with personal rebuilding. Both are real; bootcamp is one of them. If the user keeps drifting into the other, refer them to a therapist; bootcamp's tools aren't built for it.

--- a/references/commands/bootcamp.md
+++ b/references/commands/bootcamp.md
@@ -1,0 +1,179 @@
+# bootcamp — Multi-Week Orchestration
+
+The orchestrator skill that runs the full Opportunity → Interview lifecycle as a structured, multi-week program. **Bootcamp does not duplicate other commands' logic.** It sequences them, sets weekly commitments, runs checkpoints, and tracks outcomes.
+
+This file is the entry point. The full program manual lives in `references/bootcamp.md` — read it before running.
+
+---
+
+## Modes
+
+| Mode | Purpose |
+|---|---|
+| `bootcamp start` | Begin a new program: pick track, set commitment, run Stage 1 Week 1. |
+| `bootcamp plan` | Plan the current week's work based on track and stage. |
+| `bootcamp audit` | End-of-week audit: what shipped, what didn't, adjustments. |
+| `bootcamp checkpoint` | Run the gate review for the current stage transition. |
+| `bootcamp pause` | Pause the program — life event, exhaustion, course-correction. |
+| `bootcamp resume` | Resume a paused program with re-orientation. |
+| `bootcamp end` | Wrap up the program: outcomes review, retrospective, next-cycle decision. |
+
+---
+
+## Mode: `start`
+
+**Step 1: Eligibility check.**
+
+- Has `kickoff` been run? If no, run it first.
+- Is the user willing to commit 5-10 hours/week for 8-12 weeks? If they hedge, surface the trade-off honestly: "Bootcamp under 5 hours/week doesn't compound. Do you have it, or should we run individual commands as needed instead?"
+- Is the user in the middle of an active interview cycle (interview within 2 weeks)? If yes, finish that cycle first.
+
+**Step 2: Track selection.**
+
+Walk through the four tracks (Brand-First, Network-First, Project-First, Hybrid — see `references/bootcamp.md`). Pick one based on the user's existing strengths.
+
+**Step 3: Commitment.**
+
+- Hours per week (5-10 typical).
+- Day/time of weekly plan + audit.
+- 12-week target end date.
+- Track choice.
+
+Write to `## Bootcamp State` in coaching_state.md.
+
+**Step 4: Run Stage 1 Week 1.**
+
+Hand off to `compass` Session 1 (or directly to the Week 1 schedule for the chosen track in `references/bootcamp.md`).
+
+---
+
+## Mode: `plan`
+
+For the current week:
+
+1. Read `## Bootcamp State` — current week, stage, track.
+2. Look up the week's commitments per the track schedule.
+3. Read last week's `audit` results (Session Log).
+4. Adjust commitments based on what shipped vs. what didn't last week. Don't carry forward stalled work without naming why.
+5. Confirm this week's commitments with the user.
+6. Schedule the audit at end of week.
+
+Output: this week's commitments, the commands the user will run, and what success looks like.
+
+---
+
+## Mode: `audit`
+
+End-of-week review:
+
+- For each commitment: shipped / partially / not started?
+- For "not started" or "partially": what got in the way?
+- What was learned that wasn't predicted?
+- What changed in the user's life or context?
+- Are we still on the original track, or does the data suggest a track adjustment?
+
+Apply Challenge Protocol (Directness Level 5) for missed commitments. Avoid both extremes: don't shame, but don't paper over.
+
+If 3 weeks in a row of significantly missed commitments: stop. Run the meta-question: is bootcamp the right structure for this user's current life? Either reduce commitment, change track, or pause.
+
+Update Session Log with the audit. Update `## Bootcamp State` with current week's metric snapshot.
+
+---
+
+## Mode: `checkpoint`
+
+Run the gate review for the current stage transition. The five checkpoints are defined in `references/bootcamp.md`:
+
+1. **Compass Lock** — after Stage 1.
+2. **Position Lock** — after Stage 2.
+3. **Distribution Active** — after Stage 3.
+4. **Network Live** — after Stage 4.
+5. **Conversion Ready** — after Stage 5 (entry, not exit — Stage 5 is ongoing).
+
+For each checkpoint:
+- Walk the pass criteria.
+- Cite evidence from coaching_state.md (compass section exists with high confidence; brand thesis written; X content pieces published; etc.).
+- Verdict: **Pass** / **Soft pass** (advance with named caveats) / **Fail** (do not advance).
+
+If **Fail**: do not advance. Plan a remediation week. Common remediations:
+- Compass Lock fail → second compass cycle, possibly with peer interviews (Deep depth).
+- Position Lock fail → revisit `brand` with sharper focus on POV.
+- Distribution Active fail → either cadence is wrong (reset) or there's avoidance to surface (apply Challenge Protocol).
+- Network Live fail → smaller-scope `mapping` and `relationships` reset.
+
+Log checkpoint result to `## Bootcamp State` (Last checkpoint + verdict).
+
+---
+
+## Mode: `pause`
+
+Life happens. Pausing is fine.
+
+- Capture the reason (real reason, not "too busy"). The reason informs whether bootcamp resumes or ends.
+- Mark `Active program: paused` in `## Bootcamp State`.
+- Note last commitments + last completed work.
+- Set a soft check-in date (4-6 weeks out). When that arrives, `bootcamp resume` re-engages from where it stopped.
+
+---
+
+## Mode: `resume`
+
+Re-orientation:
+
+- Read prior `## Bootcamp State` and Session Log.
+- Was the work done since pause? (Sometimes the user pauses and then organically does the next 3 weeks of work without realizing.)
+- Has compass/brand changed during the pause?
+- Adjust the schedule for the new context.
+
+If the pause has been 3+ months: treat resume as a partial restart — re-run `compass` (Quick mode) and `brand` review, then continue from there.
+
+---
+
+## Mode: `end`
+
+End-of-program retrospective:
+
+- Outcomes review against bootcamp's success metrics (`references/bootcamp.md` — Success Metrics).
+- Compass stability — does the user still endorse the compass that was set in Week 1?
+- Brand thesis stability.
+- Reciprocity ratio.
+- Inbound count + alignment.
+- Aligned offers / role changes.
+- Network durability assessment.
+
+Hand off:
+- If bootcamp produced an active interview pipeline → Interview Track is now primary.
+- If outcomes are partial — the system is built but inbound is just starting — recommend a second 12-week cycle with adjusted targets.
+- If bootcamp didn't produce expected outcomes despite execution — diagnose. Likely culprits: compass clarity (most common), audience/channel fit, or timing (some segments take 18+ months).
+
+Archive the bootcamp state. The next cycle starts fresh but draws on the prior cycle's learnings.
+
+---
+
+## Coordination With Other Commands
+
+When bootcamp is active:
+
+- The user is welcome to invoke any other command directly (`compass`, `brand`, etc.). Bootcamp doesn't trap them.
+- The coach should reference bootcamp commitments when relevant: "We're in Week 6 of bootcamp; this week's commitments include `relationships give`. Want to address that now or later this week?"
+- Other commands (especially `progress`) should be aware of bootcamp state and weave bootcamp metrics into their reviews.
+
+When bootcamp produces an active interview process:
+
+- Hand off cleanly. Interview Track takes over for that opportunity.
+- Bootcamp continues in parallel — distribution and relationship work doesn't pause for one interview cycle.
+- If multiple interviews compete with bootcamp time, decide together: pause bootcamp temporarily, or accept reduced bootcamp velocity for the duration.
+
+---
+
+## Recommended Next
+
+After `start`: hand off to `compass` Session 1.
+
+After `plan`: execute the week's commands.
+
+After `audit`: continue to next week's `plan`. **Alternatives**: `bootcamp checkpoint` if a stage transition is due.
+
+After `checkpoint` (Pass): advance to next stage. After `checkpoint` (Fail): plan remediation week.
+
+After `end`: decide on next cycle, pause, or move primarily into Interview Track.

--- a/references/commands/brand.md
+++ b/references/commands/brand.md
@@ -1,0 +1,166 @@
+# brand — Personal Brand Strategy
+
+Build the personal brand thesis: what the candidate wants to be known for, to whom, on which channels, with what defensible POV. Brand is the strategic layer that `pitch`, `content`, `linkedin`, and `projects` all serve.
+
+Read `references/opportunity-system.md` (Section: Brand Distribution Thesis), `references/commands/pitch.md` (positioning is a building block of brand, not a substitute), and `references/differentiation.md`.
+
+---
+
+## Brand vs. Pitch
+
+These are different artifacts. Don't conflate them.
+
+- **`pitch`** = a positioning *statement* — the thing the candidate says when introducing themselves in a conversation. Granular. Often role-specific.
+- **`brand`** = a positioning *strategy* — what the candidate wants to be known for over months and years, to whom, through which channels, with what defensible point of view. Architectural.
+
+A brand without a pitch is invisible in conversation. A pitch without a brand is a sentence with no compounding behind it.
+
+---
+
+## Priority Check
+
+- If no `compass`: Hard gate — "Brand without compass builds for the wrong audience. Run `compass` first."
+- If no `targets`: Soft gate — "Brand needs an audience. Without a target ecosystem, we'll pick an audience by guess. Want to run `targets` first?"
+- If no `pitch`: Note — "We can build brand strategy first; pitch will derive from it. Both work in either order, but pitch is faster to ship and is a usable byproduct."
+
+---
+
+## Required Inputs
+
+- Compass output (aligned-opportunity sentence + anti-criteria).
+- Target ecosystem (segments + communities).
+- Storybank (earned secrets feed defensible POV).
+
+## Optional Inputs
+
+- Depth: Quick (1 session, thesis + audience + channels + cadence) / Standard (2 sessions, default — includes POV development + anti-brand + 90-day commitment) / Deep (3 sessions, full distribution thesis with proof-of-work plan + content backlog seeding).
+- Existing brand artifacts (LinkedIn About, Twitter bio, personal site, recent posts).
+- Public reputation evidence (where the candidate has been cited, mentioned, invited).
+
+---
+
+## Logic / Sequence
+
+### Step 1: Thesis Extraction
+
+Ask, in order — one question at a time:
+
+1. "What's one thing that, if everyone in your target ecosystem believed it about you, would change how opportunities flow?"
+2. "Now narrow. Pick one — not three."
+3. "Is this thing true? What would the strongest evidence be that you can actually back this thesis up?"
+
+The thesis is a single sentence, narrow:
+- Weak: "An expert in product management."
+- Better: "The PM you call when your pricing model is breaking trust with customers."
+- Strongest: "The PM who has rebuilt pricing systems at three companies and writes about how trust gets metabolized into revenue."
+
+The thesis must:
+- Be narrow enough that 5-10 specific people in the target ecosystem could think of the candidate when the situation arises.
+- Tie to a real artifact-creating capability (something the candidate can show, ship, write).
+- Not be a job title.
+
+### Step 2: Defensible POV
+
+A thesis without a defensible POV is a job title. The candidate must articulate at least one belief that most peers do not share, with a real reason for holding it.
+
+Pull from:
+- Storybank earned secrets — these are the rawest material.
+- Patterns the candidate has noticed across companies they've worked at.
+- Things they've gotten wrong and what they now believe instead.
+- Common-wisdom claims they think are wrong.
+
+Test the POV: "If you said this in a room of peers, would at least 30% disagree?" If everyone agrees, the POV isn't defensible — it's consensus dressed up.
+
+Capture 1-3 POVs. The candidate's content and projects will be the demonstration of these POVs over time.
+
+### Step 3: Audience Definition
+
+Audience must be at the intersection of:
+- The compass aligned-opportunity sentence (who would be the source of work the candidate wants).
+- The target ecosystem segments and communities.
+- The candidate's authentic interest (who they actually want to be in conversation with).
+
+If audience and target ecosystem don't overlap, the brand will build the wrong career.
+
+Be specific: "founders of B2B SaaS companies between Series A and Series C who are wrestling with pricing for the first time" beats "people in tech."
+
+### Step 4: Channel Strategy
+
+Rank channels: primary, secondary, tertiary. Three is the maximum.
+
+For each channel:
+- Why this channel for this audience? (Where does the audience actually pay attention?)
+- What format does this channel reward? (LinkedIn rewards short hot takes + long carousels; Substack rewards essays; Twitter/X rewards real-time signal; podcasts reward conversations with credible hosts; conferences reward talks.)
+- What's the realistic cadence the candidate can hold for 12 months?
+
+The channel ranking from `linkedin.md` and `outreach.md` is reused: LinkedIn is foundational because it's where credibility is checked. But LinkedIn is rarely the *only* channel, and for many segments it's not the primary channel.
+
+### Step 5: Cadence Commitment
+
+The cadence is the floor the candidate commits to for at least the next 90 days. Examples:
+
+- "1 long-form essay per month + 1 short post per week on LinkedIn."
+- "1 podcast appearance per quarter + 4 short technical posts per month + 1 conference talk per year."
+- "1 open source contribution shipped per month + 1 detailed write-up of the work."
+
+The cadence must:
+- Be sustainable. A cadence the candidate burns out at fails.
+- Be specific. "Post regularly" is not a cadence.
+- Have an audit point (every 30 days, did they hold the floor?).
+
+### Step 6: Anti-Brand
+
+What the candidate refuses to say or do, even when easy. Examples:
+
+- "Won't write about prompt-engineering tips, even though they get traction. It's not the brand thesis."
+- "Won't ghostwrite or LLM-launder posts. The voice is the asset."
+- "Won't cross-post my employer's marketing. The brand is mine, not theirs."
+- "Won't take consulting work outside the thesis just for revenue."
+
+Anti-brand entries are the integrity test. A brand without edges does not pull aligned opportunities.
+
+### Step 7: Success Signals
+
+What proves the brand is working? Define 2-4 leading indicators (12-week horizon) and 2-4 lagging indicators (12-month horizon).
+
+Leading: cadence held, target audience is in the comments/replies, named referrals back to a specific post, invitations to community spaces.
+
+Lagging: inbound count + alignment, citations or mentions in target audience's own content, invitations to talk/write/advise, opportunities arriving that satisfy the compass sentence.
+
+---
+
+## Output Schema
+
+Write to coaching_state.md under `## Brand Strategy`:
+
+```markdown
+## Brand Strategy
+- Date: [date]
+- Depth: [Quick / Standard / Deep]
+- Brand thesis: [one sentence — narrow]
+- Defensible POV: [1-3 beliefs + why]
+- Audience: [specific intersection of compass and target ecosystem]
+- Distribution channels (ranked): [primary, secondary, tertiary]
+- Cadence commitment: [specific frequency + format per channel]
+- Success signal — leading: [list]
+- Success signal — lagging: [list]
+- Anti-brand: [list of refusals]
+- Next review: [date 90 days out]
+```
+
+---
+
+## Failure Modes
+
+- **Brand-as-job-title.** "Senior PM" is not a brand. Force narrowness.
+- **Borrowed brand.** Mimicking a recognizable operator's brand. Push back — it's recognizable because it's authentic to *them*. The candidate's brand needs the candidate's voice and earned secrets.
+- **Five primary channels.** Channel overload guarantees nothing compounds. Force three or fewer.
+- **Cadence aspiration.** The candidate commits to a cadence they can't hold. Model the time cost honestly.
+- **No anti-brand.** A brand without edges absorbs everything and pulls nothing. Force at least three anti-brand entries.
+- **Thesis with no proof-of-work pathway.** A thesis the candidate can't yet back up. Either revise the thesis or pair brand with `projects` to build the proof.
+
+---
+
+## Recommended Next
+
+**Recommended next**: `content` — convert the brand strategy into a 90-day content calendar with the first 3-5 pieces backlogged. **Alternatives**: `linkedin` (Standard depth — bring the existing profile in line with the thesis), `projects` (if the brand thesis needs proof-of-work to back it before content lands), `pitch` (if the candidate also needs the conversational positioning artifact).

--- a/references/commands/compass.md
+++ b/references/commands/compass.md
@@ -1,0 +1,169 @@
+# compass — Discover What You Actually Want
+
+Help the candidate define what an aligned opportunity actually looks like for them — concretely enough that they could recognize one in the wild and refuse a misaligned one. This is the foundational Opportunity Track command. Most other commands in the track derive from compass output.
+
+Read `references/opportunity-system.md` (especially Section: Discovery Rigor) before running.
+
+---
+
+## Why This Command Exists
+
+Most career searches optimize the search before defining what's being searched for. The result: the user gets pulled toward the loudest opportunities, not the right ones. Compass forces a definition specific enough that it can be tested against real opportunities — and refused.
+
+The deeper claim: the user who has a sharp compass attracts a sharper network, builds a sharper brand, and converts opportunities at a higher rate. The compass is upstream of every other Opportunity Track command.
+
+---
+
+## Priority Check
+
+Before running:
+- If `kickoff` hasn't run: Soft gate — "Compass works best with profile context. Want to run `kickoff` first, or proceed?"
+- If a recent compass exists (<60 days) and the user wants a fresh run: Ask — "You have a compass from [date]. Do you want to revise it, or rebuild from scratch? Revising preserves continuity; rebuilding lets you challenge the foundation."
+- If the user is in active interview prep (interview <14 days): Redirect — "Compass is a multi-session process. Let's finish the active interview cycle first, then come back."
+
+---
+
+## Required Inputs
+
+- The user's current state: confused / in-between roles / employed but searching / employed and content but exploring.
+- Permission to ask uncomfortable questions. State this upfront: "Compass works by pushing on what feels obvious. I'll ask you to be specific in places that are easier to leave vague. OK?"
+
+## Optional Inputs
+
+- Depth: Quick (60 min, single-session) / Standard (3 sessions over 1-2 weeks, default) / Deep (5 sessions over 3-4 weeks, includes external testing — peer interviews, archive review, lifestyle math).
+- Resume / past role history (improves data, not required).
+- Any prior values or career-design exercises (Ikigai, Designing Your Life, etc.) — these are inputs, not outputs.
+
+---
+
+## Depth Levels
+
+| Level | When to Use | What It Covers |
+|---|---|---|
+| **Quick** | User has a strong intuition and wants help articulating it. | Single 60-90 min session: work-shape Q&A, anti-criteria forcing, aligned-opportunity sentence test. |
+| **Standard** | Default. User is in genuine search mode. | 3 sessions: (1) work-shape + anti-criteria draft, (2) past-data testing — when each value last cost something, (3) sentence test + confidence calibration. |
+| **Deep** | User is making a major pivot or has been searching unsuccessfully. | Standard + (4) peer interviews — user reaches out to 3 people who knew them in past roles for outside-view input, (5) archive review — past calendar/journal review for what energized vs. drained. |
+
+Default to Standard. Suggest Deep when:
+- The user has completed prior career-design work and is still stuck.
+- Two prior search cycles produced misaligned outcomes.
+- A major life change (parenthood, health, partner relocation) is reshaping constraints.
+
+---
+
+## Logic / Sequence
+
+### Session 1 — Work Shape + Anti-Criteria Draft
+
+**Step 1: Work shape inquiry.** One question at a time. After each answer, push for specificity.
+
+- "Forget titles. What is the work itself? Describe a typical week of work that you'd want to keep doing for years."
+- "What's the problem space? Not the industry — the kind of problem you keep being drawn back to."
+- "Who's the customer of your work? Not the company — the person whose life changes."
+- "What scope of impact are you trying to have, realistically, in the next 3-5 years? Don't say 'big.'"
+- "How much autonomy do you actually want? Be honest — autonomy has a cost too."
+
+When an answer is too abstract, ask: "Can you make that concrete enough that someone reading it would know what to send you?"
+
+**Step 2: Anti-criteria forcing.** This is the core diagnostic.
+
+"Tell me three things you would refuse, even if everything else were perfect. Not 'wouldn't prefer' — refuse."
+
+If the user struggles, prompt: "Companies, work styles, hours, missions, leadership types, geographies, equity structures, team sizes — pick the dimension that feels most loaded."
+
+If the user gives soft answers ("I wouldn't want a really toxic culture"), push: "Everyone says that. What's a specific thing you've seen or experienced that you would now refuse?"
+
+**Output Session 1:**
+- Draft work-shape paragraph (3-5 sentences).
+- Draft anti-criteria list (3-7 items).
+- Open questions list (things the user couldn't answer with confidence).
+
+### Session 2 — Past-Data Testing
+
+For each value claimed in Session 1, ask: "When did this last cost you something? What did you choose, and what did you give up?"
+
+Values that have never been tested are hypotheses. Mark them as such. Values that have been tested and held are real.
+
+**Pattern surfacing.** Look for contradictions across the user's history. Common ones:
+- Claims to value autonomy but accepted three roles in a row with high oversight.
+- Claims to want strategic work but consistently took roles where execution was the rewarded skill.
+- Claims to want small teams but the most energized periods were on large ones.
+
+When you spot a contradiction, name it: "You said X is a value, but the pattern in your history suggests you're actually drawn to Y. Which is true, or is it both contextually?"
+
+**Lifestyle math.** What does the user need this work to make possible (financially, geographically, time-wise)? If the lifestyle constraints contradict the work shape (e.g., "I want deep technical work" + "I need to be home by 6pm + travel <5%"), name the tradeoff.
+
+**Output Session 2:**
+- Refined work-shape paragraph.
+- Refined anti-criteria — promoted from drafts only when supported by past data.
+- Hypothesis list — values claimed but not yet tested.
+
+### Session 3 — Sentence Test + Confidence Calibration
+
+**The aligned-opportunity sentence test.** The user must write a single sentence — one sentence — that an opportunity must satisfy to count.
+
+Examples (illustrative, not templates):
+- "A senior PM role at a 50-500-person B2B SaaS company building infrastructure for engineering teams, where I report to a founder or CPO who has shipped product before."
+- "Any role where I lead a team of 4-10 people doing applied research in clinical AI, with at least 30% of my time on hands-on work, no more than two layers above the work."
+
+The sentence is good when:
+- A specific, real opportunity could be evaluated against it in under 60 seconds.
+- It forecloses many opportunities cleanly (the anti-criteria are doing real work).
+- It's narrow enough that the user could imagine 5-20 opportunities in the world fitting it, not 5,000.
+
+If the sentence is fuzzy, run another round.
+
+**Confidence calibration.** For each component of the sentence, the user labels their confidence: high / medium / low.
+
+- **High** = held across multiple roles, tested under pressure, refused costly opportunities to defend.
+- **Medium** = consistent intuition + some past data.
+- **Low** = stated preference, untested.
+
+A compass with multiple Low ratings is fine — but the next stage isn't `brand` or `targets`, it's testing. Recommend `projects` (small projects to test the hypothesis) or peer interviews.
+
+**Output Session 3 (final):**
+- Aligned-opportunity sentence.
+- Component-level confidence labels.
+- Anti-criteria (final list).
+- Open questions / hypotheses to test.
+- Compass section written to coaching_state.md.
+
+---
+
+## Output Schema
+
+```markdown
+## Compass (Opportunity Track)
+- Date: [date]
+- Depth: [Quick / Standard / Deep]
+- What I want — work shape: [paragraph from Session 1, refined]
+- What I want — values/environment: [team type, leadership style, pace, geography]
+- Anti-criteria: [3-7 items, each backed by past data when claimed at high confidence]
+- Aligned opportunity definition: [the single sentence]
+- Confidence: [overall: low / medium / high — based on component confidence]
+- Component confidence:
+  - Work shape: [low / medium / high]
+  - Values/environment: [low / medium / high]
+  - Anti-criteria: [low / medium / high]
+- Open questions: [hypotheses still to test]
+```
+
+---
+
+## Failure Modes & How to Catch Them
+
+- **Performative clarity.** The user delivers a confident-sounding sentence in Session 1. Slow down. Real compass requires friction.
+- **Ikigai poetry.** The user keeps reaching for elegant abstractions ("the intersection of art and engineering"). Force one concrete artifact: "Show me the most recent week of work that felt like that."
+- **The compromise sentence.** A sentence that no real opportunity satisfies because it tries to satisfy too many constraints. Fix by ranking — which constraint is most load-bearing?
+- **Anti-criteria avoidance.** The user can list things they want but not things they'd refuse. This is the most common failure. Push harder. People who can't name what they refuse end up saying yes to whatever's offered.
+
+---
+
+## Recommended Next
+
+After compass:
+- If Confidence is **high** → `targets` (build the ecosystem this compass implies).
+- If Confidence is **medium** → `targets` + `mapping` (build the ecosystem and find people in it who can pressure-test the compass).
+- If Confidence is **low** → `projects` (run a small test project) or peer interviews via `outreach`.
+
+**Recommended next**: `targets` — translate the aligned-opportunity sentence into a real target ecosystem. **Alternatives**: `brand` (if the user is impatient and confidence is high), `projects` (if compass is hypothesis-heavy and needs testing).

--- a/references/commands/content.md
+++ b/references/commands/content.md
@@ -1,0 +1,140 @@
+# content — Content Calendar & Writing Coaching
+
+Convert the brand strategy into a 90-day content calendar, coach individual pieces against the thesis, and audit what's published for inbound signal.
+
+Read `references/opportunity-system.md` (Section: Content Discipline) and `references/commands/brand.md`.
+
+---
+
+## Priority Check
+
+- If no `brand`: Hard gate — "Content without a brand thesis is volume, not strategy. Run `brand` first."
+- If `brand` cadence commitment exists: Reuse it. Don't override.
+- If candidate is in active interview prep within 7 days: Redirect — "Let's finish the interview cycle. Content this week is a distraction."
+
+---
+
+## Required Inputs
+
+- Brand Strategy (from coaching_state.md).
+- Storybank (earned secrets are the renewable content fuel).
+
+## Optional Inputs
+
+- Mode: `plan` (build/refresh the calendar) / `coach [piece]` (coach a specific draft) / `audit` (review published log for inbound signal).
+- Specific piece in progress (draft, outline, idea).
+- Time horizon — default 90 days.
+
+---
+
+## Modes
+
+### Mode: `plan`
+
+Build or refresh the calendar.
+
+**Step 1: Cadence verification.** Pull cadence from Brand Strategy. Confirm the candidate can still hold it. If they're already 30 days into a missed cadence, force the conversation: "What changed? Do we adjust the cadence or address the blocker?"
+
+**Step 2: Backlog seeding.** Generate 8-12 candidate ideas, drawing from:
+- Storybank earned secrets (each strong story is at least one piece).
+- The 1-3 defensible POVs in Brand Strategy (each POV needs multiple demonstrations over time, not just one post).
+- Open questions in the candidate's compass (these often become "thinking out loud" pieces).
+- Recent moments where the candidate had a strong opinion and held back from sharing — those are the highest-signal pieces.
+- Reactions to public discourse where the candidate has a defensible counter.
+
+For each idea capture:
+- Working title.
+- Format (long-form essay / LinkedIn post / thread / talk / repo + write-up).
+- Earned secret hook (the unique insight).
+- Target audience reaction (what would constitute success — debate? saves? DMs?).
+- Estimated effort (hours).
+
+**Step 3: Sequencing.** Sequence the backlog into 90 days against the cadence commitment. Front-load the strongest 2-3 pieces — early wins shape the trajectory.
+
+**Step 4: First piece scoping.** Take the first piece in the calendar. Outline it together — 5-bullet outline, hook, close, one earned secret highlighted. Block the next session as a coaching session on the draft.
+
+### Mode: `coach [piece]`
+
+Coach a specific piece.
+
+**Quality rubric:**
+
+| Dimension | What to check |
+|---|---|
+| **Thesis tie** | Does this piece reinforce the brand thesis? If a reader couldn't connect this back to the candidate's positioning, it's noise. |
+| **Earned-secret content** | Is there at least one insight that only this candidate could write? "Show, don't claim." |
+| **Voice authenticity** | Does this sound like the candidate? Watch for AI voice, consultant voice, LinkedIn-speak. |
+| **Hook strength** | Does the first sentence/paragraph earn the reader's attention without clickbait? Test against `pitch.md` curiosity-gap principles. |
+| **Specificity** | Numbers, names of decisions, real tradeoffs — not "I learned a lot." |
+| **Defensible stance** | Would 30%+ of peers disagree? If everyone agrees, it's consensus content. |
+| **Channel fit** | Is the format right for the channel? LinkedIn post, Twitter thread, essay, talk all want different shapes. |
+| **Anti-brand check** | Does this violate any anti-brand entry? |
+
+Walk the rubric. Surface 2-3 highest-leverage edits. Provide annotations, not a rewritten version. The voice is the asset.
+
+If the piece scores low on multiple dimensions, name it: "This piece doesn't move the brand thesis forward. We can ship it, but it won't compound. Want to either revise toward the thesis, or shelve it?"
+
+### Mode: `audit`
+
+Review the Published log against the success signals from Brand Strategy.
+
+For each piece in the last 90 days:
+- Reach (impressions/views — only directionally; don't optimize for reach).
+- Reactions (saves > likes > none — saves indicate the piece was useful).
+- DMs / replies from target audience (the highest-signal indicator — these are the people the brand is trying to reach).
+- Inbound conversations or opportunities traceable to the piece.
+
+**Patterns to surface:**
+- Which formats produced inbound from the target audience?
+- Which POVs landed (debate, saves, DMs)?
+- Which formats produced reach without alignment? (Reach without target-audience traction is a vanity signal.)
+
+**Recommendations:**
+- Double down on what works: which thesis variants, formats, channels.
+- Stop what doesn't: pieces that get reach but no aligned signal are noise.
+- Test what's missing: if the calendar has been monoformat, propose a different format next cycle.
+
+If 90 days of content has produced zero target-audience inbound, the issue is upstream: brand thesis, channel fit, or audience definition. Recommend revisiting `brand`.
+
+---
+
+## Output Schema
+
+Write to coaching_state.md under `## Content Calendar`:
+
+```markdown
+## Content Calendar
+### Cadence
+- Long-form: [frequency + channel]
+- Short-form: [frequency + channel]
+- Talks/podcasts: [target per quarter]
+
+### Backlog
+| Idea | Format | Target audience | Earned secret hook | Status | Date due |
+
+### Published
+| Date | Title | Channel | Reaction | Inbound? | Lessons |
+```
+
+In-session output (mode-dependent):
+- `plan`: backlog table + first-piece outline + next-session block.
+- `coach`: 2-3 annotated edits + voice-authenticity check + thesis-tie verdict.
+- `audit`: pattern summary + recommendations.
+
+---
+
+## Anti-Patterns (Strict)
+
+- **Ghostwriting / LLM-laundering.** Catch this. The voice is the asset. The coach edits structure, sharpens specificity, never replaces voice. If the candidate asks for "just write the post for me," redirect: "I can outline, edit, sharpen — but if I write it, you don't have a brand, you have a content account."
+- **Volume optimization.** Posting daily without thesis is noise. The cadence is a floor, not a sprint.
+- **Reach chasing.** Tweaking pieces toward virality at the cost of POV. A 100-impression post that produces 3 inbound DMs from target audience beats a 100k-impression post that produces 0.
+- **Ghosted topics.** The candidate avoids the topic that would land hardest because it's the one they have a defensible POV on. Push toward the friction. (Apply Challenge Protocol if Directness Level 5.)
+
+---
+
+## Recommended Next
+
+**Recommended next** depends on mode:
+- After `plan`: `content coach [first piece]` — coach the first draft into shape. **Alternatives**: `events` (if a talk fits the calendar), `projects` (if a project is the next piece).
+- After `coach`: ship and log to Published table; in 30 days, run `content audit`. **Alternatives**: `relationships` (signal the piece to relevant Tier 1).
+- After `audit`: if patterns are clear, refine `brand` (small adjustments) or revise channel ranking. If no inbound after 90 days, return to `brand`. **Alternatives**: `mapping` if the issue may be that the audience isn't even reachable from current channels.

--- a/references/commands/convert.md
+++ b/references/commands/convert.md
@@ -1,0 +1,142 @@
+# convert — Conversation-to-Opportunity Conversion
+
+Coach the candidate through the conversion gap: the meetings, intros, and conversations that *could* become opportunities, but only if the right bridge is built. Where most networking effort dies — great conversations followed by silence.
+
+Read `references/opportunity-system.md` (Section: Conversation-to-Opportunity Conversion), `references/commands/decode.md`, and `references/commands/prep.md`.
+
+---
+
+## Why This Command Exists
+
+A coffee chat is not an opportunity. An intro call is not an opportunity. A great conversation that ends "let's keep in touch" is not an opportunity. They are *upstream* of opportunity — and the conversion happens in the bridge between conversation and concrete next step.
+
+Most candidates are good at having the conversation and bad at building the bridge. This command teaches the bridge.
+
+---
+
+## Priority Check
+
+- If no `compass`: Soft gate — "Without a compass, conversion looks like 'land what's in front of you.' That's how people end up in misaligned roles. Want a quick `compass` first?"
+- If conversation is in <24 hours and the candidate is asking for prep: Triage to fast-prep mode.
+
+---
+
+## Required Inputs
+
+- The conversation under consideration: who, what was said, where it stands now.
+
+## Optional Inputs
+
+- Mode: `before` (pre-conversation prep) / `during` (live coaching during, rare) / `after` (post-conversation conversion plan) / `revive` (a stalled lead the candidate wants to restart).
+- Conversation transcript or the candidate's recall.
+
+---
+
+## Modes
+
+### Mode: `before`
+
+Pre-conversation prep. Brief — under 30 minutes for most prep.
+
+- **Goal for this conversation.** Specific and not a job ask. "Understand how X thinks about pricing for stage Y." "Get their honest read on whether my brand thesis lands with people in this segment." "Find out what's actually going on at company Z under the marketing layer."
+- **What the candidate brings.** Something specific to talk about — recent work, a piece of content, a question they've been wrestling with. Tie to brand thesis.
+- **Foreshadowed ask, if there will be one.** If the conversation is meant to lead toward a specific opportunity, foreshadow it — don't reveal it as a surprise at the end.
+- **Listening orientation.** The candidate should plan to listen 60-70% of the time. Most pitches in coffee chats fail because the candidate dominates.
+
+### Mode: `during`
+
+Live coaching mid-conversation is rare. If asked, give one specific tactical move:
+- "Ask about their hardest problem this quarter, then shut up for two minutes."
+- "If they offer a follow-up, make it concrete: 'send you what by when?'"
+- "If they ask what would help, have one specific small thing ready, not a long list."
+
+### Mode: `after`
+
+Post-conversation, within 24-48 hours. This is where conversion happens or doesn't.
+
+**Step 1: Capture the conversation.** What was said, what struck the candidate, any specific follow-ups promised.
+
+**Step 2: Diagnose alignment.** Did the conversation reveal genuine alignment with what the candidate actually wants? (Cross-check against compass.)
+- **Strong alignment** — pursue with conversion bridges.
+- **Partial alignment** — keep warm via Relationship Pipeline, no specific conversion needed yet.
+- **Misaligned** — graceful close (give-and-release), don't force.
+
+**Step 3: Choose the conversion bridge.** Not every conversation needs every bridge. Pick the most natural one.
+
+**The bridges:**
+
+1. **Collaboration test.** Offer to do a small piece of work together — review a draft, look at a problem, prototype a thing. Demonstrates fit faster than any pitch. Best when the conversation hinted at a shared problem.
+
+2. **Follow-up artifact.** Send something within 48 hours that the conversation prompted — an article, a contact, a piece of work, a question. Keeps the conversation alive without an ask. Best when alignment isn't yet clear and you want to maintain the connection.
+
+3. **Named ask.** When alignment is established, make the ask specific and small enough to say yes to. "I'm thinking about the X role at Y — would you be open to flagging it to whoever's running that hiring process if I sent you a one-pager?" Beats "any leads?"
+
+4. **Graceful pass.** If alignment isn't there, end cleanly: "This was useful, here's something I'd send you that's relevant, let me know how I can be helpful." Burns no bridges, leaves the door open.
+
+For each bridge picked, draft the actual message. Coach against `outreach.md` Message Quality Rubric.
+
+**Step 4: Schedule the next checkpoint.**
+- If a follow-up artifact is going: send within 48 hours, log next touch in 2-4 weeks.
+- If a collaboration test is offered: offer concrete, time-boxed scope (≤2 hours of work). If they accept, schedule the deliverable.
+- If a named ask is made: send and wait 2-3 weeks before the soft follow-up.
+- If graceful pass: log to Relationship Pipeline at appropriate tier.
+
+**Step 5: Log the conversion event.**
+
+Write to `## Conversion Log`:
+| Date | Conversation | Bridge used | Ask | Result | What converted / didn't |
+
+The Result column gets updated when something concrete happens (next interview, project signed, no response).
+
+### Mode: `revive`
+
+A stalled lead. The candidate had a great conversation 3-6 months ago, things looked promising, then it went quiet.
+
+**Diagnosis:**
+- Did the candidate follow up after the original conversation? If not, that's the issue. Re-warm.
+- Did the lead fall through external causes (their funding round failed, their priorities shifted)? If so, revive with timing-aware re-warm.
+- Did the candidate's compass shift? Maybe this lead is no longer aligned. Verify before reviving.
+
+**Re-warm options:**
+- Send a recent piece of content that connects to what was discussed originally.
+- Acknowledge the gap honestly, share what you've been working on, ask what's new on their side.
+- If a specific event occurred (their company hit a milestone, they posted something), reference it and re-engage from there.
+
+If the lead is dead despite a good re-warm, mark it dead. Some opportunities are real at one moment and not at another.
+
+---
+
+## Output Schema
+
+Write to coaching_state.md under `## Conversion Log`:
+
+```markdown
+## Conversion Log
+| Date | Conversation | Bridge used | Ask | Result | What converted / didn't |
+```
+
+If the conversion produces a job conversation, also create or update `## Interview Loops` entry and hand off to Interview Track.
+
+---
+
+## Failure Modes
+
+- **The surprise pivot.** Going into a conversation with a hidden ask and revealing it at the end. Destroys trust. Foreshadow asks before, not after.
+- **The vague follow-up.** "Great chatting!" with no specific next step. Conversion gap.
+- **Premature ask.** Asking for the job/intro/referral on the first conversation. Almost always backfires unless the conversation explicitly invited it.
+- **The conversation marathon.** Many great conversations, no conversion bridges, no opportunities. The fix is bridges, not more conversations.
+- **The half-bridge.** Promising a follow-up artifact and not sending it. Worse than no promise.
+
+---
+
+## Recommended Next
+
+After `before`: have the conversation. Then `convert after`.
+
+After `after` (Strong alignment + Named ask): wait for response; meanwhile add to Relationship Pipeline. If the ask becomes a formal process: hand off to Interview Track (`decode` → `prep`).
+
+After `after` (Partial alignment): `relationships` to set the appropriate cadence.
+
+After `after` (Misaligned): close gracefully, log to Pipeline at low priority.
+
+After `revive`: if revived, treat as new `convert before` cycle. If dead, log and move on. **Alternatives**: `mapping` (if many leads are dying, the network strategy may need to change).

--- a/references/commands/events.md
+++ b/references/commands/events.md
@@ -1,0 +1,139 @@
+# events — Event & Community Strategy
+
+Choose which events and communities to invest in, prepare to show up well, and convert event interactions into Relationship Pipeline entries that compound.
+
+Read `references/opportunity-system.md` (Section: Showing Up) and `references/commands/relationships.md`.
+
+---
+
+## Priority Check
+
+- If no `targets`: Soft gate — "Events without a target ecosystem turn into networking-for-its-own-sake. Want to run `targets` first?"
+- If candidate is at an event right now and needs immediate help: Skip planning, jump to `at-event` mode.
+
+---
+
+## Required Inputs
+
+- Event(s) under consideration, OR a community/scene the candidate is evaluating.
+- Brand Strategy (target audience must overlap with event audience for the event to count).
+
+## Optional Inputs
+
+- Mode: `plan` (which events to attend) / `prepare [event]` (pre-event prep) / `at-event` (live triage during) / `debrief [event]` (post-event capture and follow-through).
+- Budget — time and money. Events have real costs.
+
+---
+
+## Modes
+
+### Mode: `plan`
+
+The candidate has a list of events under consideration; the goal is ruthless prioritization.
+
+For each event, score against:
+
+| Filter | Test |
+|---|---|
+| **Audience fit** | Does the audience overlap with the brand's target audience? Or is it a different scene the candidate is using to feel productive? |
+| **Density** | What's the ratio of target-audience attendees to total attendees? A 200-person curated dinner often beats a 5,000-person conference. |
+| **Format leverage** | Is the candidate showing up as attendee, speaker, panelist, organizer, host? Each multiplies leverage. Speaking > panel > attending. |
+| **Compounding cost** | Is this a one-shot or a recurring scene? Recurring scenes (annual conferences, monthly meetups) compound. One-shots rarely do. |
+| **Cost / time honesty** | What does this actually cost — registration, travel, time off work, prep time, recovery? Is it justified? |
+
+Output: a ranked list of events worth attending, with the top 1-3 marked as "investment events" — the candidate plans for these, not just shows up.
+
+If the candidate's calendar already has 5+ events booked: force triage. Three events with prep > five events without.
+
+**Speaking pathway.** For each "investment event," ask: is there a speaking pathway (CFP, sponsor talk, lightning, panel, hosted side event)? Speaking is 5-10x leverage over attending. If yes, capture the deadline and what would need to be true for the candidate to apply.
+
+### Mode: `prepare [event]`
+
+For one specific upcoming event:
+
+**Step 1: Set one specific goal.** Not "network." Examples:
+- "Meet 3 founders working on pricing problems."
+- "Find one collaborator for the Q2 project."
+- "Get a real-world reaction to the brand thesis from people who'd never heard of me."
+
+**Step 2: Identify 3-5 people worth meeting in advance.** Public schedule + LinkedIn + recent posts. For each:
+- Why this person?
+- What's a credible reason to talk to them at the event?
+- What can the candidate offer them in 30 seconds that's genuinely useful?
+
+**Step 3: Prepare one current thing to talk about.** Tied to the brand thesis. The candidate should be ready to answer "what are you working on" with something specific and recent — not a job title.
+
+**Step 4: Anti-prep.** Identify failure modes for this candidate at this format. Examples:
+- "I default to talking to whoever's nearest — set a goal of 3 specific people first."
+- "I leave early when overwhelmed — schedule a buffer break midday."
+- "I overcommit to follow-ups in the moment — say 'I'll send you a note after,' not 'let's grab coffee Thursday.'"
+
+### Mode: `at-event`
+
+Live triage. Candidate is at the event now.
+
+Quick interventions:
+- "Three real conversations beat thirty cards. Quality > quantity."
+- "Take a 90-minute break midday. Recall collapses without it."
+- "Capture each meaningful conversation in 30 seconds: name, role, one specific thing said, follow-up commitment if any."
+- "If you said 'we should grab coffee' to more than two people, you're overcommitting. Pull back."
+- "Don't pitch yourself. Ask what they're working on. They'll ask back."
+
+If the candidate texts a specific question ("how do I introduce myself to X who's standing alone?"), answer in <60 seconds with one specific suggestion tied to the brand thesis.
+
+### Mode: `debrief [event]`
+
+Post-event, within 48 hours.
+
+**Step 1: Inventory.** Walk through every meaningful conversation:
+- Name, role, company.
+- What was said worth remembering.
+- Was there a specific commitment? (Send X, intro to Y, follow up on Z.)
+
+**Step 2: Tier and add to Relationship Pipeline.** Each new contact:
+- Tier 2 by default if there was a real exchange.
+- Tier 3 if it was brief but worth tracking.
+- Tier 1 only if the conversation had real depth and mutual interest.
+
+**Step 3: Follow-through queue.** For each commitment made, schedule the follow-up in the next 48 hours. Specific reference to the conversation — "great to meet you" with no specifics fails.
+
+**Step 4: Goal verdict.** Did the goal from `prepare` get met? Yes / partially / no. If no, was it an event-fit issue or an execution issue?
+
+**Step 5: Recurring commitment.** Worth attending again? If yes, mark it as a recurring scene and note the next occurrence. If no, cross it off.
+
+---
+
+## Output Schema
+
+Write to coaching_state.md under `## Events`:
+
+```markdown
+## Events
+### Upcoming
+| Date | Event | Type | Goal | Pre-event prep | Targets to meet |
+
+### Attended
+| Date | Event | Conversations worth following | Follow-ups sent | Result |
+```
+
+Also update `## Relationship Pipeline` with new contacts captured at the event.
+
+---
+
+## Anti-Patterns
+
+- **Conference tourism.** Attending events for the experience, not the relationships. The Attended log will reveal this — many events, no relationship pipeline growth, no inbound.
+- **Card-collection.** Maximizing conversation count. Track quality (Tier 1/2 conversions) instead.
+- **The follow-up debt.** Promising follow-ups in the moment, never sending. Burns trust faster than not promising.
+- **Speaking without thesis.** Accepting a speaking slot because it's offered, not because it advances the brand. Some talks are net-negative for the brand.
+- **Avoiding the smaller scene for the bigger one.** A 50-person curated dinner with target audience often outperforms a 5000-person conference. Density matters more than size.
+
+---
+
+## Recommended Next
+
+After `plan`: `events prepare [top investment event]` — plan the next big event seriously. **Alternatives**: `relationships` (deepen Tier 1 in parallel), `content` (write something to bring with you).
+
+After `prepare`: at the event, use `events at-event` if needed; after, `events debrief`. **Alternatives**: `intro` (if pre-event reveals an intro path).
+
+After `debrief`: `relationships` — bring new pipeline entries into cadence. **Alternatives**: `convert` (if a conversation hinted at a real opportunity), `intro` (if an introduction is now available).

--- a/references/commands/intro.md
+++ b/references/commands/intro.md
@@ -1,0 +1,146 @@
+# intro — Warm Intro Orchestration
+
+Coach the full warm-intro choreography: the private ask of the introducer, the double opt-in, the forwardable email, the follow-through, and the reciprocity owed afterward.
+
+Read `references/opportunity-system.md` (Section: Intro Choreography) and `references/commands/outreach.md` (warm intros extend, not replace, the outreach system).
+
+---
+
+## Why This Command Exists
+
+Warm introductions convert 3-5x better than cold (per `outreach.md`). But badly handled warm intros burn social capital — the introducer pays, and the door closes. This command makes the choreography rigorous so the intro lands and the relationship survives.
+
+---
+
+## Priority Check
+
+- If candidate has no `mapping`: Soft gate — "Without a network map, we'll find ourselves asking introducers we haven't earned the right to ask. Want to run `mapping` first?"
+- If reciprocity ledger is significantly negative: Hard flag — "You've been asking more than giving recently. An intro is a real ask. Let's give first."
+
+---
+
+## Required Inputs
+
+- The target (the person the candidate wants to be introduced to).
+- The proposed introducer (the Tier 1/2 contact who could connect).
+- The reason: what the candidate genuinely wants from the conversation.
+
+## Optional Inputs
+
+- Mode: `plan` (full choreography) / `forwardable` (write/coach the forwardable email) / `audit` (review intro tracker for outcomes and reciprocity).
+
+---
+
+## Modes
+
+### Mode: `plan`
+
+**Step 1: Sanity check the ask.**
+
+- Why this person? (What does the target uniquely offer that justifies their time?)
+- Why now? (Timing matters — random intros land flatter than timely ones.)
+- Why through this introducer? (Are they actually connected? Have they vouched for the candidate before? Or is this a stretch ask?)
+
+If the candidate can't answer all three crisply, slow down. The ask isn't ready.
+
+**Step 2: Earn the right to ask.**
+
+- Has the candidate given to the introducer recently? Within the last 90 days. If not, this isn't the right time. Plan a give first, then come back to the intro in 30+ days.
+- Is the candidate's brand presentable? If the introducer is going to vouch, they need to feel safe. Quick LinkedIn/site sanity check.
+
+**Step 3: Draft the private ask to the introducer.**
+
+This is *not* the forwardable email. This is the candidate's private message asking the introducer if they'd be willing.
+
+Properties of the private ask:
+- Acknowledges the cost: "I know intros are real currency, no pressure."
+- Specific reason for the target: "I've been working on X and noticed they've shipped Y — would value 20 minutes on Z."
+- Specific reason for the introducer: why them (not just because they happen to know the target).
+- Includes either: (a) a forwardable note pre-written for them (most introducers prefer this), or (b) the offer to write one if they're willing.
+- Has an off-ramp: "If it's not the right moment or you don't think it's a fit, totally understood — won't ask again."
+
+The private ask does NOT include the forwardable note in the same message unless the candidate is confident the introducer wants efficiency over choice. When unsure, ask first.
+
+**Step 4: The double opt-in protocol.**
+
+- Introducer agrees in principle.
+- Introducer (or candidate, depending on convention) drafts the forwardable.
+- Introducer asks the target privately first: "Would you be open to a quick intro to X? Here's why."
+- Only after target agrees does the forwardable go out.
+
+If the introducer skips the double opt-in and just blast-CCs both parties: that's their call, not the candidate's. But the candidate should make their preference known.
+
+**Step 5: Forwardable email construction.**
+
+See Mode: `forwardable` below.
+
+**Step 6: Post-intro choreography.**
+
+Once the intro lands and the conversation is scheduled:
+- Schedule the conversation promptly. Ghosting a warm intro burns the introducer.
+- Send a brief thank-you to the introducer the day of the intro.
+- After the conversation, send the introducer a short note on how it went. Two reasons: (1) the introducer cares; (2) it tells them whether to keep making such intros for the candidate.
+- Reciprocity owed: log this in `## Intro Tracker`. Pay it forward — not necessarily to the same person.
+
+### Mode: `forwardable`
+
+Write or coach the forwardable email.
+
+**Properties of a great forwardable:**
+
+- **Easy to forward without editing.** ≤150 words. Reads naturally as if the introducer wrote it (because they did, or co-wrote it).
+- **Self-contained context.** The target should know who the candidate is, why the introduction is happening, and what's being asked, without clicking anything.
+- **Specific bounded ask.** "20 minutes on how you handled the pricing migration at A" beats "would love to chat."
+- **Establishes the candidate's credibility briefly.** One concrete signal — recent project, role at a known company, recommendation, public artifact.
+- **Includes a clear out for the target.** "If now's not a good moment, no pressure."
+
+**Anti-pattern: the chained ask.** Don't pile multiple asks into one intro. "20 minutes + please review my resume + if you're hiring, here's my background" overwhelms. One ask per intro.
+
+Coach the draft against these properties. Push back if the candidate is over-pitching themselves — the intro is for the target's benefit too, not just the candidate's.
+
+### Mode: `audit`
+
+Review `## Intro Tracker` quarterly.
+
+For each intro:
+- Did it land? (Conversation happened.)
+- What came of it? (Real lead, dead end, ongoing relationship, opportunity surfaced.)
+- Was reciprocity paid? (Did the candidate find a way to give back, even indirectly?)
+
+Pattern questions:
+- Which introducers are repeatedly producing real conversations? Invest in those relationships.
+- Which intros aren't landing? Pattern in the candidate's framing, the target type, or the introducer's reach?
+- Reciprocity ratio over the period — gives ≥ asks?
+
+If the candidate has 5+ intros with no reciprocity paid: course-correct. The Opportunity Track isn't sustainable as one-way extraction.
+
+---
+
+## Output Schema
+
+Write to coaching_state.md under `## Intro Tracker`:
+
+```markdown
+## Intro Tracker
+| Date | Asked of | For whom | Forwardable sent? | Outcome | Reciprocity owed |
+```
+
+---
+
+## Failure Modes
+
+- **The ambush forwardable.** Sending an introducer a "I already wrote this, just forward it" with no opt-in. Treats the introducer as a free distribution channel.
+- **The chained ask.** Multiple things bundled in one intro. Pick the most important one.
+- **Ghosting after intro lands.** Not scheduling the conversation, or scheduling and not showing up, or showing up unprepared. The introducer paid; the candidate burned the trust.
+- **No follow-up to the introducer.** Letting the introducer wonder how it went. Common, lazy, expensive over time.
+- **No reciprocity ledger.** Asking for intros without ever offering them. Sustainable only briefly.
+
+---
+
+## Recommended Next
+
+After `plan`: send the private ask. When the introducer agrees: `intro forwardable` to coach the actual email.
+
+After `forwardable`: send. After the conversation: log to Intro Tracker, follow up with introducer, plan reciprocity.
+
+After `audit`: pay forward owed reciprocities, prune over-asked introducers, double down on high-yield ones. **Alternatives**: `relationships` (refresh cadence with high-yield introducers).

--- a/references/commands/mapping.md
+++ b/references/commands/mapping.md
@@ -1,0 +1,128 @@
+# mapping — Network Topology
+
+Map the candidate's actual network (not their LinkedIn list) into Tier 1 / Tier 2 / Tier 3, identify coverage gaps against the target ecosystem, and surface the highest-leverage relationships to deepen first.
+
+Read `references/opportunity-system.md` (Section: Network Topology).
+
+---
+
+## Priority Check
+
+- If no `targets`: Soft gate — "Mapping without a target ecosystem produces an unfocused list. Want to run `targets` first, or proceed and tier purely by relationship strength?"
+- If candidate believes "I don't have a network": Reframe — "Most people who say this have one and don't see it. Let's find it before we conclude that."
+
+---
+
+## Required Inputs
+
+- The candidate's willingness to dig — phone contacts, email, LinkedIn, Slack DMs, calendar history. Mapping is upstream of relationship quality, so the inventory has to be honest.
+- Target ecosystem (from coaching_state.md, if available).
+
+## Optional Inputs
+
+- Depth: Quick (1 session, top 30 contacts only) / Standard (2 sessions, full inventory + tiering, default) / Deep (3 sessions, includes Tier 3 path-finding for ecosystem gaps).
+
+---
+
+## Logic / Sequence
+
+### Step 1: Inventory
+
+Walk the candidate through every source of contacts, in order:
+
+1. **Phone contacts** — usually the most overlooked, often the warmest.
+2. **Recent calendar** (last 12 months) — who has the candidate actually had real conversations with?
+3. **Email "sent" history** — who has the candidate written a substantive message to recently?
+4. **LinkedIn 1st-degree connections** — long list, but most are Tier 3 by the test below.
+5. **Slack/Discord communities** the candidate is active in.
+6. **Past colleagues** — for each company in their history, who would they call?
+7. **School / cohort / program alumni** — degree, bootcamp, fellowship, accelerator.
+8. **People who have introduced themselves to the candidate** — don't forget reverse-warm contacts.
+
+The output is a long list — typically 50-300 names — that gets tiered.
+
+### Step 2: Tiering
+
+The tier test for each contact:
+
+- **Tier 1 — Strong tie.** "If I texted them today, would they reply within 24 hours? Would they take a 30-minute call this week if I asked?" Both yes → Tier 1.
+- **Tier 2 — Warm.** Real history, but no recent meaningful contact (24+ months). Re-warmable with a non-extractive opener.
+- **Tier 3 — Cold or LinkedIn-only.** Connected but no real history, or one interaction long ago. Reachable mostly via someone else.
+
+LinkedIn connection counts mean nothing here. The relationship is what it actually is, not what the connection list says.
+
+For each Tier 1 contact, capture:
+- Name, role, company.
+- Last meaningful contact (date + topic).
+- Mutual connections that could become Tier 1/2.
+- One thing the candidate could give them this quarter.
+- Notes (what makes this relationship valuable, what the candidate values about them, anything sensitive — e.g., "going through divorce, don't ask about partner").
+
+### Step 3: Coverage Gap Analysis
+
+Cross-reference the network map against the target ecosystem.
+
+For each segment / community / Tier 1-2 company in the target ecosystem:
+- Does the candidate have a Tier 1 contact there? If yes, mark it.
+- Does the candidate have a Tier 2 contact? Mark it.
+- Tier 3 reachable via someone? Mark the path.
+- No path at all → coverage gap.
+
+Coverage gaps are the inputs to brand and content strategy. You can't network into a room you have no path into; you have to be invited via something you've published, shipped, or shown up to.
+
+### Step 4: Highest-Leverage Relationships
+
+From the Tier 1 list, identify 3-5 contacts that most overlap with the target ecosystem and the candidate's brand thesis. These are the relationships to deepen first — not because you're extracting, but because they're the natural connectors who could amplify content, suggest intros, and notice misalignment.
+
+For each, propose:
+- A near-term give (this month).
+- A natural cadence (monthly, quarterly).
+- A possible eventual ask, if alignment ever supports it (logged but not yet activated).
+
+### Step 5: Tier 3 Path-Finding (Deep only)
+
+For the most important coverage gaps, find the bridge:
+- Which Tier 1/2 contact is most likely to know someone at [target company]?
+- What's the shortest credible path?
+- What would the candidate need to do (build, write, ship) to make a warm intro from that bridge actually land?
+
+Output: a small set of "intro-ready" paths to revisit during `intro`.
+
+---
+
+## Output Schema
+
+Write to coaching_state.md under `## Network Map`:
+
+```markdown
+## Network Map
+
+### Tier 1 — Strong ties
+| Name | Role / Company | Last meaningful contact | Mutuals | Notes |
+
+### Tier 2 — Warm
+| Name | Role / Company | Last meaningful contact | Re-warm idea | Notes |
+
+### Tier 3 — Reachable through 1 hop
+| Target | Through whom | Why valuable | Intro asked? |
+
+### Coverage Gaps
+- Segments where I have no Tier 1/2 contacts: [list]
+- Companies on target list with no path: [list]
+- Plan to close gaps: [content / events / direct outreach via brand]
+```
+
+---
+
+## Failure Modes
+
+- **Confusing acquaintances with strong ties.** The 24-hour reply test is the discipline. If they wouldn't reply, they're not Tier 1.
+- **Inflating Tier 1 to feel less alone.** A short, honest Tier 1 list beats a long performative one. The map is what's real.
+- **Skipping the gap analysis.** Mapping without checking coverage against the target ecosystem produces a friend list, not a strategy.
+- **Treating LinkedIn count as the network.** If the candidate keeps citing their connection count, redirect to the actual map.
+
+---
+
+## Recommended Next
+
+**Recommended next**: `relationships` — set the cadence and give-before-ask plan for Tier 1 + the 3-5 highest-leverage contacts. **Alternatives**: `brand` + `content` (if coverage gaps dominate the picture and the user needs distribution to enter rooms they can't network into), `intro` (if a specific Tier 3 path is ready to activate now).

--- a/references/commands/opportunities.md
+++ b/references/commands/opportunities.md
@@ -1,0 +1,141 @@
+# opportunities — Inbound Opportunity Funnel
+
+When the system works, opportunities arrive — sometimes faster than the candidate expects. Track every inbound, score against compass, manage stage transitions, and surface patterns about what's pulling.
+
+Read `references/opportunity-system.md` (Section: Inbound Funnel Hygiene) and `references/commands/decode.md` (used for inbound JDs).
+
+---
+
+## Why This Command Exists
+
+Many candidates working an Opportunity Track system fail at the inbound stage in two ways:
+
+1. **Saying yes to flattering misalignments.** A prestigious inbound that doesn't match compass, accepted because saying no feels wasteful.
+2. **Ghosting good fits.** An inbound arrives at a bad moment, the candidate doesn't respond fast enough, and the door quietly closes.
+
+This command makes the funnel explicit so neither happens silently.
+
+---
+
+## Priority Check
+
+- If no `compass`: Soft gate — "I can log inbounds, but without compass we can't score fit. The data will be fine for tracking, weak for decisions. Want a quick `compass` first?"
+- If candidate is logging an inbound currently in active interview process: Coordinate with Interview Track. The Interview Loops section may already have this opportunity logged; cross-reference.
+
+---
+
+## Required Inputs
+
+- The inbound itself: who, where it came from, what's the offer/conversation.
+
+## Optional Inputs
+
+- Mode: `log` (record a new inbound) / `score [name/company]` (compass-fit assessment) / `move [name/company] [stage]` (stage transition) / `audit` (pattern review across recent inbounds).
+- JD if available (will trigger `decode` flow).
+
+---
+
+## Modes
+
+### Mode: `log`
+
+Capture every inbound, even ones the candidate immediately knows aren't aligned. Pattern detection requires data.
+
+For each:
+- Date.
+- Source: cold inbound / warm intro / event / content reaction / referral / other.
+- Person + company.
+- Type: job / contract / advisor / collab / speaking / other.
+- Stage (initial state): "surfaced."
+- Initial impression in 1 line.
+
+If the inbound came with a JD or detailed description, optionally trigger `decode` for full JD analysis.
+
+### Mode: `score [name/company]`
+
+Score the inbound against the compass:
+
+- Pull the aligned-opportunity sentence from `## Compass`.
+- Score the inbound against each component:
+  - Work shape match: yes / partial / no.
+  - Values/environment match: yes / partial / no.
+  - Anti-criteria violation: any? (Even one anti-criteria violation is a strong signal to pass.)
+- Verdict: **Aligned** / **Investable adjacent** / **Misaligned**.
+
+If verdict is **Misaligned** but candidate is tempted: name what's pulling them. ("It's prestigious." "It pays a lot." "I'm tired of looking.") None of those are wrong reasons — but the candidate should make the decision with the trade-off named, not because the misalignment got obscured.
+
+If verdict is **Aligned** or **Investable adjacent**: move to next stage; continue to the Interview Track when "formal process" is reached.
+
+### Mode: `move [name/company] [stage]`
+
+Stage progression:
+
+| Stage | What it means | Fit confidence required |
+|---|---|---|
+| **Surfaced** | Logged. No conversation yet. | Any |
+| **First conversation** | Initial chat held. | Aligned or Investable adjacent |
+| **Explore** | Specific role/scope under discussion. | Aligned or Investable adjacent |
+| **Formal process** | Real interview process started. Hand off to Interview Track. | Aligned, ideally |
+| **Decision** | Offer / declined / passed. | — |
+
+At each transition, ask:
+- Is this still aligned? (Re-score if anything has changed.)
+- What was learned in this stage that the candidate didn't know before?
+- What's the next concrete step + by when?
+
+When stage moves to **Formal process**, automatically:
+- Create or update `## Interview Loops` entry for the company.
+- Recommend Interview Track sequence: `decode` (if JD) → `prep` → etc.
+
+When stage moves to **Decision** (offer or declined): log result to Outcome Log. If offer, hand off to `negotiate`.
+
+### Mode: `audit`
+
+Run every 5-10 inbounds, or quarterly, whichever comes first.
+
+**Pattern questions:**
+
+1. **Source mix.** Where are inbounds coming from? Cold / warm intro / events / content / referral. Surface the dominant source.
+2. **Alignment hit rate.** What fraction of inbounds are scored Aligned? If <30%, the brand is pulling the wrong audience or compass is ambiguous.
+3. **Conversion rates between stages.** Surfaced → First conversation → Explore → Formal process. Where are inbounds dropping?
+4. **What's pulling.** Trace aligned inbounds back: did they reference a specific post, project, talk, mutual? Pattern-match.
+5. **What's not pulling.** Effort poured into channels that produce nothing.
+
+**Recommended actions** based on patterns:
+- If most inbound comes from one piece of content → double down on that thesis variant in `content`.
+- If most inbound comes from one person → recognize the connector and invest in that relationship in `relationships`.
+- If alignment hit rate is low → revisit `brand` (is the audience right?) or `compass` (is the definition right?).
+- If conversion drops at first conversation → coach the conversation skills via `convert`.
+- If formal process opportunities aren't converting → Interview Track issue, run `progress`.
+
+---
+
+## Output Schema
+
+Write to coaching_state.md under `## Inbound Opportunity Funnel`:
+
+```markdown
+## Inbound Opportunity Funnel
+| Date | Source | Person/Company | Type | Stage | Fit verdict | Next action |
+```
+
+Update rows on stage transitions. Cross-link to `## Interview Loops` when stage reaches **Formal process**.
+
+---
+
+## Failure Modes
+
+- **Selective logging.** Only logging the inbounds that feel important. Missing the pattern data.
+- **Stage drift.** Inbound stuck at "Explore" for 4+ weeks with no movement and no decision. Force the question: is this real, or is the candidate avoiding the call?
+- **Compass override.** Saying yes to a misaligned inbound because the alternative is doing nothing. Name it. Sometimes it's the right call. But name it.
+- **Skipping handoff.** Inbound reaches "formal process," but the candidate doesn't trigger Interview Track prep. Then the interview goes badly. Make the handoff explicit.
+
+---
+
+## Recommended Next
+
+After `log` + `score` (Aligned): when ready, `convert` (move to first conversation) or proceed to formal process (Interview Track via `decode`/`prep`). **Alternatives**: `relationships` (note the source for reciprocity).
+
+After `move` to **Formal process**: `decode [company]` if JD available, then `prep [company]`. **Alternatives**: skip `decode` if JD analysis is unnecessary.
+
+After `audit`: act on the surfaced patterns. **Alternatives**: revisit `brand` or `compass` if the patterns suggest upstream issues.

--- a/references/commands/projects.md
+++ b/references/commands/projects.md
@@ -1,0 +1,146 @@
+# projects — Proof-of-Work Projects
+
+Coach the candidate through public projects whose purpose is to prove the brand thesis to the target ecosystem and seed future stories. Projects in the Opportunity Track are not portfolio padding — they are deliberate artifacts.
+
+Read `references/opportunity-system.md` (Section: Proof of Work), `references/commands/brand.md`, and `references/storybank-guide.md` (completed projects seed the Storybank).
+
+---
+
+## Priority Check
+
+- If no `brand`: Hard gate — "Projects without a brand thesis tend to drift into hobbies. Run `brand` first to align."
+- If candidate has 3+ active projects already: Force triage — "You've got more in flight than is shippable. Let's pick one to ship and either pause or kill the others."
+
+---
+
+## Required Inputs
+
+- Brand Strategy (target audience + thesis + defensible POV).
+- Compass (open questions — projects are good vehicles for testing low-confidence compass entries).
+
+## Optional Inputs
+
+- Mode: `propose` (generate aligned project ideas) / `scope [project]` (define hypothesis, ship date, audience) / `coach [project]` (in-flight coaching) / `ship [project]` (ship-day choreography) / `debrief [project]` (post-ship learning + Storybank seeding).
+- Existing project ideas under consideration.
+
+---
+
+## Modes
+
+### Mode: `propose`
+
+Generate 5-7 project ideas drawn from:
+- Defensible POVs in Brand Strategy — each POV deserves at least one demonstration project over time.
+- Open questions in Compass — projects are testing apparatus.
+- Coverage gaps in the target ecosystem — projects can be invitations into rooms the candidate can't network into.
+- Real problems the candidate has noticed in target ecosystem they could plausibly contribute to (open source, a tool that doesn't exist, a write-up nobody else has done).
+
+For each idea capture:
+- Hypothesis: what does shipping this prove?
+- Brand alignment: which POV or thesis component does this advance?
+- Audience: who is meant to find this, and how?
+- Format: code repo, essay, deck, video, dataset, talk, tool.
+- Effort estimate: hours over how many weeks.
+
+Force ranking. The candidate picks one (or two if they have capacity). Three is a stretch. Five is a guarantee none ship.
+
+### Mode: `scope [project]`
+
+For one chosen project:
+
+**Step 1: Hypothesis statement.** "If I ship this, I expect [target audience] to react with [specific reaction]. If that doesn't happen, I'll learn [X about my brand thesis]."
+
+A project without a falsifiable hypothesis is decoration.
+
+**Step 2: Audience and discovery path.** Who specifically should find this? How will they find it? Channel ranking from `brand` applies. If the project ships to a channel the audience doesn't use, the project will succeed silently.
+
+**Step 3: Ship date.** Hard date. The candidate commits. Bias toward earlier — a worse v1 shipped beats a better v2 imagined.
+
+**Step 4: Scope cut.** Take the candidate's initial scope and cut it by half. Then half again. The smaller the v1, the higher the probability of shipping, the faster the learning loop.
+
+**Step 5: Anti-perfection clauses.** Define the v1 quality bar. Examples:
+- "Shipping when the README + demo work for one use case. Edge cases come later."
+- "Publishing when the essay has one strong example and one defensible POV. Three more examples can come in v2."
+- "Talk submitted when the abstract is good, even if the slides are 60% done. Slides finish in the next 2 weeks."
+
+### Mode: `coach [project]`
+
+For an in-flight project:
+
+- Where is the candidate vs. the ship date?
+- What's blocking? (Genuine technical blocker, scope creep, perfectionism, fear of shipping to target audience?)
+- Apply the scope cut again — what could be deferred to v2 to ship sooner?
+- Is the brand alignment still intact? (Projects drift. Mid-flight check.)
+
+If the candidate is more than 2 weeks past the original ship date with no clear blocker: name it. Apply Challenge Protocol if Directness Level 5 — perpetual projects are usually proof of avoidance, not proof of work.
+
+### Mode: `ship [project]`
+
+Ship-day choreography:
+
+- Public artifact published (repo, essay, deck — wherever it lives).
+- Discovery path activated:
+  - Posted on primary channel from Brand Strategy.
+  - Sent to 5-10 Tier 1/2 contacts who would genuinely care (not a blast — specific notes).
+  - Submitted to relevant communities/newsletters if the format fits.
+- Add to Projects table with status "Shipped."
+- Schedule debrief in 14-21 days (enough time for reactions to land).
+
+### Mode: `debrief [project]`
+
+Post-ship, ~2-3 weeks after shipping:
+
+**Step 1: Hypothesis check.** Did the predicted reaction happen? Yes / partially / no.
+
+**Step 2: Audience analysis.** Who actually engaged?
+- Target audience members? (Highest-signal.)
+- Adjacent audience? (Useful.)
+- Wrong audience? (Means the discovery path or the framing was off.)
+- Nobody? (Either the discovery path failed or the project didn't resonate with anyone.)
+
+**Step 3: Inbound surfacing.** Did this project produce any inbound — DMs, conversations, opportunity hints? Log to `## Inbound Opportunity Funnel` if yes.
+
+**Step 4: Storybank seeding.** Create at least one story:
+- Title that reads as a proper story (not "I shipped a thing").
+- STAR structure with the project's actual decisions.
+- Earned secret: what the candidate now believes that they didn't before.
+- Save to Storybank with full Story Details.
+
+**Step 5: Brand thesis update.** Did this project's reception support, contradict, or refine the brand thesis? Note any update needed.
+
+**Step 6: Next project.** If the project was a success, what does v2 or the next adjacent project look like? If it was a failure, what does the failure mean for `brand` and `compass`?
+
+---
+
+## Output Schema
+
+Write to coaching_state.md under `## Projects (Proof of Work)`:
+
+```markdown
+## Projects (Proof of Work)
+| Project | Hypothesis | Brand alignment | Audience | Status | Public artifact | Result |
+```
+
+After debrief, also seed Storybank (`## Storybank` and `### Story Details`).
+
+---
+
+## Failure Modes
+
+- **Perpetual project.** The project is always almost ready. Apply scope cut + force a ship date.
+- **Hidden project.** Built but not shipped to target audience. The discovery path is half the work.
+- **Misaligned project.** Built to the candidate's interests but not to the brand thesis. Hobby, not proof of work.
+- **Resume-stuffer project.** Built to look impressive on a resume, with no audience hypothesis. These never compound.
+- **The infinite v2.** Shipping v1, then immediately starting v2 instead of debriefing v1 and starting next project. Diminishing returns. Move on after debrief unless v1 generated specific user demand.
+
+---
+
+## Recommended Next
+
+After `propose`: `projects scope [chosen]` — define the hypothesis and ship date. **Alternatives**: more `compass` if no project feels alignment-clear (means compass needs work).
+
+After `scope`: build. Coach in-flight via `projects coach` if blocked.
+
+After `ship`: `content` — write a piece introducing the project to the target audience (the project IS content). **Alternatives**: `relationships` (signal the ship to relevant Tier 1).
+
+After `debrief`: `projects propose` (next project) or revisit `brand` (if the project's reception suggests thesis revision). **Alternatives**: `stories` (improve the seeded story before it's used in interviews).

--- a/references/commands/relationships.md
+++ b/references/commands/relationships.md
@@ -1,0 +1,137 @@
+# relationships — Long-Term Relationship Development
+
+Run the candidate's lightweight CRM: cadence per relationship, give-before-ask plan, follow-through queue, and re-warming sequences for Tier 2 contacts. Ensures the network compounds rather than decays.
+
+Read `references/opportunity-system.md` (Section: Give Before Ask Calculus) and `references/commands/mapping.md`.
+
+---
+
+## Priority Check
+
+- If no `mapping`: Soft gate — "I can coach individual relationships, but without the map we'll miss leverage. Want to run `mapping` first?"
+- If candidate's reciprocity ledger is significantly negative (more asks than gives in last 90 days): Flag — "You've been asking more than giving recently. Let's plan a giving cycle before any new asks."
+
+---
+
+## Required Inputs
+
+- Network Map (Tier 1 + 2 from coaching_state.md).
+
+## Optional Inputs
+
+- Mode: `cadence` (set or revise cadence per Tier 1) / `give` (plan gives for the next cycle) / `rewarm [name]` (reactivate a Tier 2) / `touch [name]` (coach a specific outreach today) / `audit` (review reciprocity ledger).
+- Specific person under consideration.
+
+---
+
+## Modes
+
+### Mode: `cadence`
+
+For each Tier 1 contact:
+
+- What's a sustainable cadence? Default monthly, but adjust to the relationship's natural rhythm. Some relationships work quarterly. Some are weekly because of shared work.
+- What's the give-before-ask ratio? Target ≥3:1 over any rolling 6-month window.
+- What does "meaningful contact" look like for this person? (Some prefer voice notes, some long emails, some meet IRL, some Slack DM with one good link.)
+
+Output: a cadence schedule. Not a calendar of forced touches — a map of natural rhythm.
+
+For Tier 2 contacts:
+- Default cadence: quarterly while relationship is warm, then move to ad-hoc.
+- Identify the 3-5 Tier 2 contacts most worth re-warming, based on overlap with target ecosystem.
+
+### Mode: `give`
+
+Plan gives for the next 30 days.
+
+For each Tier 1 contact, identify one possible give:
+- A specific intro (only if it's a real fit — not a speed-dating intro).
+- A signal-boost of their work (only if genuine).
+- A piece of useful info (article, product, person they should know).
+- Honest, useful feedback (only when invited).
+- A real show-up (their launch, talk, hard moment).
+
+Generic likes/comments don't count.
+
+Constraint: don't manufacture gives. A forced "give" lands as transparent. The discipline is *attention* — paying enough attention to the relationships that real gives surface.
+
+### Mode: `rewarm [name]`
+
+Reactivating a Tier 2 contact who hasn't had meaningful contact in 12+ months.
+
+**The non-extractive opener** has these properties:
+- Acknowledges the gap honestly. ("It's been a while" is fine. Manufactured continuity isn't.)
+- Brings something useful unprompted. An article they'd care about, a person they should know, a follow-up to something they once mentioned.
+- Has no ask. None. The first re-warm is purely a give.
+- Is short. ≤4-5 sentences for the message.
+
+After the re-warm, schedule a follow-up touch in 6-8 weeks. Don't ghost the re-warm.
+
+**Anti-pattern:** the re-warm with embedded ask. "Just thinking about you, also wondering if you know anyone hiring." Burns trust permanently.
+
+### Mode: `touch [name]`
+
+Coach a specific outreach today.
+
+Pull from coaching_state.md:
+- Last meaningful contact (date + topic).
+- Notes (what's sensitive, what they care about, what they value).
+- Reciprocity ledger (what they've given recently, what's owed).
+
+Coach the message:
+- Reference something specific from the prior interaction or their recent public work.
+- Lead with something useful or substantive.
+- If there's an ask, foreshadow it briefly and make it small enough to say yes to.
+
+Apply the Message Quality Rubric from `outreach.md` if the candidate is drafting cold or warm-cold; for established relationships, the rubric is overkill — focus on specificity and care.
+
+### Mode: `audit`
+
+Reciprocity ledger review.
+
+- Last 90 days, count gives and asks per Tier 1 contact.
+- Who has the candidate given to? Who has the candidate asked of?
+- Where is the imbalance?
+
+If the ledger is out of balance:
+- Identify 2-3 contacts to give to in the next 30 days, before any further asks.
+- If the candidate is *over*-giving without reciprocity from the other side, flag it. A one-way give relationship is friendship, not network. That's fine — but don't expect career leverage from it.
+
+Look for signs of pipeline decay:
+- Tier 1 contacts who haven't had meaningful contact in 6+ months are silently moving to Tier 2.
+- Tier 2 contacts with no re-warm activity in 12+ months are silently moving to Tier 3.
+
+Surface 3-5 highest-leverage interventions: who to re-engage, who to deepen, who to release.
+
+---
+
+## Output Schema
+
+Write to coaching_state.md under `## Relationship Pipeline`:
+
+```markdown
+## Relationship Pipeline
+| Person | Tier | Cadence | Last touch | Next touch | Give offered | Ask (if any) | Notes |
+```
+
+Update individual rows after each `touch` or `give` cycle.
+
+---
+
+## Failure Modes
+
+- **The fake CRM.** Treating the pipeline as a sales funnel. The relationship is the asset, not the conversion.
+- **Forced cadence.** Setting monthly touches and dispatching templated check-ins. Lands as transparent. Real cadence is rhythmic, not scheduled.
+- **The favor bank misconception.** Believing every give creates an obligation. It doesn't. Some gives are pure care, and the candidate should be honest about which is which.
+- **Ghosting the rewarm.** Sending a re-warm message and then disappearing again. Worse than no re-warm. Schedule the follow-up before sending.
+- **Over-asking after a single give.** "I helped you, now help me" is transparent. The 3:1 ratio matters.
+
+---
+
+## Recommended Next
+
+After `cadence`: `relationships give` — plan the first cycle of gives. **Alternatives**: `intro` (if a near-term intro path is ready).
+
+After `give`: execute the gives over the next 30 days; in 30 days, run `relationships audit`. **Alternatives**: `touch [name]` (if a specific outreach is needed today).
+
+After `audit`: act on the surfaced interventions. **Alternatives**: `mapping` (if the audit reveals coverage gaps that need to be addressed via brand and content), `events` (if the audit suggests the network needs new entry points).

--- a/references/commands/targets.md
+++ b/references/commands/targets.md
@@ -1,0 +1,144 @@
+# targets — Build the Target Ecosystem
+
+Translate the candidate's compass into a concrete target ecosystem: tiered companies, communities and scenes, and the segment they're actually targeting. The output is what `mapping`, `brand`, and `content` build on.
+
+Read `references/opportunity-system.md` (Section: Target Ecosystem Model) and `references/commands/research.md` (research workflow is reused per company).
+
+---
+
+## Priority Check
+
+- If no `compass` exists: Hard gate — "I need a compass to build a target ecosystem against. Let's run `compass` first. Otherwise we'll build a target list optimized for opportunities you don't actually want."
+- If `compass` exists at low confidence: Soft gate — "Your compass confidence is low. I can build a target ecosystem, but treat it as a hypothesis we'll revise. Want to proceed, or run `projects` first to test compass?"
+- If user already has a long target list in mind: Useful — we'll bring rigor to it, not build from scratch.
+
+---
+
+## Required Inputs
+
+- Compass output (from coaching_state.md).
+- The candidate's current notion of where they want to look — even if vague.
+
+## Optional Inputs
+
+- Depth: Quick (1 session, 30-50 companies surfaced, 10 prioritized) / Standard (2 sessions, ecosystem + communities, default) / Deep (3 sessions, ecosystem + communities + segment hypothesis testing).
+- Existing target list (will be evaluated against compass).
+- Geographic constraints, time-zone constraints.
+- Recent rejection patterns (these inform anti-targets).
+
+---
+
+## Logic / Sequence
+
+### Step 1: Compass-to-Targets Translation
+
+Pull the aligned-opportunity sentence from the Compass section. Decompose it into:
+- **Sector / industry** signals.
+- **Company stage** signals (size, funding stage, age).
+- **Role/scope** signals.
+- **Cultural** signals.
+- **Anti-criteria** (these become target filters).
+
+Surface candidate companies. The candidate's own list is the starting set; supplement with research:
+- Industry and segment maps (use web research per `research.md` Quick Scan).
+- "Companies similar to X" via product-similarity, hiring-pattern similarity, leadership-tree similarity.
+- Communities and Slack/Discord/Substack lists where target operators congregate (these are leading indicators of new companies).
+
+### Step 2: Tier Assignment
+
+Each company gets a tier:
+
+- **Tier 1 — Core fit.** Compass-aligned with no significant bridge required. Cap at ~10. If >10, force prioritization.
+- **Tier 2 — Adjacent.** Strong alignment with one bridge required (domain shift, stage shift, role shift). Cap at ~10.
+- **Tier 3 — Stretch.** Aligned in some dimension but requires significant bridges. ≤10.
+- **Tier 4 — Watch-only.** Interesting signals (recent funding, new product line, hire of someone the candidate respects) but not currently pursuing. Logged so the candidate can watch passively.
+
+If the user wants to add a 21st company to active tiers, force a swap: which one comes off?
+
+### Step 3: Watch Signals
+
+For each Tier 1-2 company, identify the **watch signal** — what specific signal would trigger active outreach? Examples:
+- Hiring announcement for a role matching compass.
+- Public post by a target person inviting collaboration.
+- Public funding round in a segment fit for the candidate.
+- Product launch indicating a domain shift toward candidate fit.
+
+Watch signals turn passive monitoring into active triggers. Without them, the target list is decorative.
+
+### Step 4: Communities & Scenes
+
+Where do the people doing the work the candidate wants to do actually congregate? Map:
+
+- **Conferences** — top 3-5 the candidate would benefit from attending or speaking at.
+- **Online communities** — Slacks, Discords, subreddits, Substacks with active comment communities.
+- **Open source / publication** — repos, projects, publications where target operators are visible.
+- **Podcasts** — both as listener (where to learn the discourse) and as guest (where to be discovered).
+- **Meetups / dinners** — local or curated communities.
+
+For each, note: what's the cost of entry (paid? referral-only? open?) and what's the cadence (every conference once a year? Slack daily?).
+
+### Step 5: Segment Statement
+
+The candidate writes a single sentence: "I am targeting [narrow segment]." Phyl Terry's spear, not a net.
+
+A weak segment: "AI/ML companies."
+A stronger segment: "Companies building applied AI for clinical workflows in mid-size hospital systems."
+
+The segment must:
+- Be narrow enough that 5-30 specific companies and 2-5 specific communities fit.
+- Be authentic to the compass (not chosen because it's trendy).
+- Be a place where the candidate's brand can plausibly land.
+
+### Step 6: Anti-Targets
+
+What the candidate is explicitly *not* pursuing, even when interesting. This prevents drift. Examples:
+- "Series B+ companies with no founder still in product-leadership role."
+- "Marketing-heavy roles dressed up as product roles."
+- "Companies whose primary moat is regulatory capture I disagree with."
+
+Anti-targets are a discipline. Without them, every interesting opportunity competes for attention.
+
+---
+
+## Output Schema
+
+Write to coaching_state.md under `## Target Ecosystem`:
+
+```markdown
+## Target Ecosystem
+
+### Companies
+| Tier | Company | Why fit | Watch signal | Status |
+
+### Communities & Scenes
+| Name | Type | Where my people are doing what | Engagement plan |
+
+### Segments
+- Primary segment: [single sentence]
+- Adjacent segments: [list]
+- Disqualified segments: [list with reason]
+
+### Anti-Targets
+- [Pattern]: [reason]
+```
+
+In-session output also includes:
+- The segment statement (highlighted).
+- The 5 most important Tier 1 companies and why (the "regret list").
+- The top 3 communities by leverage.
+- The top 3 anti-targets with reasoning.
+
+---
+
+## Failure Modes
+
+- **The wish list.** 100 companies the user finds interesting but couldn't realistically pursue. Force pruning.
+- **The trendy segment.** Picking a segment because it's hot, not because the compass points there. Test against compass — does the segment actually serve the work-shape paragraph?
+- **The fragmented ecosystem.** Companies in 5 unrelated segments. Either compass is unfocused (back to compass) or the user has multiple compasses (force one).
+- **No anti-targets.** A target ecosystem with no anti-targets has no edges; it'll absorb every opportunity that comes in.
+
+---
+
+## Recommended Next
+
+**Recommended next**: `mapping` — figure out who you already know inside this ecosystem and where the gaps are. **Alternatives**: `brand` (if mapping reveals strong existing ties and the bottleneck is positioning, not access), `research [Tier-1 company]` (if you want to deep-dive a specific top target).

--- a/references/integrations/ai-native.md
+++ b/references/integrations/ai-native.md
@@ -1,0 +1,161 @@
+# Integration Notes — `jazzmind/ai-native`
+
+This document outlines how the interview-coach + opportunity-system skill could be integrated with the [ai-native](https://github.com/jazzmind/ai-native) advisory platform. It is a planning artifact, not an implementation: ai-native is an external project we don't control, and the integration surface should be revisited against the actual repo state before code lands.
+
+These notes are intentionally adapter-focused. The two systems should remain independently useful; integration should compose them, not couple them.
+
+---
+
+## What ai-native Is (Working Model)
+
+Per the public README at the time of this writing, ai-native is a multi-agent advisory platform:
+
+- **Frontend**: Next.js chat UI with Electron desktop.
+- **Backend**: Node.js API routes that route to **Claude Managed Agents**.
+- **Database**: Postgres (Neon) via Drizzle ORM for conversations, memory, feedback, behavior tracking.
+- **Agents**: Seven domain advisors (Founder, Strategy, Funding, Finance, Legal, Growth, Technology), plus a **Chief of Staff** orchestrator and a **QA Judge**.
+- **Modes**: Advise, Coach, Plan, Assist, Execute.
+- **Memory**: Persistent, organized by type, scoped per project/workspace.
+- **Expert-in-the-loop** review and behavioral adaptation.
+
+The interview-coach + opportunity-system skill is not currently any of those advisors; it covers a different domain (career, brand, network, opportunity, interview) and a different operating model (file-based persistent state in `coaching_state.md`, command-driven workflows).
+
+---
+
+## Integration Hypothesis
+
+There are three plausible integrations, in order of decreasing coupling and increasing safety:
+
+### Option 1 — Career Advisor (additive)
+
+Add this skill as an additional ai-native domain advisor — alongside Founder, Strategy, Growth, etc. — with names like `career` or `opportunity`.
+
+**Pros:** Natural fit. Extends the platform's surface area into a domain it doesn't currently cover.
+
+**Cons:** Requires this skill to be reformulated as a managed-agent prompt (or set of prompts) rather than a SKILL.md + reference-file structure. The state model would need to migrate from `coaching_state.md` to ai-native's typed memory store.
+
+**Recommended only if** ai-native maintainers want to officially extend the platform into career coaching.
+
+### Option 2 — External Skill Linked via Chief of Staff (loose integration)
+
+Keep this skill repo as-is (file-based, command-driven, used in Claude Code or compatible IDEs). Have ai-native's Chief of Staff orchestrator know how to delegate career-related requests to this skill — either by spawning a Claude session that loads the skill, or by referencing this skill's outputs.
+
+**Pros:** Minimal coupling. Both systems evolve independently. Users who run ai-native get career coverage; users who run this skill alone keep the existing experience.
+
+**Cons:** Two memory systems. Outputs from this skill (compass, brand thesis, target ecosystem, network map, storybank) need to either flow into ai-native's memory or be referenced as external artifacts.
+
+**Recommended baseline.** This is what an integration should look like first.
+
+### Option 3 — Skill-as-Agent Bridge (full bridge)
+
+Build an adapter that exposes this skill's commands as ai-native agent endpoints, with ai-native's memory system as the canonical state store and this skill's reference files as the working knowledge base.
+
+**Pros:** Full integration. Coaching state visible to other ai-native advisors (e.g., Founder advisor knows the user's career compass).
+
+**Cons:** Significant adapter work. Must keep behavior identical to standalone use, which means the adapter is a translation layer between two paradigms.
+
+**Recommended later** — only after Option 2 has proven the value of integration.
+
+---
+
+## Adapter Surface (Option 2 / Option 3)
+
+If integration goes ahead, these are the interface points to define and stabilize.
+
+### State Sync
+
+This skill's canonical state is `coaching_state.md` — a single Markdown file with structured sections defined in `SKILL.md`. ai-native's canonical state is a typed Postgres schema accessed via Drizzle.
+
+Adapter needs:
+- A read mapping from each `coaching_state.md` section to a structured shape ai-native can store (Compass, Brand Strategy, Target Ecosystem, Network Map, Storybank, Score History, etc.).
+- A write mapping from updates ai-native or other agents make back into `coaching_state.md`.
+- Conflict resolution rules: both sides can write; this skill expects to be the source of truth for career-coaching artifacts. The adapter should serialize updates rather than allow concurrent edits.
+
+A stable v1 sync is one-directional: this skill writes, ai-native reads. Bidirectional sync should wait until concrete needs justify it.
+
+### Command Routing
+
+This skill exposes 30+ commands (see SKILL.md Command Registry). ai-native's Chief of Staff would not invoke each individually. Recommended grouping for routing:
+
+| ai-native intent | Skill commands to invoke |
+|---|---|
+| "Help me figure out what I want from my career" | `compass` |
+| "Build my career strategy" | `compass` → `targets` → `brand` → `bootcamp start` |
+| "I have an interview at [company]" | `prep [company]` |
+| "Just had an interview" | `debrief` |
+| "Critique my LinkedIn / resume" | `linkedin` / `resume` |
+| "Run the full career bootcamp" | `bootcamp start` |
+| "I have an inbound opportunity" | `opportunities log` + (if JD) `decode` |
+| "Help me reach out / network" | `outreach` / `intro` / `relationships` |
+
+The router lives in ai-native's Chief of Staff prompt; this skill itself shouldn't be modified to know about ai-native.
+
+### Memory Translation
+
+ai-native organizes memory by type (per the README, persistent memory across sessions, organized by type). Suggested mapping:
+
+| ai-native memory type | This skill's source |
+|---|---|
+| User profile / values | Compass section |
+| Goals | Aligned-opportunity sentence + Bootcamp State |
+| Project state | Active interview loops + bootcamp current week |
+| Knowledge base / artifacts | Storybank, Brand Strategy, Content Calendar |
+| Relationships | Network Map + Relationship Pipeline |
+| History / outcomes | Score History, Outcome Log, Conversion Log |
+
+The adapter translates between Markdown sections and ai-native's memory schema. Keep the mapping explicit and versioned — schema migrations on either side will require adapter updates.
+
+### Mode Mapping
+
+ai-native has five modes (Advise, Coach, Plan, Assist, Execute). This skill is primarily **Coach** by default — it leads with self-reflection, direct feedback, and structured workflows. The mapping:
+
+| ai-native mode | How this skill maps |
+|---|---|
+| **Advise** | Reduce coaching scaffolding, lead with verdict + reasoning. Roughly equivalent to Directness Level 5 + skipping reflection prompts. |
+| **Coach** | Default — exactly how the skill operates. |
+| **Plan** | Bootcamp `plan` mode + multi-step intent sequences. |
+| **Assist** | Pre-fill drafts (e.g., outreach messages, content outlines) with annotations rather than coach the user to write them. |
+| **Execute** | Limited — the skill doesn't autonomously send messages. Could publish drafts to a queue for user approval. |
+
+The skill's `feedback directness` (1-5) and ai-native's modes are related but not identical. Make the mapping explicit; don't silently override.
+
+### Expert-in-the-Loop
+
+ai-native supports expert review. The natural integration point is at high-stakes outputs:
+- Compass at low confidence (could route to a human career coach for review).
+- Brand thesis (could route to a peer reviewer).
+- Real interview transcript analyses (could route to an interview coach who knows the target company).
+
+This skill doesn't currently distinguish "expert review eligible" outputs. If integration with ai-native's expert review is desired, add a tag at command output: `expert_review: recommended | optional | not_applicable`.
+
+---
+
+## Concrete Next Steps (When Integration Is Pursued)
+
+1. **Read the actual ai-native repo state** — README, agent prompt files, mode templates, memory schema. The notes above are based on a single README fetch and may be stale.
+2. **Decide between Options 1, 2, 3.** Default to Option 2.
+3. **Build a state-mirror adapter** — read-only first. Confirm the mapping holds for real users on both systems.
+4. **Add a routing prompt addendum to ai-native's Chief of Staff** — so career-related requests get routed to this skill rather than to one of the existing seven advisors.
+5. **Pilot with 2-3 users** running both systems. Surface conflicts, refine the mapping.
+6. **Publish a version-pinned compatibility note** — this skill version X is compatible with ai-native commit/version Y. Don't claim broader compatibility than was tested.
+
+---
+
+## What Not to Do
+
+- **Don't fork this skill to "integrate" it.** The skill should remain standalone-usable. Integration is an adapter responsibility.
+- **Don't move state into ai-native's database before validating the mapping.** Bidirectional sync without confirmed schemas creates data loss risk.
+- **Don't auto-trigger commands without user awareness.** ai-native's Execute mode shouldn't autonomously run `outreach` or `intro` — those send real messages and burn real social capital. Stay at Plan/Assist for these.
+- **Don't conflate "career advisor" with the existing Founder advisor.** The Founder advisor in ai-native is about personal alignment for someone running a company. This skill is about career and opportunity for someone in a job search or career build. Overlap exists; equivalence does not.
+
+---
+
+## Open Questions (For ai-native Maintainers)
+
+1. Are you interested in extending ai-native into career/opportunity coverage, or is your scope intentionally limited to founder/operator advisory?
+2. What's your preferred integration shape — additional advisor, external skill via Chief of Staff, or full bridge?
+3. How is your memory schema versioned, and what's your migration path for schema additions?
+4. What's your stance on cross-skill state sharing — does Founder advisor's view of a user share state with a future Career advisor?
+5. Do you have an existing convention for external-skill routing (Option 2)?
+
+These should be answered before significant adapter work begins.

--- a/references/opportunity-system.md
+++ b/references/opportunity-system.md
@@ -1,0 +1,323 @@
+# Opportunity System — Shared Reference
+
+This is the philosophical and operational backbone for the Opportunity Track. All Opportunity Track commands (`compass`, `targets`, `mapping`, `brand`, `content`, `events`, `relationships`, `projects`, `opportunities`, `intro`, `convert`, `bootcamp`) build on the principles and modules defined here. Read this before running any Opportunity Track command.
+
+---
+
+## Core Premise
+
+Most career advice optimizes the application — better resume, better cover letter, better keyword match. The strongest careers are not built that way. They are built so that **opportunity arrives because the right people know the right things about you**.
+
+The aspirational user has never sent a resume to a stranger. Every meaningful opportunity in their career came through:
+
+1. A network they deliberately built and maintained, **not** a Rolodex they happened to have.
+2. A brand they cultivated so the opportunities that arrived were the ones they wanted to do.
+
+The Opportunity Track teaches the user to do this on purpose. Not as luck, not as charisma — as a rigorous system.
+
+This is **not** a substitute for the Interview Track. When opportunities come in, they still need to be evaluated, prepared for, and converted. But the goal is to spend the bulk of one's career-building energy upstream — on compass, brand, network, and proof — so that the interview pipeline is small, aligned, and warm by default.
+
+---
+
+## The Five Stages
+
+Every Opportunity Track engagement passes through five stages. They are not strictly linear — later stages feed back into earlier ones — but they have a natural sequence the first time through.
+
+| Stage | Question it answers | Primary commands |
+|---|---|---|
+| **Discover** | What kind of work do I actually want to be pulled toward? | `compass`, `targets` |
+| **Position** | What do I want to be known for, and to whom? | `brand`, `pitch`, `linkedin`, `resume` |
+| **Distribute** | How do the right people learn the right things about me? | `content`, `projects`, `events` |
+| **Activate** | Who do I already know, and how do I deepen those ties without extracting? | `mapping`, `relationships`, `intro` |
+| **Convert** | When opportunity arrives, how do I evaluate and land what fits? | `opportunities`, `convert`, then Interview Track (`decode`, `prep`, `mock`, `negotiate`) |
+
+A user can enter the system at any stage — but a user who skips Discover often produces brand and network output that doesn't compound, because they're optimizing for opportunities they don't actually want.
+
+---
+
+## Discovery Rigor
+
+Used by: `compass`.
+
+Most discovery exercises are weak because they accept whatever the candidate says first. Real discovery has to be earned through specificity and contradiction.
+
+**Rules:**
+
+1. **Specificity over abstraction.** "Working on hard problems" is not a compass entry. "Designing pricing systems for B2B SaaS where the customer is also a developer" is.
+2. **Anti-criteria are non-negotiable.** What you will not accept is more diagnostic than what you say you want. If a user can't name three things they would refuse, the compass is incomplete.
+3. **Test against past data.** For every value the user claims, ask: when did this last cost you something? If it's never been tested, treat it as a hypothesis, not a value.
+4. **The aligned-opportunity sentence test.** The user must be able to write a single sentence that an opportunity must satisfy to count. If they can't, run another round.
+5. **Confidence labeling.** Compass at "low confidence" is fine — it means the next step is to test, not to position. Compass at "high confidence" without three pieces of supporting evidence is a red flag for performative clarity.
+
+**Output discipline:** the compass entry is the foundation. Brand, targets, content, projects all derive from it. If compass shifts later, those derivatives must be revisited — not silently.
+
+---
+
+## Target Ecosystem Model
+
+Used by: `targets`, `mapping`.
+
+Targets are not just a company list. A target ecosystem has three parts:
+
+1. **Companies (tiered).** Tier 1 = core fit. Tier 2 = adjacent (would consider with one bridge). Tier 3 = stretch (would consider for the right role). Tier 4 = watch-only (interesting signals, not pursuing).
+2. **Communities and scenes.** Where do the people doing the work the user wants to do actually congregate? Conferences, Slacks, Discords, open source projects, podcasts, publications, meetups. The community list is often more durable than the company list because companies churn.
+3. **Segments.** The narrow market the user is targeting. Phyl Terry's principle from `outreach.md` applies here directly: "a spear, not a net." A user targeting "AI" is targeting nobody. A user targeting "applied AI for clinical workflows in hospital systems" is targeting somebody.
+
+**Anti-pattern:** building a 200-company list. Beyond ~20 companies the list stops being a target list and starts being a wish list. If the user has 50 companies, force prioritization — which 10 would they regret not pursuing?
+
+---
+
+## Network Topology
+
+Used by: `mapping`, `relationships`, `intro`.
+
+Three tiers, each treated differently:
+
+- **Tier 1 — Strong ties.** People who would take your call today. Treat them as collaborators, not lottery tickets. Default cadence: monthly meaningful contact, give-before-ask ratio at least 3:1.
+- **Tier 2 — Warm.** People you have history with but haven't talked to recently. Re-warming requires a non-extractive opener — sharing something useful before any ask. Default cadence: quarterly until re-warmed.
+- **Tier 3 — Reachable through one hop.** Targets you don't know directly but a Tier 1 or strong Tier 2 could introduce. The currency for reaching Tier 3 is your own credibility with the introducer (their social capital).
+
+**Coverage assessment.** For each segment in the target ecosystem, count Tier 1/2 contacts. Segments with zero are coverage gaps that the brand and content strategy must address — you can't network into a room you have no path into; you have to be invited via something you've published.
+
+**Anti-pattern:** treating LinkedIn connections as the network map. The map is what's real, not what's listed. If you haven't had a meaningful exchange in 24 months, that person is Tier 3 to you regardless of what the connection says.
+
+---
+
+## Brand Distribution Thesis
+
+Used by: `brand`, `content`, `projects`.
+
+A brand without a distribution thesis is a private monologue. A distribution thesis answers three questions:
+
+1. **What do I want to be known for?** (One thing, narrow. "PM" is not a brand; "the PM you call when your pricing model is breaking trust with customers" is.)
+2. **Who needs to know it?** (Must overlap with the target ecosystem from `targets`. If your audience and your target ecosystem don't overlap, your brand is building someone else's career.)
+3. **Where do they encounter me?** (Channel ranking — primary, secondary, tertiary. A brand strategy with five primary channels has none.)
+
+**Defensible POV.** A brand thesis without a defensible point of view is a job title. The user needs at least one belief that most peers do not share, with a real reason for holding it. (See `differentiation.md` — earned secrets and spiky POVs apply here directly.)
+
+**Cadence over volume.** A brand built on three high-quality long-form pieces a year compounds more than one built on daily posts that say nothing. The cadence commitment in the brand strategy is a floor, not a ceiling — but it must be a floor the user can hold for 12 months without burning out.
+
+**Anti-brand.** What the user will not say, even when easy. This is the integrity test. A brand that lacks an anti-brand has no edges, and a brand without edges does not pull aligned opportunities; it pulls noise.
+
+---
+
+## Content Discipline
+
+Used by: `content`.
+
+Content is the brand's distribution mechanism. Most content advice is volume-pilled. The Opportunity Track is not.
+
+**Rules:**
+
+1. **Every piece reinforces the thesis.** If the user can't tie a piece back to the brand thesis from `brand`, it's noise — it'll get clicks but won't compound.
+2. **Earned secrets are the renewable fuel.** The Storybank is a content backlog. Every story with an earned secret is a piece worth writing.
+3. **Show, don't claim.** "I'm a great PM" loses to "Here's a pricing decision I made that cost us $400k in the first quarter and saved us $4M over two years — and the framework I'd use again."
+4. **Distribution is half the work.** A great post on a platform the audience doesn't use is wasted. Match the channel ranking from `brand`.
+5. **Audit the inbound.** Every published piece logs its outcome — reach, reactions, inbound DMs, opportunities surfaced. Content that doesn't pull anything from the target audience after 3-5 attempts is a signal to revise the thesis or the channel, not to publish more.
+
+**Anti-pattern:** outsourcing voice. Ghostwritten or LLM-laundered content destroys the differentiation dimension. The user's own voice is the asset; the assistant's job is to coach structure, sharpness, and distribution — never to ventriloquize.
+
+---
+
+## Showing Up (Events)
+
+Used by: `events`.
+
+Events are not networking opportunities; they are relationship initiation moments that require pre- and post-work to count.
+
+**Pre-event:**
+- Set one specific goal (meet 3 people from segment X, find one collaborator for project Y, validate hypothesis Z).
+- Identify 3-5 people worth meeting before arrival. Public schedule + LinkedIn + recent posts.
+- Have one current thing to talk about that ties to the brand thesis.
+
+**At the event:**
+- Quality of conversation > number of conversations. Three real exchanges beat 30 cards.
+- Take notes on conversations within 90 minutes (after that, recall collapses).
+
+**Post-event:**
+- Follow up within 48 hours, with something specific from the conversation (not "great to meet you").
+- Add new contacts to Relationship Pipeline at the appropriate tier.
+- Debrief: what worked, what didn't, was the goal met, what's the next event.
+
+**Anti-pattern:** treating events as content opportunities ("posting my conference photo"). The event's value is the relationships initiated, not the content produced. Content is fine as a byproduct.
+
+---
+
+## Give Before Ask Calculus
+
+Used by: `relationships`, `intro`, `outreach`.
+
+The strongest networks run on a give-before-ask ratio of at least 3:1 — three meaningful, useful, no-strings exchanges before any direct ask.
+
+**What counts as a give:**
+- A relevant introduction (the strongest give — but only when both sides will benefit).
+- A signal-boost of their work to your audience (only if genuine).
+- A specific piece of useful information (an article they'd care about, a product they'd use, a person they should meet).
+- Honest, useful feedback when invited.
+- Showing up — to their launch, talk, recovery, hard moment.
+
+**What does not count:**
+- Generic "great post!" comments.
+- LinkedIn likes.
+- A note saying "we should catch up" with no substance.
+- Asking for a 15-minute "quick chat" framed as a give.
+
+**The cadence floor.** Tier 1: at least one meaningful contact per quarter, ideally monthly. Tier 2: at least one per 6 months while warm; then move to ad-hoc.
+
+**Anti-pattern:** the audit-and-extract pattern. Reaching out only when the user needs something. The relationship pipeline is the longest-half-life asset in a career; extracting from it without renewal collapses it.
+
+---
+
+## Proof of Work
+
+Used by: `projects`.
+
+Projects in the Opportunity Track are not hobbies and not portfolio padding. A project is a proof-of-work artifact that:
+
+1. **Reinforces the brand thesis.** A user whose brand is "applied AI for clinical workflows" should not be shipping a generic Twitter clone.
+2. **Is publicly findable.** If the target audience can't find it, it doesn't pull opportunities. GitHub, a blog post, a public demo, a published essay, a talk recording.
+3. **Has a falsifiable hypothesis.** What does the user expect this project to demonstrate? Who do they expect to react to it? If the hypothesis fails, what does that mean about the brand thesis?
+4. **Produces a story.** Every completed project seeds the Storybank with at least one earned-secret-bearing story for future interviews and future content.
+
+**Anti-pattern:** the perpetual side project. A project that's been "almost ready" for six months is not proof of work; it's proof of avoidance. Set ship dates. A bad shipped project teaches more than a perfect unshipped one.
+
+---
+
+## Inbound Funnel Hygiene
+
+Used by: `opportunities`.
+
+When the system works, opportunities arrive — sometimes faster than the user expects. Inbound funnel hygiene prevents two failure modes: (a) saying yes to misaligned opportunities because they're flattering, and (b) ghosting good opportunities because they're badly timed.
+
+**Rules:**
+
+1. **Every inbound logs.** Even the ones the user immediately declines. Pattern detection requires data.
+2. **Score against the compass, not against the offer.** If the inbound doesn't satisfy the aligned-opportunity sentence from `compass`, the right move is to redirect or pass — even if it's prestigious.
+3. **Stage discipline.** Surfaced → first conversation → explore → formal process → decision. Each stage has a different fit-confidence threshold.
+4. **Reciprocity tracking.** Every warm intro that produced an inbound creates a reciprocity owed entry — log it.
+5. **Pattern review.** Every 5-10 inbounds, ask: what's pulling? Is it the brand thesis? An old project? A specific person sending referrals? The answer informs where to invest more.
+
+**Handoff to Interview Track.** When an inbound reaches "formal process," create or update an Interview Loop and let the Interview Track take over: `decode` the JD, `prep`, `mock`, etc.
+
+---
+
+## Intro Choreography
+
+Used by: `intro`.
+
+Warm intros are 3-5x more likely to convert than cold (per `outreach.md`), but only when handled correctly. Bad warm intros burn the introducer's social capital and don't get repeated.
+
+**The double opt-in protocol:**
+
+1. User asks the introducer privately: "Would you be open to introducing me to X? Here's the context, here's the ask, no pressure."
+2. Introducer asks X privately: "I'd like to introduce you to Y because of Z. Open to it?"
+3. Only after both yes, the forwardable email goes out.
+
+**The forwardable email** has three properties:
+- Easy to forward without editing (≤150 words).
+- Self-contained context (X learns who you are without clicking anything).
+- A specific, bounded ask (not "would love to chat" — "would love 20 minutes on how you handled the pricing migration at A").
+
+**Reciprocity.** Every intro received creates an obligation. Track it. Pay it forward — not necessarily to the same person, but to the same network.
+
+**Anti-pattern:** the chained ask. Asking the introducer to also weigh in on your resume, also send your work to their CEO, also recommend you elsewhere. One ask per intro. If you need three things, that's three intros, not one bundle.
+
+---
+
+## Conversation-to-Opportunity Conversion
+
+Used by: `convert`.
+
+A coffee chat or intro call is not an opportunity. It is a meeting that may produce one. The conversion gap is where most networking effort is wasted — great conversations followed by silence.
+
+**The conversion bridges:**
+
+1. **The collaboration test.** Offer to do a small piece of work together — review a draft, look at a problem, prototype a thing. Demonstrates fit faster than any pitch.
+2. **The follow-up artifact.** Send something within 48 hours that the conversation prompted — an article, a contact, a piece of work, a question. Keeps the conversation alive without an ask.
+3. **The named ask, when it's time.** When alignment is established, make the ask specific and small enough to say yes to. "I'm thinking about the X role at Y — would you be open to flagging it to whoever's running that hiring process if I sent you a one-pager?" beats "any leads?"
+4. **The graceful pass.** If alignment isn't there, end cleanly: "This was useful, here's something I'd send you that's relevant, let me know how I can be helpful." Burns no bridges, leaves the door open.
+
+**Anti-pattern:** the surprise pivot. Going into a conversation with a hidden ask and revealing it at the end. Destroys trust. The ask should be foreshadowed before the meeting or land naturally inside it.
+
+---
+
+## Cross-Command Dependencies
+
+Opportunity Track commands form a dependency graph. The coach should respect it.
+
+```
+compass ──▶ targets ──▶ mapping
+   │           │           │
+   ▼           ▼           ▼
+ brand ◀────  projects ◀─ relationships
+   │           │           │
+   ▼           ▼           ▼
+ content ──▶  events ───▶  intro
+                │           │
+                ▼           ▼
+             opportunities ──▶ convert ──▶ Interview Track
+```
+
+**Soft gates** (do not block, but flag):
+
+- Running `brand` without `compass` → "We can build a brand thesis, but without compass clarity we may build for the wrong audience. Want a quick compass first?"
+- Running `content` without `brand` → "We can plan content, but it'll lack a thesis to compound around. Want to run `brand` first?"
+- Running `mapping` without `targets` → "We can map your network, but we won't know which of those ties matter most. Want to define targets first?"
+- Running `projects` without `brand` → "Projects compound when they reinforce a thesis. Without brand, this is a hobby. Want to align first?"
+- Running `convert` without `compass` → "Without an aligned-opportunity definition, conversion looks like 'land what's in front of you.' That's how people end up in misaligned roles."
+
+**Hard handoffs:**
+
+- `opportunities` reaches "formal process" → create Interview Loop, hand off to `decode` and `prep`.
+- `convert` produces a job conversation → create or update Interview Loop.
+- `projects` ships → seed Storybank with a story.
+
+---
+
+## Operating Rules (Opportunity Track)
+
+These extend the Non-Negotiable Operating Rules in SKILL.md. They do not replace them.
+
+1. **Every recommendation cites compass alignment.** Recommendations that don't reference what the user said they wanted are coaching theater. Tie back to compass — or say compass is missing and recommend running it first.
+2. **Distinguish authentic from performative.** Brand and content work has a strong gravitational pull toward what is publishable, not what is true. Push back when you see it. The user's voice is the asset.
+3. **Time horizons are explicit.** A brand built in two weeks is not a brand. A network "warmed up" in one outreach burst is not warm. The Opportunity Track operates in months and quarters; do not let the user pretend otherwise. If they have a 4-week interview deadline, redirect to Interview Track sequences.
+4. **Resist the urge to ship a resume.** When the user defaults to "should I just apply?" — name it. The system exists because that approach has known returns. Pursue it only when the upstream system is genuinely insufficient or the user explicitly chooses it.
+5. **Reciprocity ledger.** When the user is given something — an intro, a referral, a recommendation — record it as reciprocity owed. The Opportunity Track is unsustainable if the user becomes a net taker.
+
+---
+
+## Anti-Patterns to Watch For
+
+| Pattern | What it looks like | The redirect |
+|---|---|---|
+| **Performance discovery** | "I want to do meaningful work with great people on hard problems" | Force specificity. Until the compass entry would surprise a stranger, it's a wish, not a compass. |
+| **The 200-target list** | A spreadsheet of every interesting company | Force prioritization to ≤20. Beyond that, it's avoidance. |
+| **The networking sprint** | Reaching out to 50 people in a week to "build a network" | Slow it down. A real relationship pipeline is built over months. Sprints burn the network. |
+| **Ghostwritten brand** | LLM-polished posts that lose the user's voice | Stop. The voice is the asset. The coach edits structure, never replaces voice. |
+| **The perpetual project** | A side project that's always almost ready | Set a ship date. A bad shipped project beats a perfect unshipped one. |
+| **The hidden ask** | "Just want to catch up" → ends with a job request | Foreshadow asks. If the meeting needs an ask, name it before. |
+| **Audit and extract** | Reaching out only when needing something | Re-warm with a give before any ask. The cadence is non-negotiable. |
+| **Brand without anti-brand** | "I want to be known for being helpful" | Force edges. A brand without things it refuses to be has no shape. |
+
+---
+
+## Success Metrics
+
+The Opportunity Track is measured at two horizons.
+
+**Leading indicators (weeks/months):**
+- Compass written, tested, and stable across two checkpoints.
+- Brand thesis shippable in a sentence.
+- Target ecosystem stable and sized appropriately.
+- Network coverage gaps named and addressed by content/events.
+- Cadence held: published content, attended events, relationship touches.
+- Reciprocity ledger balanced (gives ≥ asks).
+
+**Lagging indicators (quarters/year):**
+- Inbound opportunities arriving — count, source, quality.
+- Inbound aligned with compass (not just prestigious).
+- Conversion rate from conversation → opportunity → formal process.
+- Time-to-aligned-opportunity vs. baseline (cold application path).
+- Network durability — Tier 1 contacts maintained without active prompting.
+
+The lagging indicators are what the system actually optimizes. Leading indicators are tactics.

--- a/releases/v4.md
+++ b/releases/v4.md
@@ -1,0 +1,197 @@
+# v4: Opportunity Track
+
+**Released May 2026**
+
+v1-v3 built the strongest system on the market for coaching the visible job search — applications, interviews, follow-ups, negotiation. Every surface where a candidate touches the market today, optimized.
+
+v4 is the counter-move.
+
+The premise is uncomfortable: the strongest careers are not built through the visible job search. They are built so that opportunity arrives because the right people know the right things about you. The aspirational user has never sent a resume to a stranger. Every meaningful opportunity in their career came through a deliberately built network and a deliberately cultivated brand. That is teachable as a system — not as luck, not as charisma. It is what v4 is.
+
+12 new commands. 35 total. A second track, fully integrated with the first.
+
+---
+
+## What's New
+
+### Two Tracks, One System
+
+The skill now operates in two integrated tracks:
+
+- **Interview Track** — the v1-v3 system. Unchanged in behavior. Same commands, same scoring, same lifecycle.
+- **Opportunity Track** — the new v4 system. Five stages: Discover, Position, Distribute, Activate, Convert.
+
+The tracks share `coaching_state.md`. They share rigor standards. They compose: a strong Opportunity Track produces aligned interview pipelines, which the Interview Track then converts. Cross-track handoffs are explicit — when the Opportunity Track surfaces a real opportunity that reaches "formal process," it creates an Interview Loop and hands off cleanly.
+
+### `compass` — What You Actually Want
+
+Most career searches optimize the search before defining what's being searched for. The result: candidates get pulled toward the loudest opportunities, not the right ones.
+
+Compass forces a definition specific enough that you could recognize an aligned opportunity in the wild and refuse a misaligned one. Three sessions:
+
+1. **Work shape and anti-criteria draft.** Specificity over abstraction. Anti-criteria (what you would refuse) over preferences.
+2. **Past-data testing.** For every value you claim, when did it last cost you something? Untested values are hypotheses, not values.
+3. **The aligned-opportunity sentence test.** A single sentence an opportunity must satisfy to count. Plus per-component confidence calibration.
+
+A compass at "low confidence" is fine — it means the next step is to test (via projects), not to position.
+
+### `targets` — The Spear, Not the Net
+
+Translates your compass into a concrete target ecosystem: tiered companies (Tier 1 core fit, Tier 2 adjacent, Tier 3 stretch, Tier 4 watch-only — capped at ~10 each), communities and scenes (where the people doing the work you want actually congregate), a single-sentence segment statement (Phyl Terry's "spear, not a net"), and explicit anti-targets.
+
+If you bring a 200-company list, the system forces pruning. Beyond ~20 active targets the list stops being a strategy and becomes avoidance.
+
+### `mapping` — Your Real Network
+
+Most people who say "I don't have a network" do, and don't see it. Mapping walks you through every source — phone contacts, recent calendar, sent email, LinkedIn, Slack, past colleagues, alumni, reverse-warm contacts — and tiers them honestly:
+
+- **Tier 1**: would take your call today.
+- **Tier 2**: real history, no recent contact, re-warmable.
+- **Tier 3**: connected but cold, reachable mostly via someone else.
+
+LinkedIn connection counts mean nothing here. The map is what's real.
+
+Then it cross-references your network against your target ecosystem to surface coverage gaps — segments where you have no Tier 1/2 contacts. You can't network into a room you have no path into; you have to be invited via something you've published, shipped, or shown up to. Coverage gaps become the input to brand and content strategy.
+
+### `brand` — Strategy, Not Pitch
+
+`pitch` (v3) builds a positioning *statement* — what you say in conversation. `brand` (v4) builds a positioning *strategy* — what you want to be known for over months and years, to whom, through which channels, with what defensible POV.
+
+Outputs:
+- **Brand thesis** — narrow enough that 5-10 specific people in your target ecosystem would think of you when the situation arises.
+- **Defensible POV** — beliefs at least 30% of peers would disagree with, with real reasons for holding them.
+- **Audience** — at the intersection of compass, target ecosystem, and authentic interest.
+- **Channel strategy** — primary, secondary, tertiary. Three is the maximum.
+- **Cadence commitment** — the floor you'll hold for 90 days. Sustainable, specific, auditable.
+- **Anti-brand** — what you refuse to say or do. The integrity test.
+
+A brand without a defensible POV is a job title. A brand without an anti-brand has no edges.
+
+### `content` — Distribution as Discipline
+
+Three modes:
+
+- **`plan`**: 90-day content calendar built from brand thesis, storybank earned secrets, and defensible POVs. First piece outlined.
+- **`coach [piece]`**: Coaches a specific draft against an 8-dimension quality rubric (thesis tie, earned-secret content, voice authenticity, hook strength, specificity, defensible stance, channel fit, anti-brand check). Annotates, doesn't rewrite. The voice is the asset.
+- **`audit`**: Reviews the published log against brand success signals. Surfaces what's pulling target audience and what's noise.
+
+Anti-pattern enforcement is strict: no ghostwriting, no LLM-laundering, no reach chasing at the expense of POV. A 100-impression post that produces 3 inbound DMs from target audience beats a 100k-impression post that produces 0.
+
+### `events` — Showing Up, On Purpose
+
+Four modes — `plan`, `prepare`, `at-event`, `debrief` — that turn events from networking-for-its-own-sake into a relationship pipeline input.
+
+Pre-event: one specific goal, 3-5 people identified in advance, one current thing to talk about tied to your brand thesis. Post-event: 48-hour follow-up rule, capture conversations to Relationship Pipeline, debrief whether the goal was met.
+
+The hard test: a 50-person curated dinner with target audience often outperforms a 5,000-person conference. Density matters more than size.
+
+### `relationships` — The Lightweight CRM
+
+Your network compounds or decays based on cadence and reciprocity. `relationships` makes both explicit.
+
+- **`cadence`**: Per-Tier-1 cadence, give-before-ask ratio target ≥3:1.
+- **`give`**: Plan gives for the next 30 days. Generic likes don't count.
+- **`rewarm [name]`**: Non-extractive openers for Tier 2 contacts who've gone cold.
+- **`touch [name]`**: Coach a specific outreach today.
+- **`audit`**: Reciprocity ledger review. Where are you out of balance?
+
+Anti-pattern detection is strict: no audit-and-extract, no fake CRM, no re-warm with embedded ask. The relationships are the asset, not the conversion.
+
+### `projects` — Proof of Work
+
+Projects in v4 are not portfolio padding. They are deliberate artifacts with falsifiable hypotheses.
+
+Every project must:
+1. Reinforce the brand thesis.
+2. Be publicly findable by the target audience.
+3. Have a falsifiable hypothesis: "If I ship this, I expect [target audience] to react with [specific reaction]. If not, I'll learn [X about my brand thesis]."
+4. Produce a story for the Storybank.
+
+The system cuts scope aggressively. A worse v1 shipped beats a better v2 imagined. Perpetual projects get named — they're usually proof of avoidance, not proof of work.
+
+### `opportunities` — Inbound Funnel Hygiene
+
+When the system works, opportunities arrive — sometimes faster than expected. Two failure modes follow: saying yes to flattering misalignments, and ghosting good fits.
+
+`opportunities` makes the funnel explicit. Every inbound logs (even ones immediately declined — pattern data). Every inbound scores against the compass. Stage transitions are intentional. Pattern audits run every 5-10 inbounds: where is alignment coming from, what's pulling, what's not?
+
+When stage reaches "formal process," the system creates an Interview Loop and hands off to the Interview Track.
+
+### `intro` — Warm Intro Choreography
+
+Warm introductions convert 3-5x better than cold. Bad warm intros burn the introducer's social capital and don't get repeated.
+
+The full choreography is enforced:
+- The private ask of the introducer (with off-ramp, no pressure framing).
+- Double opt-in protocol (introducer asks the target privately first; only after both yes does the forwardable go out).
+- The forwardable email — ≤150 words, self-contained context, specific bounded ask, clear out for the target.
+- Post-intro reciprocity — every intro received logs an obligation paid forward.
+
+No chained asks. No ambush forwardables. No ghosting after the intro lands.
+
+### `convert` — Conversation to Opportunity
+
+A coffee chat is not an opportunity. The conversion happens in the bridge between conversation and concrete next step.
+
+Four bridges, picked situationally:
+1. **Collaboration test.** Offer to do a small piece of work together.
+2. **Follow-up artifact.** Send something within 48 hours that the conversation prompted.
+3. **Named ask.** Specific and small enough to say yes to. "Would you be open to flagging the X role to whoever's running that hiring process if I sent you a one-pager?" beats "any leads?"
+4. **Graceful pass.** End cleanly when alignment isn't there.
+
+Anti-patterns: the surprise pivot (hidden ask revealed at the end), the vague follow-up, premature ask, the conversation marathon.
+
+### `bootcamp` — The Multi-Week Orchestrator
+
+The capstone command. Runs the full Opportunity → Interview lifecycle as a structured 8-12 week program with weekly cadence and five checkpoints between stages:
+
+| Checkpoint | After Stage | Pass criteria |
+|---|---|---|
+| **Compass Lock** | 1 | Aligned-opportunity sentence with confidence ≥ Medium |
+| **Position Lock** | 2 | Brand thesis + LinkedIn aligned |
+| **Distribution Active** | 3 | 3+ pieces published or 1 project shipped, cadence held 4+ weeks |
+| **Network Live** | 4 | Tier 1 mapped, cadence set, 5+ gives logged, gaps named |
+| **Conversion Ready** | 5 | First inbound logged, conversion bridges practiced |
+
+Four tracks: Brand-First (default, 12 weeks), Network-First (8-10 weeks), Project-First (10-12 weeks), Hybrid. Pick at start. Don't switch mid-program without naming the reason.
+
+Bootcamp does not duplicate other commands. It sequences them, sets weekly commitments, runs checkpoints, and tracks outcomes. Modes: `start`, `plan`, `audit`, `checkpoint`, `pause`, `resume`, `end`.
+
+### Cross-Track Integration
+
+Every cross-track handoff is explicit:
+
+- `opportunities` reaches "formal process" → creates Interview Loop, hands off to `decode`/`prep`.
+- `convert` produces a job conversation → creates or updates Interview Loop.
+- `projects` ships → seeds Storybank with at least one earned-secret-bearing story (feeds `stories`, `pitch`, `resume`, `linkedin`).
+- Interview Track outcomes → can refresh compass and brand thesis (rejections from misaligned opportunities are signal that compass or targets need revision).
+
+### State Schema Extensions
+
+Twelve new sections in `coaching_state.md`: Compass, Target Ecosystem, Network Map, Brand Strategy, Content Calendar, Events, Relationship Pipeline, Projects (Proof of Work), Inbound Opportunity Funnel, Intro Tracker, Conversion Log, Bootcamp State.
+
+Migration is silent and backward-compatible. Existing v1-v3 state files upgrade cleanly — missing sections are added with empty fields and a single Coaching Notes entry pointing at `compass`.
+
+### ai-native Integration Notes
+
+`references/integrations/ai-native.md` outlines three integration paths for [jazzmind/ai-native](https://github.com/jazzmind/ai-native): additive Career advisor, loose integration via Chief of Staff, or full bridge. Adapter surfaces are defined for state sync, command routing, memory translation, and mode mapping. Default recommendation: loose integration first. The skill remains independently usable.
+
+---
+
+## Why This Matters
+
+The job market measures what's visible: applications submitted, interviews held, offers received. The strongest careers don't run on those metrics. They run on a network and a brand that produce aligned opportunities continuously, with the visible search shrinking to the few interviews that come from meaningful pre-existing connection.
+
+v1-v3 built the best coaching engine for the visible job search. v4 builds the system that, run well, makes most of that visible search unnecessary.
+
+That's a multi-month, multi-quarter claim. v4 is built for that timescale. Bootcamp's success metrics include 12-month indicators — network durability, inbound alignment rate, time-to-aligned-opportunity vs. cold-application baseline. The leading indicators (cadence held, pieces published, intros made) are tactics; the lagging indicators are what the system actually optimizes.
+
+The system isn't for everyone. A candidate with a 4-week interview deadline should run the Interview Track and come back to v4 after they're stable. A candidate willing to invest 5-10 hours/week for 8-12 weeks gets a system that compounds for years.
+
+---
+
+## What's Next
+
+v5: Interaction model — voice mode, session replay, lightweight companion UI, calendar awareness, collaborative storybank. v6: Platform — full web app, marketplace, team mode, anonymized intelligence network.
+
+But the real risk is dilution. v4 nearly doubles the command surface. The next stretch is about discipline: keeping the two-track model coherent, making sure users know which track they're in, and proving that brand-and-network-led careers can be coached as a system, not as case studies.


### PR DESCRIPTION
…erview Track

Adds 12 new commands across 5 stages (Discover, Position, Distribute, Activate, Convert) plus a multi-week `bootcamp` orchestrator. Built on the premise that the strongest careers come from brand and network, not cold applications.

New commands: compass, targets, mapping, brand, content, events, relationships, projects, opportunities, intro, convert, bootcamp.

New references:
- references/opportunity-system.md (philosophy, anti-patterns, cross-command deps)
- references/bootcamp.md (program manual: tracks, checkpoints, success metrics)
- references/integrations/ai-native.md (integration plan for jazzmind/ai-native)
- references/commands/{12 new files}

SKILL.md updates: description, command registry, file routing, mode detection (12 new triggers), multi-step intent table (6 new sequences), coaching_state.md schema (12 new sections), schema migration rule, state update triggers.

Cross-track handoffs explicit:
- opportunities → Interview Loop on "formal process"
- convert (job conversation) → Interview Loop
- projects ship → Storybank seed

Backward compatible: existing v1-v3 state files upgrade silently.

Docs updated: README two-track framing + Opportunity Track tables, VERSIONS.md v4 entry (renumbered v5/v6), releases/v4.md.