### PR TITLE
feat(decode): add URL fetching protocol

### DIFF
--- a/references/commands/decode.md
+++ b/references/commands/decode.md
@@ -72,6 +72,7 @@ When the user provides a URL instead of pasted text, it must be a direct link to
    - Garbled, login-walled, or clearly incomplete → proceed to Step B (cURL fallback)
 
 **Step B — cURL fallback**
+Note: the Bash tool requires user approval in standard permission mode. If approval is not granted, proceed directly to Step C.
 1. If WebFetch fails or returns insufficient content, attempt retrieval via the Bash tool using cURL with a browser user-agent:
 
 ```

--- a/references/commands/decode.md
+++ b/references/commands/decode.md
@@ -59,6 +59,37 @@ Every interpretation gets a confidence label. This is non-negotiable — it's wh
 - At least one JD (pasted text or key details)
 - For batch triage: 2-5 JDs
 
+### URL Fetching Protocol
+
+When the user provides a URL instead of pasted text, it must be a direct link to the job posting page — not a search results page or company careers listing. If the URL doesn't lead directly to a single JD, ask the user to navigate to the job posting and share that URL. Then attempt retrieval in this order — only escalate to the next step if the previous one fails:
+
+**Step A — WebFetch**
+1. Fetch the page using the WebFetch tool with the URL as provided.
+2. If the result indicates a redirect (response contains "REDIRECT DETECTED" and a new URL), automatically retry WebFetch with the redirected URL. Treat the retry result as the Step A result.
+3. Quality check the result:
+   - Clear role title + responsibilities + requirements (200+ words of JD content) → proceed with decode
+   - Partial but usable (role and some requirements visible) → proceed, flag: "Content may be incomplete — flag anything that looks off."
+   - Garbled, login-walled, or clearly incomplete → proceed to Step B (curl fallback)
+
+**Step B — curl fallback**
+If WebFetch fails or returns insufficient content, attempt retrieval via the Bash tool using curl with a browser user-agent:
+
+```
+curl -s -L \
+  -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36" \
+  "[URL]"
+```
+
+3. Quality check the curl result:
+   - Sufficient JD content retrieved → extract and proceed with decode
+   - Content is a JavaScript bundle (minimal readable text, heavy `<script>` blocks) → the page is client-side rendered. Before escalating to Step C, try two things: (1) retry curl with `-H "X-Requested-With: XMLHttpRequest"` and inspect the URL structure for an API path pattern. If a clean JSON response with JD content is returned, use it; (2) check the raw HTML for SEO structured data that ATS platforms commonly embed. If either yields sufficient JD content, proceed with decode. If not, proceed to Step C.
+   - Still insufficient (login-walled, fully blocked) → proceed to Step C
+
+**Step C — user paste**
+Only if both WebFetch and curl fail: tell the user: "The page is blocking automated retrieval — it likely requires a login or uses JavaScript rendering that curl can't reach. Can you paste the JD text directly?" Then wait before proceeding.
+
+**For batch triage with multiple URLs**: attempt Steps A–B for each URL sequentially. If any URL reaches Step C, request the paste for that JD only and continue with the others.
+
 ### Optional Inputs
 
 - Depth level: Quick Scan / Standard / Deep Decode (default: Standard)

--- a/references/commands/decode.md
+++ b/references/commands/decode.md
@@ -69,24 +69,25 @@ When the user provides a URL instead of pasted text, it must be a direct link to
 3. Quality check the result:
    - Clear role title + responsibilities + requirements (200+ words of JD content) → proceed with decode
    - Partial but usable (role and some requirements visible) → proceed, flag: "Content may be incomplete — flag anything that looks off."
-   - Garbled, login-walled, or clearly incomplete → proceed to Step B (curl fallback)
+   - Garbled, login-walled, or clearly incomplete → proceed to Step B (cURL fallback)
 
-**Step B — curl fallback**
-If WebFetch fails or returns insufficient content, attempt retrieval via the Bash tool using curl with a browser user-agent:
+**Step B — cURL fallback**
+1. If WebFetch fails or returns insufficient content, attempt retrieval via the Bash tool using cURL with a browser user-agent:
 
 ```
 curl -s -L \
   -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36" \
   "[URL]"
 ```
-
+2. Redirects are followed automatically via the -L flag. No retry required.
 3. Quality check the curl result:
-   - Sufficient JD content retrieved → extract and proceed with decode
+   - Clear role title + responsibilities + requirements (200+ words of JD content) → proceed with decode
+   - Partial but usable (role and some requirements visible) → proceed, flag: "Content may be incomplete — flag anything that looks off."
    - Content is a JavaScript bundle (minimal readable text, heavy `<script>` blocks) → the page is client-side rendered. Before escalating to Step C, try two things: (1) retry curl with `-H "X-Requested-With: XMLHttpRequest"` and inspect the URL structure for an API path pattern. If a clean JSON response with JD content is returned, use it; (2) check the raw HTML for SEO structured data that ATS platforms commonly embed. If either yields sufficient JD content, proceed with decode. If not, proceed to Step C.
-   - Still insufficient (login-walled, fully blocked) → proceed to Step C
+   - Garbled, login-walled, or clearly incomplete → proceed to Step C
 
 **Step C — user paste**
-Only if both WebFetch and curl fail: tell the user: "The page is blocking automated retrieval — it likely requires a login or uses JavaScript rendering that curl can't reach. Can you paste the JD text directly?" Then wait before proceeding.
+Only if both WebFetch and cURL fail: tell the user: "The page is blocking automated retrieval — it likely requires a login or uses JavaScript rendering that curl can't reach. Can you paste the JD text directly?" Then wait before proceeding.
 
 **For batch triage with multiple URLs**: attempt Steps A–B for each URL sequentially. If any URL reaches Step C, request the paste for that JD only and continue with the others.
 


### PR DESCRIPTION
## Summary

Adds a URL Fetching Protocol to the `decode` command so users can paste a direct job posting URL instead of JD text. The existing paste-text workflow is unchanged.

## What's changed

- New 3-step fallback chain for URL input: **WebFetch → cURL → user paste**
- **Step A (WebFetch)**: fetches the page directly; detects and retries on geographic and ATS redirects
- **Step B (cURL)**: handles JavaScript-rendered ATS pages via XHR retry and SEO structured-data extraction (`ld+json`, `og:description`); redirects followed via `-L`
- **Step C (user paste)**: only triggered when A and B both fail (e.g. login-walled or fully JavaScript-rendered pages)
- Search results and listing pages are explicitly rejected upfront — only direct posting URLs are accepted

**Note**: Step A uses the WebFetch tool, which is Claude Code-specific. Not tested with OpenAI Codex; on those clients the protocol falls through to Step B.

## Test plan

- [ ] Direct posting URL on a static ATS page: WebFetch succeeds, JD analysis runs
- [ ] URL that redirects (geographic or ATS-side): WebFetch retry path handles it
- [ ] JS-rendered posting where Step A returns near-empty HTML: Step B extracts JD content via `ld+json` / `og:description`
- [ ] Login-walled posting (e.g. LinkedIn while logged out): cleanly falls through to Step C with a clear user-paste prompt
- [ ] Search-result URL or listing page: rejected upfront with explanation
- [ ] Pasted JD text (no URL): existing decode path unchanged, no regression
- [ ] OpenAI Codex client (or any client without WebFetch): Step A unavailable, protocol falls through to Step B without error

🤖 Generated with [Claude Code](https://claude.com/claude-code) and curated by a human. 🧑‍💻