### PR TITLE
feat: add technical flashcard reference files for satellite/EO interview prep

### DIFF
--- a/flashcards_ai_ml_edge.md
+++ b/flashcards_ai_ml_edge.md
@@ -1,0 +1,281 @@
+# Flashcards: AI/ML, Edge Processing & EO Data Pipelines
+
+Planet-calibrated technical reference for interview prep.
+
+---
+
+## ML/AI Fundamentals (PM-Level)
+
+**Machine Learning taxonomy:**
+
+| Type | What it does | EO example |
+|------|-------------|------------|
+| **Supervised learning** | Learns from labeled examples | Ship detection (trained on labeled ship/not-ship images) |
+| **Unsupervised learning** | Finds patterns without labels | Anomaly detection in time-series imagery |
+| **Self-supervised / Foundation models** | Learns representations from unlabeled data, then fine-tunes | Planet's "Foundation Models for the Real World" pillar |
+| **Reinforcement learning** | Learns by trial and reward | Constellation scheduling optimization, TALOS agents |
+
+**Deep learning vs. traditional ML:**
+Deep learning = neural networks with many layers. Dominant for computer vision (which is what EO AI mostly is). Traditional ML (random forests, SVMs) still used for tabular data, time-series, and cases with limited training data.
+
+---
+
+## Computer Vision for EO
+
+**Core tasks:**
+
+| Task | What it does | Planet product example |
+|------|-------------|----------------------|
+| **Classification** | "What is this?" — assigns a label to an image or pixel | Land use classification (urban, forest, water, agriculture) |
+| **Object detection** | "What's here and where?" — draws bounding boxes | Ship detection, aircraft detection, vehicle detection |
+| **Semantic segmentation** | "Label every pixel" — pixel-level classification | Road mapping, building footprints, field boundaries |
+| **Instance segmentation** | "Label every pixel AND distinguish individual objects" | Counting individual ships in a harbor |
+| **Change detection** | "What changed between two images?" — temporal comparison | Construction monitoring, deforestation, military buildup |
+| **Object tracking** | "Same object across multiple images/time" | Vessel tracking across multiple passes |
+
+**Planet's AI products map to these:**
+- Global Monitoring Solutions (GMS): change detection + object detection
+- Maritime Domain Awareness (MDA): vessel detection + tracking + classification
+- Road & Building Change Detection: semantic segmentation + change detection
+- Area Monitoring / I&W: broad-area change detection → tip-and-cue
+
+---
+
+## Training, Inference & the Edge
+
+**Training vs. Inference:**
+
+| | Training | Inference |
+|---|---------|-----------|
+| What | Teaching the model — adjusting weights from data | Running the trained model on new data |
+| Compute | Massive (GPU clusters, days/weeks) | Modest (single GPU, seconds/milliseconds) |
+| Where | Always on ground (cloud GPU clusters) | Ground OR on orbit (edge) |
+| Data | Large labeled dataset | Single new image |
+| Frequency | Periodic (retrain monthly/quarterly) | Continuous (every new image) |
+
+**Why inference works on orbit but training doesn't:**
+Training requires backpropagation across millions of parameters with large batch sizes — needs hundreds of watts and terabytes of training data. Inference is a forward pass through a fixed model — Jetson Orin can do this at 15–60W. Planet trains on ground, deploys trained models to orbit via Docker containers.
+
+**Quantization:**
+Reducing model numerical precision to run faster on edge hardware.
+- FP32 (full precision): training standard, most accurate
+- FP16 (half precision): 2x faster, minimal accuracy loss
+- INT8 (8-bit integer): 4x faster than FP32, ~1-3% accuracy loss typical
+- INT4 (4-bit): 8x faster, more accuracy loss, emerging
+
+**TensorRT:** NVIDIA's inference optimizer. Takes a trained PyTorch/TensorFlow model and optimizes it for specific Jetson hardware — fuses layers, selects optimal precision, optimizes memory. This is how you get a model that runs on ground GPUs to fit in a 15W power envelope on orbit.
+
+**Why quantization matters for a PM:**
+It's the accuracy-latency-power tradeoff knob. A PM defines the requirement: "95% detection accuracy within 30 seconds at 15W." The ML engineer uses quantization to hit that target. If the requirement is too aggressive, the PM needs to know that relaxing accuracy from 99% to 95% might cut power consumption in half.
+
+---
+
+## Data Pipeline Architecture
+
+**Planet's full pipeline (TC-PED framework):**
+
+```
+Tasking → Collection → Processing → Exploitation → Dissemination
+   |          |            |              |              |
+   |          |            |              |              |
+API/mission  Satellite    Radiometric    AI/ML models   Insights
+planner +    physics:     calibration,   (detection,    Platform
+scheduler    slew,settle, atmospheric    classification, APIs,
+             capture      correction,    change detect)  alerts,
+                          ortho,                        dashboards
+                          pansharp,
+                          cloud mask
+                          → ARD
+```
+
+**Where edge AI inserts:**
+Between Collection and traditional Processing. On orbit, after capture, the satellite runs inference on raw imagery and produces structured detections alongside (or instead of) full imagery downlink.
+
+**Planet's three AI pillars:**
+1. **AI-Enabled Solutions** (present): GMS, MDA, change detection — ground-based ML on Planet data
+2. **GPUs in Space** (near-term): Pelican Jetson Orin, onboard inference, "Planetary Intelligence"
+3. **Foundation Models for the Real World** (longer bet): large models trained on Planet's 3,000+ images-per-point archive
+
+**The archive as training data moat:**
+Planet has 3,000+ images of every point on Earth's landmass. No competitor can replicate this without another decade of operations. This archive is the training dataset for foundation models — temporal patterns (seasonality, construction progress, vegetation cycles) that single-snapshot competitors can't learn.
+
+---
+
+## Optical Imagery Processing
+
+**How a satellite camera works (simplified):**
+Pushbroom sensor: a linear array of detectors sweeps across the ground as the satellite moves. Each detector captures one line of pixels. The satellite's forward motion builds up the 2D image line by line.
+
+**Panchromatic vs. Multispectral:**
+- **Panchromatic (PAN)**: Single broad-wavelength band, highest spatial resolution (Pelican: 30cm). Grayscale.
+- **Multispectral (MS)**: Multiple narrow bands (e.g., Red, Green, Blue, NIR), lower spatial resolution (Pelican: 6 MS bands). Color and vegetation analysis.
+- **Pansharpening**: Fusing PAN (high-res grayscale) with MS (lower-res color) to produce high-res color imagery. Computationally intensive — currently done on ground.
+
+**Key spectral bands and what they reveal:**
+
+| Band | Wavelength | What it shows |
+|------|-----------|---------------|
+| Blue | 450–520 nm | Water penetration, atmospheric scattering |
+| Green | 520–600 nm | Vegetation vigor, turbidity |
+| Red | 630–690 nm | Vegetation stress, soil |
+| Red Edge | 690–730 nm | Vegetation health transition zone — sensitive indicator |
+| NIR | 770–895 nm | Vegetation biomass, water boundaries (strong contrast) |
+| SWIR | 1.5–2.5 µm | Mineral identification, fire detection, moisture |
+
+**NDVI (Normalized Difference Vegetation Index):**
+(NIR - Red) / (NIR + Red). Simple ratio that measures vegetation health. Ranges from -1 to +1. Healthy vegetation: 0.6–0.9. Bare soil: 0.1–0.2. Water: negative. This is the canonical "derived product" — raw bands → actionable metric.
+
+---
+
+## Hyperspectral Processing
+
+**What's different from multispectral:**
+- Multispectral: 4–12 broad bands
+- Hyperspectral: 100–400+ narrow contiguous bands across the full spectrum
+- Think: multispectral is seeing in a few colors, hyperspectral is seeing the full rainbow with no gaps
+
+**Planet's Tanager satellite:** ~400 bands, 30m resolution. Built for methane detection (Carbon Mapper partnership). 5,500+ methane detections in two weeks of October 2024.
+
+**How methane detection works:**
+Methane absorbs specific SWIR wavelengths (~1.65 µm and ~2.3 µm). Hyperspectral sensor measures absorption depth at those wavelengths — deeper absorption = more methane. Algorithms subtract background atmosphere to isolate point-source plumes.
+
+**Spectral unmixing:**
+Each pixel contains a mix of materials (soil + vegetation + concrete). Hyperspectral analysis "unmixes" the spectrum to estimate the proportion of each material within a single pixel. This is how you detect materials at sub-pixel scale — you don't need to resolve individual objects, just their spectral signature.
+
+**PM relevance:**
+Hyperspectral generates 10–100x more data per scene than multispectral. The processing pipeline is more complex (atmospheric correction is harder with 400 bands). Edge processing for hyperspectral is a future challenge — too much data for current onboard compute. Product decision: do you downlink all 400 bands, or process to derived products (methane concentration map) on ground and deliver only the result?
+
+---
+
+## AI Model Lifecycle (What a PM Manages)
+
+**1. Data collection and labeling:**
+- Labeled training data is the bottleneck, not model architecture
+- For EO: human analysts draw bounding boxes around ships, buildings, vehicles in satellite images
+- Active learning: model identifies uncertain predictions → human labels those first → most efficient use of labeling budget
+- Planet's archive advantage: pre-existing labeled datasets from years of analyst work
+
+**2. Model training:**
+- GPU clusters on ground (AWS, GCP, or on-prem)
+- Weeks of compute for large models
+- Hyperparameter tuning, architecture selection
+- Validation on held-out test set
+
+**3. Model evaluation:**
+- **Precision**: of everything the model flagged as a ship, what % actually were ships? High precision = few false positives.
+- **Recall**: of all actual ships in the image, what % did the model find? High recall = few missed detections.
+- **F1 score**: harmonic mean of precision and recall. Single metric balancing both.
+- **mAP** (mean Average Precision): standard object detection metric across confidence thresholds.
+- **Confusion matrix**: grid showing true positives, false positives, true negatives, false negatives.
+
+**Precision vs. recall tradeoff (critical for PM):**
+You can't maximize both. The PM decides which matters more based on use case:
+
+| Use case | Bias toward | Why |
+|----------|------------|-----|
+| Maritime Domain Awareness | Recall | Missing a ship is worse than a false alarm. Analysts can dismiss false positives. |
+| Emergency response | Balanced (slight precision) | False positive = expensive mobilization. But missing a real event is catastrophic. |
+| D&I threat detection | Recall | Miss nothing. Sub-second alerts. Analysts triage false positives. |
+| Supply chain monitoring | Precision | Throughput matters. Too many false positives overwhelm the pipeline. |
+| Methane detection | Precision | False methane reports damage credibility with regulators and carbon markets. |
+
+**Pelican-4 reported 80% detection accuracy** — Planet explicitly acknowledged "work is underway to improve model precision and recall." At 80%, roughly 1 in 5 detections is wrong or missed. A PM's job: define what accuracy threshold is required for each customer segment before the product is viable.
+
+**4. Model deployment:**
+- On ground: standard CI/CD, containerized inference service
+- On orbit (Planet's edge): Docker container pushed to satellite, loaded on Jetson Orin
+- Model versioning: multiple models can coexist, operator selects which to run
+- A/B testing on orbit: run two models on same imagery, compare results on ground
+
+**5. Model monitoring and retraining:**
+- Model drift: the world changes (new ship types, new building styles, seasonal changes) — model accuracy degrades over time
+- Feedback loop: ground truth from analysts feeds back into training data → retrain → redeploy
+- For Planet: the 3,000+ image archive means temporal drift is detectable — you can measure whether last year's model still works on this year's data
+
+---
+
+## Edge AI Decision Framework
+
+**When to process on orbit vs. on ground:**
+
+| Factor | Process on orbit | Process on ground |
+|--------|-----------------|-------------------|
+| Latency requirement | Minutes or less | Hours acceptable |
+| Bandwidth available | Limited (can't downlink everything) | Sufficient ground stations |
+| Model complexity | Simple detection/classification | Complex multi-stage pipelines |
+| Accuracy requirement | 80–95% acceptable with analyst review | 99%+ required |
+| Customer trust threshold | Will act on automated alert | Needs analyst-confirmed imagery |
+| Power budget | Can duty cycle GPU | N/A |
+| Model update frequency | Monthly or less | Continuous retraining |
+
+**Decision velocity framework (from your prep):**
+The real constraint isn't accuracy — it's whether the customer trusts the result enough to act without human review.
+- 95% accurate real-time alert that arrives in minutes > 99% accurate report that arrives in hours
+- Trust threshold varies by customer, mission, and consequence of false positive/negative
+- OODA loop: edge AI compresses the Observe phase. Customer gets "threat at X,Y,Z" instead of raw pixels.
+
+---
+
+## Classification & Labeling
+
+**Taxonomy of classification in EO:**
+
+| Level | What | Example |
+|-------|------|---------|
+| Scene-level | What type of scene is this? | Urban, rural, coastal, desert |
+| Object-level | What objects are present? | Ships, aircraft, vehicles, buildings |
+| Object attribute | Properties of detected objects | Ship type (cargo, tanker, military), ship length, heading |
+| Activity-level | What's happening? | Construction in progress, convoy movement, port loading |
+| Change-level | What's different from before? | New building, road extension, forest clearing |
+
+**Labeling approaches:**
+
+| Method | Speed | Cost | Quality |
+|--------|-------|------|---------|
+| Manual (human analyst) | Slow | High | Highest |
+| Semi-automated (model suggests, human corrects) | Medium | Medium | High |
+| Active learning (model requests labels for uncertain cases) | Fast | Lower | High where it matters |
+| Weak supervision (programmatic rules generate noisy labels) | Very fast | Low | Lower (noisy) |
+| Self-supervised pretraining | N/A | Low | Learns representations, not labels |
+
+**Planet's advantage:** Years of analyst-labeled data from government and commercial customers. Bedrock Research brings additional labeled D&I datasets. The archive + labels = training data moat that's nearly impossible to replicate.
+
+---
+
+## Foundation Models for EO
+
+**What's different about EO foundation models:**
+Standard vision models (ImageNet, CLIP) are trained on natural photos — perspective view, RGB, variable lighting. Satellite imagery is fundamentally different:
+- Nadir (top-down) view
+- Multispectral bands (not just RGB)
+- Temporal dimension (same location over time)
+- Consistent scale (known GSD)
+- Global coverage (not curated scenes)
+
+**Why Planet is well-positioned:**
+A foundation model for EO needs massive temporal+spatial coverage for pretraining. Planet's daily global archive is the largest such dataset. "Foundation Models for the Real World" is their third AI pillar — longer bet but potentially the most defensible.
+
+**How it works:**
+Self-supervised pretraining on unlabeled imagery (predict masked patches, predict next timestep, contrastive learning across bands) → produces a general-purpose visual representation → fine-tune on specific tasks (ship detection, change detection) with much less labeled data than training from scratch.
+
+---
+
+## Quick Quiz (Self-Test)
+
+1. A defense customer wants onboard ship detection with zero missed detections. What do you tell them?
+   → Zero missed detections = 100% recall, which is impossible without also accepting many false positives. Frame the conversation around acceptable false positive rate and analyst triage workflow. "The model can be tuned for very high recall — say 99% — but that means roughly X false positives per Y images. Your analysts would need to triage those. Is that workflow acceptable?"
+
+2. Why does Planet use Docker containers for on-orbit AI?
+   → Same DevOps abstractions as ground software. Deploy new models like a software update. Isolate workloads. No need to reflash firmware. Enables rapid model iteration — critical when Bedrock Research is improving detection models monthly.
+
+3. What's the difference between pansharpening and multispectral analysis?
+   → Pansharpening fuses high-res grayscale (PAN) with lower-res color (MS) to get high-res color. Multispectral analysis uses the individual bands for science (vegetation health via NDVI, water detection via NIR, etc.). Different purposes — one is visual, one is analytical.
+
+4. Why is 80% detection accuracy on Pelican-4 a starting point, not a failure?
+   → First on-orbit demonstration of full inference pipeline. 80% proves the architecture works (Docker containers, Jetson Orin, geo-rectification on orbit). Accuracy improves with model iteration — that's why they chose GPU over FPGA (easy model updates). The product question is: at what accuracy threshold does each customer segment trust it enough to act?
+
+5. Why can't you just train a bigger model to improve accuracy on orbit?
+   → Bigger model = more compute = more power = more thermal. Jetson Orin at 60W is already a significant fraction of a smallsat's power budget. You optimize with quantization (INT8/INT4), model distillation (train a small model to mimic a large one), and architecture efficiency — not brute force. The PM defines the accuracy-power tradeoff requirement.
+
+6. What gives Planet's AI a moat that BlackSky or Satellogic can't easily replicate?
+   → The archive. 3,000+ images of every point on Earth's landmass over 10+ years. Temporal depth enables time-series models (change detection, seasonal patterns, activity baselines) that single-snapshot competitors can't train. Bedrock Research + archive = vertically integrated AI pipeline.

--- a/flashcards_rf_comms.md
+++ b/flashcards_rf_comms.md
@@ -1,0 +1,188 @@
+# Flashcards: RF, Comms, Latency, Bandwidth & Downlink Architecture
+
+Planet-calibrated technical reference for interview prep.
+
+---
+
+## RF Fundamentals
+
+**What is RF in satellite context?**
+Radio Frequency — the electromagnetic spectrum used for all satellite-ground and satellite-satellite communication. Satellites use specific frequency bands allocated by ITU.
+
+**Key frequency bands for EO satellites:**
+
+| Band | Frequency | Typical Use | Tradeoff |
+|------|-----------|-------------|----------|
+| S-band | 2–4 GHz | TT&C (telemetry, tracking, command) | Low data rate, robust, works in rain |
+| X-band | 8–12 GHz | Traditional imagery downlink | Moderate data rate, moderate rain fade |
+| Ka-band | 26–40 GHz | High-throughput imagery downlink | High data rate, significant rain fade |
+| Ku-band | 12–18 GHz | Broadcast, some downlink | Middle ground |
+| V-band | 40–75 GHz | Emerging, next-gen high throughput | Very high rate, severe atmospheric absorption |
+
+**Planet uses Ka-band for Pelican downlink.** Peak rate: ~10 Gbps. Each Pelican can downlink 1–2 TB/day. AES-256 encryption on all TT&C and imagery data.
+
+**Rain fade:** Higher frequencies (Ka, V) are absorbed by water. Ka-band links lose 5–10 dB in heavy rain. This is why ground station diversity matters — if one station is in rain, route to another.
+
+---
+
+## Downlink Architecture
+
+**What determines how fast you can get data to the ground?**
+Three constraints: (1) link budget (power, antenna gain, frequency, distance), (2) contact time (how long the satellite is in view of a ground station per orbit), (3) ground station network density.
+
+**Contact time math:**
+A LEO satellite at ~475 km (Pelican orbit) has roughly 5–10 minute passes over a ground station. At 10 Gbps, a 7-minute pass = ~525 GB downlinked. That's significant but not unlimited — you can't downlink everything you collect.
+
+**Ground station network:**
+Planet operates 48 ground stations across 11 countries. 8 Ka-band stations specifically for Pelican (phased deployment). More stations = more contact opportunities per orbit = lower latency to get data down.
+
+**Latency budget breakdown (tasking to delivery):**
+
+| Segment | Time | What's happening |
+|---------|------|------------------|
+| Tasking command uplink | Seconds–minutes | Command reaches satellite via ground station or ISL relay |
+| Slew and settle | 10–60 seconds | Satellite points camera at target |
+| Image capture | Seconds | Exposure and readout |
+| Onboard processing (if any) | Seconds–minutes | Cloud mask, detection, compression |
+| Wait for ground station | 0–90 minutes | Orbital geometry — biggest variable |
+| Downlink | Minutes | Transfer at Ka-band rate |
+| Ground processing | Minutes–hours | Radiometric cal, ortho, pansharpening |
+| Delivery to customer | Seconds | API/platform push |
+
+**Planet's Pelican target: 2–4 hour tasking-to-delivery latency.** The biggest lever to compress this is inter-satellite links (skip waiting for a ground station) and onboard processing (skip ground processing).
+
+**Store-and-forward vs. real-time downlink:**
+Most EO satellites store imagery onboard and dump it when over a ground station. Real-time continuous downlink requires either geostationary relay satellites or dense LEO relay networks. Planet is working toward relay via ISLs.
+
+---
+
+## Inter-Satellite Links (ISLs)
+
+**What are ISLs?**
+Communication links between satellites — data hops from one satellite to another until it reaches one with a ground station in view. Eliminates the "wait for ground station" latency.
+
+**RF ISLs vs. Optical ISLs:**
+
+| | RF ISL | Optical ISL (Laser) |
+|---|--------|-------------------|
+| Data rate | 100s Mbps – low Gbps | 1–100+ Gbps |
+| Range | 1,000–5,000 km typical | Up to 5,000+ km (LEO-LEO) |
+| Pointing | Easier (wider beam) | Hard (sub-microradian pointing) |
+| Size/weight | Moderate | Smaller terminal |
+| Interference | Subject to RF spectrum congestion | No RF interference |
+| Atmosphere | N/A (space-to-space) | N/A (space-to-space) |
+
+**Pelican uses RF ISLs (C-band and Ka-band).** Pelican-2 conducted Planet's first on-orbit satellite-to-satellite comms tests. This enables tasking and data relay when a satellite isn't directly over a ground station.
+
+**Why Planet chose RF ISLs over laser (for now):**
+RF ISLs are simpler to implement — wider beamwidth means easier acquisition and tracking. For Planet's use case (reducing latency, not maximizing throughput between relay nodes), RF ISLs are sufficient. Laser ISLs are the future but add cost, complexity, and pointing requirements.
+
+---
+
+## Laser Communications (Optical)
+
+**How laser comms work:**
+A laser terminal on the satellite transmits a tightly focused infrared beam (typically 1550 nm or 1064 nm) to a receiver. Same physics as fiber optic, but through free space.
+
+**Key advantages:**
+- 10–100x higher data rates than RF at same power
+- No spectrum licensing needed (light isn't regulated like RF)
+- Extremely narrow beam = hard to intercept (security advantage for defense)
+- Smaller, lighter terminals than equivalent RF
+
+**Key challenges:**
+- Sub-microradian pointing accuracy required (the beam is extremely narrow)
+- Acquisition and tracking is complex — two satellites must find each other's beam
+- Atmospheric turbulence affects space-to-ground links (not space-to-space)
+- Cloud cover blocks space-to-ground optical links entirely (unlike RF which penetrates clouds)
+
+**Free-Space Optical (FSO) communication:**
+The general term for laser comms through atmosphere or space. "Free space" = no fiber, no waveguide. Includes:
+- Space-to-space (ISLs): best case, no atmosphere
+- Space-to-ground: affected by turbulence, clouds, scintillation
+- Ground-to-ground: short range, weather-dependent
+
+**Current state of the market:**
+- Starlink Gen2 satellites have laser ISLs — mesh network in orbit
+- SpaceX has ~10,000+ laser terminals deployed
+- Vendors: Mynaric (Condor Mk3), Tesat (SCOT80), Honeywell/Ball OISL, CACI, SA Photonics
+- Typical LEO-LEO optical ISL: 1–10 Gbps, 5,000 km range
+
+**Planet-specific relevance:**
+Optical ISLs are the logical next step after RF ISLs for Pelican/Owl — higher throughput for relaying large imagery datasets. The Suncatcher program (Google TPU on-orbit) will likely need high-bandwidth ISLs to move processed results between nodes. Not deployed yet but on the technology roadmap.
+
+---
+
+## Bandwidth as the Bottleneck
+
+**Why bandwidth drives product decisions:**
+This is the core insight behind "ship insights, not pixels."
+
+**The math:**
+- Pelican 30cm image, 10x10 km scene = ~25 GB raw, ~6 GB compressed
+- Pelican collects up to 30 targets/day at mid-latitudes
+- Total daily collection capacity: potentially 150–180 GB compressed imagery
+- Downlink capacity: 1–2 TB/day (comfortable margin for imagery, tight if you add full-res video or hyperspectral)
+
+**If you process onboard:**
+- Raw scene: ~6 GB compressed
+- Detection-only output (GeoJSON bounding boxes): 10–500 KB
+- That's a 10,000–100,000x reduction in downlink requirement
+
+**Product implication:**
+Edge AI isn't just a latency play — it's an economics play. You can either build more ground stations and wider pipes, or you can be smarter about what you send down. The PM decision: which use cases justify full imagery downlink vs. detection-only alerts?
+
+---
+
+## Link Budget (Simplified)
+
+**What is a link budget?**
+The accounting of all gains and losses in a communication link — transmit power, antenna gains, path loss, atmospheric loss, receiver sensitivity. If the received signal is above the noise floor with sufficient margin, the link closes.
+
+**Key terms:**
+- **EIRP** (Effective Isotropic Radiated Power): transmit power + antenna gain. Higher = stronger signal.
+- **G/T** (Gain-to-noise Temperature): receiver figure of merit. Higher = more sensitive receiver.
+- **Path loss**: signal weakening over distance. Proportional to distance squared and frequency squared. Higher frequency = more loss.
+- **Link margin**: how much signal strength you have above the minimum. Typical targets: 3–6 dB margin for clear sky, more if you need rain fade tolerance.
+- **BER** (Bit Error Rate): acceptable error rate. Drives how much margin you need.
+
+**Why a PM cares about link budgets:**
+You don't calculate them — RF engineers do. But you need to understand the tradeoffs: higher data rate requires either more transmit power (consumes satellite power budget), larger antennas (costs mass/volume), or accepting less margin (riskier link). Every product decision about data throughput traces back to this physics.
+
+---
+
+## Latency Taxonomy
+
+**Processing latency categories (know these):**
+
+| Type | Definition | Planet example |
+|------|-----------|----------------|
+| Tasking latency | Command to satellite start collecting | Minutes (with ISL) to hours (wait for ground pass) |
+| Collection latency | Time to capture the image | Seconds |
+| Downlink latency | Getting data to ground | Minutes (in pass) to 90 min (waiting for next pass) |
+| Processing latency | Ground pipeline: raw → analysis-ready | Minutes to hours |
+| Exploitation latency | Raw/ARD → actionable insight | Minutes (AI) to days (human analyst) |
+| Dissemination latency | Insight → customer's system | Seconds (API push) |
+
+**Edge AI compresses exploitation latency AND downlink latency simultaneously.** That's why it's transformative — it attacks two segments at once.
+
+**"Hours to minutes" (Will Marshall's claim):** Refers to total tasking-to-insight. Pre-edge: task → wait for pass → downlink → ground process → analyze. Post-edge: task → capture → onboard detect → downlink alert. The wait-for-pass segment is still there unless ISLs are used, but the total chain compresses dramatically.
+
+---
+
+## Quick Quiz (Self-Test)
+
+1. Why does Planet use Ka-band for Pelican instead of X-band?
+   → Higher data rate (~10 Gbps vs ~1 Gbps). Worth the rain fade tradeoff because Planet has ground station diversity.
+
+2. What's the single biggest latency contributor in the current architecture?
+   → Waiting for a ground station pass (0–90 minutes). ISLs fix this.
+
+3. Why is "ship insights not pixels" an economic argument, not just a speed argument?
+   → Detection output is 10,000–100,000x smaller than raw imagery. Reduces downlink infrastructure cost and enables more targets per orbit.
+
+4. Why might a defense customer still want full imagery downlinked even if onboard AI detects something?
+   → Chain of custody / evidentiary standards. A GeoJSON bounding box isn't admissible intelligence — analysts need to see the pixels to confirm and classify. Trust threshold varies by customer.
+
+5. What's the security advantage of optical ISLs over RF ISLs?
+   → Extremely narrow beam is nearly impossible to intercept. No RF signature to detect. Important for defense/sovereign customers.

--- a/flashcards_satellite_systems.md
+++ b/flashcards_satellite_systems.md
@@ -1,0 +1,213 @@
+# Flashcards: Satellite Systems, Constellation Design & Power
+
+Planet-calibrated technical reference for interview prep.
+
+---
+
+## Satellite Architecture (Subsystems)
+
+Every satellite has the same core subsystems. Know what each does and the PM tradeoffs:
+
+| Subsystem | What it does | PM tradeoff |
+|-----------|-------------|-------------|
+| **Payload** | The mission instrument (camera, SAR, comms) | Resolution vs. mass vs. cost. Drives the bus design. |
+| **Bus** | Structural frame, power, thermal, attitude control | Modularity vs. optimization. Planet's common bus (Pelican/Tanager/Owl) is a strategic choice — platform leverage. |
+| **ADCS** (Attitude Determination & Control) | Points the satellite accurately | Agility (slew rate) vs. stability (settling time). Pelican's agility enables 30 tasks/day. |
+| **EPS** (Electrical Power System) | Solar panels, batteries, power distribution | Peak power budget constrains everything — payload, compute, comms, all compete. |
+| **TT&C** (Telemetry, Tracking & Command) | Ground communication for health/commands | Separate from payload data downlink. Usually S-band. |
+| **Thermal** | Heat management in vacuum | On-orbit compute generates heat that must be radiated. Suncatcher thesis: deep space = free heat sink. |
+| **Propulsion** | Orbit maintenance, collision avoidance | Fuel = finite lifetime. Station-keeping budget determines operational life. |
+| **OBC** (Onboard Computer) | Flight software, scheduling, autonomy | Traditional: radiation-hardened, slow. New: commercial GPUs (Jetson) for AI workloads alongside rad-hard flight computer. |
+
+**Planet's common smallsat bus:** Shared across Pelican, Tanager, Owl, and Suncatcher. This is a major strategic asset — new missions leverage existing design, manufacturing line, and ground software. The PM enforces the productization boundary: what customization is allowed per mission vs. what's standard bus.
+
+---
+
+## Power Budget
+
+**Why power matters for a PM:**
+Every watt is contested. Payload, compute, comms, ADCS, thermal, and propulsion all draw from the same solar panels and batteries. The PM's product decisions directly affect the power budget — adding onboard AI inference, increasing downlink rate, or adding ISL comms all cost power.
+
+**Solar power basics:**
+- Solar panels convert sunlight to electricity. LEO satellites get ~1,361 W/m2 of solar flux.
+- Typical LEO smallsat: 100–500W of solar panel capacity (Pelican-class likely 200–400W range)
+- Solar cells are ~30% efficient (triple-junction GaAs) → ~400 W/m2 actual power per panel area
+- Body-mounted panels are simpler but lower power. Deployable wings give more area but add mass and failure modes.
+
+**Batteries:**
+- Lithium-ion, same chemistry as your phone but space-qualified
+- Sized for eclipse — when the satellite is in Earth's shadow, batteries are the only power source
+- LEO orbit: ~90 minutes total, ~35 minutes in eclipse (roughly). That's 35 minutes on battery every orbit, 15+ times per day.
+- Battery depth of discharge (DoD): typically limit to 20–30% per cycle for longevity. Deeper discharge = fewer total cycles before degradation.
+- **Eclipse minimum SOC**: The floor battery charge you'll never go below. All power-hungry operations (inference, downlink) must be scheduled around this.
+
+**Peak power vs. average power:**
+- **Average power**: what the solar panels sustain over a full orbit (sun + eclipse). This is your budget for continuous operations.
+- **Peak power**: maximum draw at any instant. Batteries supplement solar for short bursts.
+- **Duty cycling**: You can run power-hungry hardware (GPU, transmitter) at peak power for limited windows, then idle. This is how Jetson Orin works on orbit — 15W idle, ramp to 60W MAXN during inference, then back down.
+
+**PM implication:** You can't run everything at once. Imaging, onboard processing, and downlink often can't happen simultaneously at full power. The scheduler decides: collect this pass, process next pass, downlink the pass after that. The product requirement ("real-time detection") becomes a power scheduling problem.
+
+---
+
+## Orbital Mechanics (PM-Level)
+
+**Orbit types relevant to EO:**
+
+| Orbit | Altitude | Period | Key Property | Example |
+|-------|----------|--------|-------------|---------|
+| LEO (Sun-Synchronous) | 400–700 km | ~90–98 min | Consistent lighting, revisit | Planet (all), Maxar, BlackSky |
+| MEO | 2,000–35,000 km | 2–12 hours | Wider coverage per pass | Navigation (GPS), some comms |
+| GEO | 35,786 km | 24 hours | Fixed position over equator | Weather sats, broadcast, relay |
+| HEO/Molniya | Varies (high apogee) | 12 hours | Long dwell at high latitudes | Russian comms, some ISR |
+
+**Sun-Synchronous Orbit (SSO):**
+The satellite crosses the equator at the same local solar time every orbit. This means consistent lighting conditions for imaging — critical for change detection (comparing images taken days apart under similar illumination). Pelican operates at ~475 km SSO.
+
+**Revisit rate:**
+How often a satellite can image the same point on Earth.
+- Single satellite: once every few days (depends on orbit, swath, agility)
+- Constellation: daily or better. Planet's SuperDove fleet images all landmass daily at 3–5m.
+- Pelican: up to 30 revisits/day at mid-latitudes (because of agility + multiple satellites + cross-track pointing)
+
+**Why latitude matters:**
+Orbital tracks converge at the poles — more passes over high latitudes than equatorial regions per day. This is Planet's structural advantage in the Arctic (more passes = more images = better monitoring of Russian Arctic bases, Northern Sea Route).
+
+**Slew and settle:**
+- **Slew**: rotating the satellite to point at a target. Rate measured in degrees/second.
+- **Settle**: waiting for vibrations to damp after slewing. Jitter during settle = blurry images.
+- **Agility**: how fast a satellite can slew to a new target. Pelican is "highly agile" — enabling multiple targets per pass. More agile = more tasks per orbit = more revenue per satellite.
+
+**Ground track and access windows:**
+The satellite traces a path over the ground (ground track). A target is "accessible" when it falls within the camera's field of regard during a pass. The scheduler optimizes which targets to image during each pass — a constrained optimization problem (finite slew time, power, memory, priority).
+
+---
+
+## Constellation Design
+
+**Why constellations, not single satellites?**
+- Coverage: daily global requires many satellites
+- Revisit: more satellites = more frequent revisit
+- Redundancy: one failure doesn't kill the mission
+- Capacity: more satellites = more total collection per day
+
+**Walker constellation:**
+A mathematical pattern for distributing satellites evenly. Defined by total satellites, number of orbital planes, and phasing between planes. Planet's SuperDove fleet is a near-Walker pattern.
+
+**Heterogeneous constellations (Planet's approach):**
+Not one fleet — multiple tiers optimized for different missions:
+- SuperDove: broad monitoring, daily, 3–5m (the "background layer")
+- Pelican: high-res tasking, agile, 30cm (the "on-demand layer")
+- Tanager: hyperspectral, specialized (methane detection)
+- Owl: next-gen monitoring, 1m, AI-native (future "smart background layer")
+
+**Tip-and-cue:**
+A multi-tier detection workflow. Broad-area monitoring satellites (SuperDove/Owl) detect anomalies → cue high-res tasking satellites (Pelican) to take a closer look. This is the operational model for "near-real-time intelligence network." The PM designs the handoff protocol: what detection confidence triggers a cue, how fast must the tasking respond, what priority does a cue get vs. standing orders.
+
+**Constellation as a product for Satellite Services:**
+In the sovereign deals, Planet isn't selling data — they're selling a constellation. The PM must think about: how many Pelicans does Germany need for their coverage requirements? What orbital planes serve European theater? How does dedicated capacity differ from shared fleet tasking?
+
+---
+
+## Telemetry
+
+**What is telemetry?**
+Health and status data from the satellite — temperatures, voltages, battery state, reaction wheel speeds, GPS position, software status. Transmitted continuously via TT&C link (usually S-band).
+
+**Why a PM cares:**
+- Telemetry drives anomaly detection. If a sensor reading drifts, operators intervene before failure.
+- At Astra, Adam turned raw telemetry into stoplights (proceed/hold/abort) — same concept applies to satellite health dashboards.
+- Satellite Services customers may want access to their constellation's telemetry. What level of visibility does the PM expose? Raw telemetry? Derived health scores? Alerts only?
+
+**Housekeeping vs. mission telemetry:**
+- Housekeeping: satellite health (temperatures, power, attitude)
+- Mission telemetry: payload-specific (camera status, onboard processing results, AI inference metadata)
+- Both flow through TT&C but may have different access controls, especially for classified missions.
+
+---
+
+## Edge Compute on Satellites
+
+**The architecture choice:**
+
+| | Traditional | Edge AI (Planet's direction) |
+|---|------------|---------------------------|
+| Onboard compute | Rad-hard processor, flight software only | Rad-hard + commercial GPU (Jetson Orin) |
+| Processing | All on ground | Detection/classification on orbit |
+| Downlink | Raw/compressed imagery | Imagery + structured detections (GeoJSON) |
+| Latency | Hours (wait for pass + ground pipeline) | Minutes (onboard result + small downlink) |
+| Power | Low (~10–30W OBC) | Higher (~15–60W GPU + OBC) |
+| Flexibility | Firmware update = risky | Docker containers, model updates |
+
+**Planet's approach:**
+- Pelican flies NVIDIA Jetson Orin alongside rad-hard flight computer
+- Workloads run in isolated Docker containers (same DevOps as ground)
+- Pelican-4 demo (March 2026): 80% detection accuracy on raw imagery, full pipeline (data gen → deep-net detection → geo-rectification) on orbit
+- Outputs: GeoTIFF (imagery) and GeoJSON (structured detections), geo-rectified on orbit
+
+**FPGA vs. GPU (will come up with Gil Michael):**
+
+| | FPGA | GPU |
+|---|------|-----|
+| Latency | Deterministic (fixed pipeline) | Variable (depends on model, batch) |
+| Power | Very efficient (5–15W) | Higher (15–60W for Orin) |
+| Flexibility | Hard to reprogram — new model = new bitstream | Easy — swap Docker container, new model |
+| ML toolchain | Custom HDL, limited frameworks | CUDA, PyTorch, TensorRT — standard ML stack |
+| Radiation | Space-heritage options exist | Commercial, needs mitigation (watchdog, ECC, checkpointing) |
+| Model updates | Risky, slow | Routine — same CI/CD as ground |
+| Best for | Fixed, well-defined processing (cloud mask, compression) | Evolving ML models, multi-model pipelines |
+
+**Why Planet chose GPU:** Model update cadence. If you're iterating on detection models monthly (which Bedrock Research will be), you can't wait for FPGA bitstream synthesis. Docker containers in orbit = deploy a new model like a software update. The power cost is manageable with duty cycling.
+
+**Radiation mitigation for commercial GPUs:**
+- External watchdog on rad-tolerant FPGA (e.g., Microsemi RTG4) or Vorago MCU
+- Hard power switch with latch-up current trip
+- ECC DRAM
+- Application-level checkpointing every N inferences
+- Accept that single-event upsets will happen — design for graceful recovery, not prevention
+
+---
+
+## Ground Processing Pipeline
+
+**Standard EO ground processing chain:**
+
+| Stage | What happens | Output |
+|-------|-------------|--------|
+| **Raw** | Detector readout, unprocessed | Raw digital numbers |
+| **L1 (Radiometric)** | Sensor calibration, dark current removal | Calibrated radiance |
+| **L2 (Atmospheric)** | Atmospheric correction, surface reflectance | Analysis-ready surface reflectance |
+| **L3 (Geometric)** | Orthorectification, map projection | Geo-located pixels |
+| **Pansharpening** | Fuse panchromatic (high-res) + multispectral (color) | High-res color imagery |
+| **Cloud masking** | Identify and flag cloudy pixels | Usable pixel map |
+| **Mosaicking** | Stitch multiple scenes into seamless basemap | Cloud-free composite |
+| **ARD** (Analysis-Ready Data) | All of the above, standardized | What customers actually consume |
+
+**Planet's "Analysis-Ready PlanetScope"**: Proprietary AI pipeline that does harmonization, cloud masking, and alignment so downstream ML can consume the data directly. This is the table-stakes layer — if your pixels aren't analysis-ready, customers reject them.
+
+**What moves onboard vs. stays on ground:**
+- Onboard now: cloud masking (Jetson), object detection, geo-rectification
+- Stays on ground (for now): full radiometric calibration, atmospheric correction, pansharpening, mosaicking
+- Future: more processing moves onboard as compute power increases (Owl, Suncatcher)
+
+---
+
+## Quick Quiz (Self-Test)
+
+1. Why does Planet use a common bus across Pelican, Tanager, Owl, and Suncatcher?
+   → Platform leverage. Same manufacturing line, same ground software, same ops team. Reduces NRE per mission. Critical for Satellite Services productization — every bespoke design erodes margin.
+
+2. A sovereign customer wants 30-minute revisit over a specific region. What determines how many Pelicans they need?
+   → Orbital geometry (how often orbits cross the region), satellite agility (how many targets per pass), and whether they need dedicated capacity (guaranteed, competition-free) or can share fleet. Latitude matters — higher latitude = more passes.
+
+3. Why can't you run the GPU at full power continuously on orbit?
+   → Power budget. Solar panels produce finite watts, batteries are sized for eclipse survival. GPU at 60W competes with payload, ADCS, comms, thermal. Must duty cycle — run inference during collection passes, idle between targets.
+
+4. What's the difference between tip-and-cue and standing tasking orders?
+   → Standing orders are pre-scheduled (image this location every pass). Tip-and-cue is reactive — a broad-area sensor detects something, dynamically tasks a high-res sensor to look closer. Tip-and-cue requires low-latency command path and constellation coordination.
+
+5. Why is depth of discharge important for battery sizing?
+   → Deeper discharge per cycle = fewer total cycles before battery degradation. A satellite designed for 5-year life with 15 eclipse cycles/day = ~27,000 cycles. Limiting DoD to 20-30% ensures the battery survives. This constrains how much peak power you can draw during eclipse.
+
+6. What makes Pelican's agility a revenue driver?
+   → More agile = faster slew between targets = more images per pass = more tasking revenue per satellite per day. At 30 tasks/day, each task is a revenue event.


### PR DESCRIPTION
## Summary
- Adds three technical flashcard/study reference files for satellite, EO, and edge AI interview preparation
- `flashcards_rf_comms.md` — RF bands, Ka-band downlink, latency budgets, ISLs, laser comms, bandwidth math
- `flashcards_satellite_systems.md` — Subsystems, power budgets, orbital mechanics, constellation design, edge compute architecture, ground processing
- `flashcards_ai_ml_edge.md` — ML/CV for EO, training vs inference, quantization, TC-PED pipeline, optical/hyperspectral processing, precision/recall tradeoffs, foundation models

All files are Planet Labs-calibrated with self-test quizzes. Designed as study material for candidates preparing for technical PM interviews in the satellite/EO domain.

## Test plan
- [ ] Review flashcard content for technical accuracy
- [ ] Verify Planet-specific details align with public information
- [ ] Confirm files don't conflict with existing reference structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds three new Planet Labs-calibrated flashcard reference files for satellite, EO, and edge AI interview preparation. The content itself is technically thorough and well-structured, but two of the files contain private, personalized details — a named Planet Labs employee used as an interview tip and a named individual's work history as an illustrative example — that are inappropriate for a shared, public skill repository.

- `flashcards_satellite_systems.md` embeds a specific interviewer's name as a section header hint and a named professional's career story as an example, both of which should either be removed, anonymized, or moved to a candidate-specific `coaching_state.md`.
- All three files are added to the repository root rather than `references/`, breaking the established directory structure used by every other reference file in the repo.
- `flashcards_ai_ml_edge.md` contains a minor personal aside (\"from your prep\") and an unexpanded ambiguous acronym (\"D&I\") that should be clarified.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is — two instances of real people's names are embedded in shared, public skill content in ways that create privacy exposure.

The satellite systems flashcard file names a specific Planet Labs employee as an interview predictor and attributes a professional accomplishment to a named individual without any indication of consent. In a public repository these are real privacy concerns that should be resolved before the files ship as part of a generic coaching skill. The technical content of all three files is otherwise solid and the structural placement issue is easy to fix.

flashcards_satellite_systems.md requires attention at lines 119 and 148 before merge; flashcards_ai_ml_edge.md has minor wording cleanup needed.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| flashcards_satellite_systems.md | New 214-line satellite systems flashcard reference; contains a named Planet Labs interviewer used as a section header tip (line 148) and a personal career anecdote from a named individual embedded in the generic Telemetry section (line 119) — both private/personalized details that shouldn't live in a shared repository skill. |
| flashcards_ai_ml_edge.md | New 281-line AI/ML flashcard reference covering ML taxonomy, EO computer vision, edge inference, quantization, and precision/recall tradeoffs; contains one unexpanded ambiguous acronym ("D&I") and a personal aside ("from your prep") that leaks candidate-specific context. |
| flashcards_rf_comms.md | New 189-line RF/comms flashcard reference covering frequency bands, Ka-band downlink, ISLs, laser comms, link budgets, and latency taxonomy; content is technically consistent and no significant issues found. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[flashcards_rf_comms.md] --> D[Interview Candidate]
    B[flashcards_satellite_systems.md] --> D
    C[flashcards_ai_ml_edge.md] --> D
    B -- Named interviewer hint line 148 --> E[Privacy Risk]
    B -- Named individual anecdote line 119 --> E
    A --> F[Placed at repo root]
    B --> F
    C --> F
    F -- Should be under --> G[references/ directory]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0Aflashcards_satellite_systems.md%3A148%0A**Named%20interviewer%20embedded%20in%20shared%20skill%20resource**%0A%0AThis%20section%20header%2C%20%60**FPGA%20vs.%20GPU%20%28will%20come%20up%20with%20Gil%20Michael%29%3A**%60%2C%20names%20a%20specific%20Planet%20Labs%20employee%20as%20an%20interview%20tip.%20Committed%20to%20a%20public%20repository%20as%20part%20of%20a%20generic%20coaching%20skill%2C%20this%20exposes%20a%20real%20person's%20name%20alongside%20implicit%20characterizations%20of%20how%20they%20interview.%20Anyone%20who%20forks%20or%20uses%20this%20skill%20will%20see%20a%20named%20individual%20tied%20to%20predicted%20interview%20behavior%20%E2%80%94%20which%20is%20a%20privacy%20concern%20and%20could%20be%20professionally%20awkward%20if%20the%20person%20encounters%20it.%20The%20coaching%20value%20can%20be%20preserved%20by%20replacing%20the%20name%20with%20a%20role%20description%20%28e.g.%2C%20%22likely%20to%20come%20up%20in%20a%20systems%20engineering%20interview%20round%22%29%20or%20moving%20the%20tip%20to%20a%20private%2C%20candidate-specific%20%60coaching_state.md%60.%0A%0A%23%23%23%20Issue%202%20of%205%0Aflashcards_satellite_systems.md%3A119%0A**Personal%20career%20anecdote%20from%20a%20named%20individual%20embedded%20as%20generic%20content**%0A%0AThe%20line%20%60At%20Astra%2C%20Adam%20turned%20raw%20telemetry%20into%20stoplights%20%28proceed%2Fhold%2Fabort%29%60%20references%20a%20specific%20person's%20work%20history%20as%20an%20illustrative%20example%20in%20a%20shared%20reference%20file.%20This%20looks%20like%20a%20coaching%20note%20authored%20for%20%E2%80%94%20or%20by%20%E2%80%94%20a%20specific%20candidate%20and%20inadvertently%20included%20in%20the%20generic%20skill%20resource.%20In%20a%20public%20repo%2C%20attributing%20professional%20accomplishments%20to%20a%20named%20individual%20without%20their%20consent%20is%20a%20privacy%20risk.%20The%20technical%20point%20%28reducing%20telemetry%20to%20decision%20signals%29%20is%20valid%20and%20can%20be%20made%20without%20the%20personal%20attribution.%0A%0A%23%23%23%20Issue%203%20of%205%0Aflashcards_ai_ml_edge.md%3A178%0A**Unexpanded%20acronym%20%22D%26I%22%20is%20ambiguous%20in%20this%20context**%0A%0A%60D%26I%20threat%20detection%60%20is%20listed%20in%20the%20precision%2Frecall%20tradeoff%20table%20without%20definition.%20In%20most%20corporate%20contexts%20%22D%26I%22%20reads%20as%20Diversity%20%26%20Inclusion%3B%20in%20satellite%2Fdefense%20contexts%20it%20might%20mean%20%22Detection%20%26%20Identification%22%20or%20%22Defense%20%26%20Intelligence.%22%20The%20document%20already%20uses%20%60I%26W%60%20%28Indication%20and%20Warning%29%20correctly%20elsewhere%20%E2%80%94%20applying%20the%20same%20standard%20here%20would%20remove%20the%20ambiguity.%0A%0A%23%23%23%20Issue%204%20of%205%0Aflashcards_ai_ml_edge.md%3A211%0A**Personal%20context%20phrase%20leaks%20into%20generic%20reference%20material**%0A%0A%60%28from%20your%20prep%29%60%20is%20a%20second-person%20aside%20that%20makes%20sense%20in%20a%20candidate-specific%20coaching%20session%20but%20reads%20as%20an%20artifact%20of%20personal%20session%20notes%20in%20a%20shared%20repository%20resource.%20Removing%20it%20keeps%20the%20content%20generic%20and%20reusable%20for%20any%20user%20of%20the%20skill.%0A%0A%60%60%60suggestion%0A**Decision%20velocity%20framework%3A**%0A%60%60%60%0A%0A%23%23%23%20Issue%205%20of%205%0Aflashcards_satellite_systems.md%3A1%0A**New%20files%20placed%20at%20repository%20root%20rather%20than%20%60references%2F%60%20directory**%0A%0AAll%20other%20reference%20material%20in%20this%20repository%20lives%20under%20%60references%2F%60%20%28e.g.%2C%20%60references%2Fcalibration-engine.md%60%2C%20%60references%2Frole-drills.md%60%2C%20%60references%2Fexamples.md%60%29.%20These%20three%20flashcard%20files%20are%20added%20directly%20to%20the%20root%20alongside%20%60README.md%60%2C%20%60SKILL.md%60%2C%20and%20%60VERSIONS.md%60%2C%20which%20breaks%20the%20established%20structure.%20This%20applies%20equally%20to%20%60flashcards_rf_comms.md%60%20and%20%60flashcards_ai_ml_edge.md%60.%20Moving%20them%20to%20%60references%2Fflashcards_rf_comms.md%60%20etc.%20would%20keep%20the%20layout%20consistent.%0A%0A&repo=noamseg%2Finterview-coach-skill&pr=55&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0Aflashcards_satellite_systems.md%3A148%0A**Named%20interviewer%20embedded%20in%20shared%20skill%20resource**%0A%0AThis%20section%20header%2C%20%60**FPGA%20vs.%20GPU%20%28will%20come%20up%20with%20Gil%20Michael%29%3A**%60%2C%20names%20a%20specific%20Planet%20Labs%20employee%20as%20an%20interview%20tip.%20Committed%20to%20a%20public%20repository%20as%20part%20of%20a%20generic%20coaching%20skill%2C%20this%20exposes%20a%20real%20person's%20name%20alongside%20implicit%20characterizations%20of%20how%20they%20interview.%20Anyone%20who%20forks%20or%20uses%20this%20skill%20will%20see%20a%20named%20individual%20tied%20to%20predicted%20interview%20behavior%20%E2%80%94%20which%20is%20a%20privacy%20concern%20and%20could%20be%20professionally%20awkward%20if%20the%20person%20encounters%20it.%20The%20coaching%20value%20can%20be%20preserved%20by%20replacing%20the%20name%20with%20a%20role%20description%20%28e.g.%2C%20%22likely%20to%20come%20up%20in%20a%20systems%20engineering%20interview%20round%22%29%20or%20moving%20the%20tip%20to%20a%20private%2C%20candidate-specific%20%60coaching_state.md%60.%0A%0A%23%23%23%20Issue%202%20of%205%0Aflashcards_satellite_systems.md%3A119%0A**Personal%20career%20anecdote%20from%20a%20named%20individual%20embedded%20as%20generic%20content**%0A%0AThe%20line%20%60At%20Astra%2C%20Adam%20turned%20raw%20telemetry%20into%20stoplights%20%28proceed%2Fhold%2Fabort%29%60%20references%20a%20specific%20person's%20work%20history%20as%20an%20illustrative%20example%20in%20a%20shared%20reference%20file.%20This%20looks%20like%20a%20coaching%20note%20authored%20for%20%E2%80%94%20or%20by%20%E2%80%94%20a%20specific%20candidate%20and%20inadvertently%20included%20in%20the%20generic%20skill%20resource.%20In%20a%20public%20repo%2C%20attributing%20professional%20accomplishments%20to%20a%20named%20individual%20without%20their%20consent%20is%20a%20privacy%20risk.%20The%20technical%20point%20%28reducing%20telemetry%20to%20decision%20signals%29%20is%20valid%20and%20can%20be%20made%20without%20the%20personal%20attribution.%0A%0A%23%23%23%20Issue%203%20of%205%0Aflashcards_ai_ml_edge.md%3A178%0A**Unexpanded%20acronym%20%22D%26I%22%20is%20ambiguous%20in%20this%20context**%0A%0A%60D%26I%20threat%20detection%60%20is%20listed%20in%20the%20precision%2Frecall%20tradeoff%20table%20without%20definition.%20In%20most%20corporate%20contexts%20%22D%26I%22%20reads%20as%20Diversity%20%26%20Inclusion%3B%20in%20satellite%2Fdefense%20contexts%20it%20might%20mean%20%22Detection%20%26%20Identification%22%20or%20%22Defense%20%26%20Intelligence.%22%20The%20document%20already%20uses%20%60I%26W%60%20%28Indication%20and%20Warning%29%20correctly%20elsewhere%20%E2%80%94%20applying%20the%20same%20standard%20here%20would%20remove%20the%20ambiguity.%0A%0A%23%23%23%20Issue%204%20of%205%0Aflashcards_ai_ml_edge.md%3A211%0A**Personal%20context%20phrase%20leaks%20into%20generic%20reference%20material**%0A%0A%60%28from%20your%20prep%29%60%20is%20a%20second-person%20aside%20that%20makes%20sense%20in%20a%20candidate-specific%20coaching%20session%20but%20reads%20as%20an%20artifact%20of%20personal%20session%20notes%20in%20a%20shared%20repository%20resource.%20Removing%20it%20keeps%20the%20content%20generic%20and%20reusable%20for%20any%20user%20of%20the%20skill.%0A%0A%60%60%60suggestion%0A**Decision%20velocity%20framework%3A**%0A%60%60%60%0A%0A%23%23%23%20Issue%205%20of%205%0Aflashcards_satellite_systems.md%3A1%0A**New%20files%20placed%20at%20repository%20root%20rather%20than%20%60references%2F%60%20directory**%0A%0AAll%20other%20reference%20material%20in%20this%20repository%20lives%20under%20%60references%2F%60%20%28e.g.%2C%20%60references%2Fcalibration-engine.md%60%2C%20%60references%2Frole-drills.md%60%2C%20%60references%2Fexamples.md%60%29.%20These%20three%20flashcard%20files%20are%20added%20directly%20to%20the%20root%20alongside%20%60README.md%60%2C%20%60SKILL.md%60%2C%20and%20%60VERSIONS.md%60%2C%20which%20breaks%20the%20established%20structure.%20This%20applies%20equally%20to%20%60flashcards_rf_comms.md%60%20and%20%60flashcards_ai_ml_edge.md%60.%20Moving%20them%20to%20%60references%2Fflashcards_rf_comms.md%60%20etc.%20would%20keep%20the%20layout%20consistent.%0A%0A&pr=55&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat: add technical flashcard reference ..."](https://github.com/noamseg/interview-coach-skill/commit/3081ca361e4e250d58fcbc5477a1d18abbb3a123) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33377456)</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->